### PR TITLE
chore: add CLAUDE.md, Cursor rules, and Windsurf rules

### DIFF
--- a/.cursor/rules/api.mdc
+++ b/.cursor/rules/api.mdc
@@ -1,0 +1,73 @@
+---
+description: oRPC procedure and router patterns for adding and modifying API endpoints
+globs:
+  - "packages/orpc/**"
+  - "apps/api/**"
+alwaysApply: false
+---
+
+# oRPC API Patterns
+
+## Procedure hierarchy
+
+```
+publicProcedure          — no auth required
+  └── protectedProcedure — requires active session (context.session.user.id)
+        └── cronOrAuthProcedure — accepts either session OR HARMONIA_CRON_SECRET header
+```
+
+Import from `@harmonia/orpc` or relative `../../procedures`.
+
+## Adding a route
+
+1. Add Zod schemas in `packages/common/src/schemas/{entity}/`
+2. Create or update a router file in `packages/orpc/src/routers/protected/` (or `public/`)
+3. Export from that router's `index.ts`
+
+```typescript
+export const playlistsRouter = {
+  list: protectedProcedure
+    .input(playlistListInput)
+    .output(z.array(playlistListItemSchema))
+    .handler(async ({ context }) => {
+      const userId = context.session.user.id;
+      return await db.select().from(playlist).where(eq(playlist.userId, userId));
+    }),
+};
+```
+
+## Router structure
+
+```
+packages/orpc/src/routers/
+  public/
+    organize.ts   (run pipeline — cronOrAuthProcedure)
+  protected/
+    playlists.ts
+    tracks.ts
+    pipeline.ts   (streamStatus uses eventIterator for SSE)
+    clusters.ts
+    spotify.ts
+    todo.ts
+```
+
+## Client usage (dashboard / web)
+
+```typescript
+import { orpc } from "@/lib/orpc";
+import { useQuery, useMutation } from "@tanstack/react-query";
+
+// Query
+const { data } = useQuery(orpc.playlists.list.queryOptions());
+
+// Mutation
+const { mutate } = useMutation(orpc.organize.run.mutationOptions({ onSuccess: ... }));
+```
+
+## CORS
+
+CORS headers are applied globally in `apps/api/src/app/api/[[...rest]]/route.ts`. Do not add per-route CORS logic.
+
+## OpenAPI
+
+All routes are automatically documented at `/api/rpc/api-reference`. Provide `.meta({ openapi: { ... } })` on routes you want to expose in the spec.

--- a/.cursor/rules/components.mdc
+++ b/.cursor/rules/components.mdc
@@ -1,0 +1,68 @@
+---
+description: React component conventions, shadcn/ui usage, Tailwind patterns, and dashboard component structure
+globs:
+  - "apps/dashboard/src/**/*.tsx"
+  - "apps/web/src/**/*.tsx"
+  - "packages/ui/src/**/*.tsx"
+alwaysApply: false
+---
+
+# Component Conventions
+
+## File and folder structure
+
+```
+apps/dashboard/src/components/
+  app/       # Feature-specific components (prefixed with the app domain)
+  layout/    # Page wrappers, nav, providers
+  shared/    # Truly reusable across features (empty-state, error-state, page-loader)
+  ui/        # Re-exports from packages/ui (or local overrides)
+
+apps/dashboard/src/hooks/
+  mutations/ # use-{action}.ts — wraps useMutation + orpc
+  queries/   # use-{resource}.ts — wraps useQuery + orpc
+```
+
+## Naming
+
+- File: `kebab-case.tsx`
+- Export: `PascalCase` matching the file name
+- Dashboard components: `dashboard-{feature}-{role}.tsx` (e.g. `dashboard-library-analysis.tsx`)
+- Always co-locate a skeleton: `export function DashboardLibraryAnalysisSkeleton() { ... }`
+
+## shadcn/ui
+
+Primitives live in `packages/ui/src/components/ui/`. Import via:
+```typescript
+import { Button } from "@/components/ui/button";    // within an app
+import { Button } from "@harmonia/ui/button";        // across packages (if exported)
+```
+
+Do not copy-paste shadcn component source into app directories — extend via props instead.
+
+## Tailwind
+
+- Sorted automatically by Biome (`cn`, `clsx`, `cva` calls)
+- Use `cn()` from `@/lib/utils` for conditional classes
+- Responsive: mobile-first (`sm:`, `md:`, `lg:`)
+- Dark mode: `dark:` prefix (managed by `next-themes`)
+
+## State and data
+
+- Server state: TanStack Query v5 via oRPC client
+- Client state: Zustand (see `apps/dashboard/src/stores/`)
+- Toast: `sonner` — use `toast.error()` for failures, no success toasts on pipeline launch
+- No Redux, no Context API for global state
+
+## Client components
+
+Add `"use client"` only when you need browser APIs, event handlers, or hooks. Prefer server components for data display.
+
+```typescript
+"use client";
+
+export function MyComponent({ initialData }: { initialData: Playlist[] }) {
+  const { data } = useQuery(orpc.playlists.list.queryOptions({ initialData }));
+  return <div>{data?.map(...)}</div>;
+}
+```

--- a/.cursor/rules/database.mdc
+++ b/.cursor/rules/database.mdc
@@ -1,0 +1,76 @@
+---
+description: Drizzle ORM schema conventions, query patterns, and migration workflow
+globs:
+  - "packages/db/**"
+alwaysApply: false
+---
+
+# Database Patterns
+
+## Schema conventions
+
+```typescript
+// packages/db/src/schema/my-table.ts
+import { pgTable, text, serial, timestamp, index } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const myTable = pgTable(
+  "my_table",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("my_table_user_id_idx").on(table.userId),
+  ],
+);
+```
+
+- Column names: `snake_case`
+- All user-owned tables must have `userId` with cascade delete
+- Always add indexes for foreign keys and common filter columns
+- Export from `packages/db/src/schema/index.ts`
+
+## Query patterns
+
+```typescript
+import { db } from "@harmonia/db";
+import { track } from "@harmonia/db/schema/track";
+import { eq, and, isNull, inArray } from "drizzle-orm";
+
+// Select
+const tracks = await db.select().from(track).where(eq(track.userId, userId));
+
+// Insert + return
+const [inserted] = await db.insert(myTable).values({ ... }).returning({ id: myTable.id });
+
+// Update
+await db.update(track).set({ llmMood: "melancholic" }).where(eq(track.id, id));
+
+// JSONB merge (for concurrent progress updates — never overwrite the whole column)
+import { sql } from "drizzle-orm";
+await db.update(pipelineRun).set({
+  progress: sql`COALESCE(progress, '{}'::jsonb) || ${JSON.stringify({ embed: p })}::jsonb`,
+}).where(eq(pipelineRun.id, runId));
+```
+
+## DB client
+
+The client in `packages/db/src/index.ts` auto-detects the driver:
+- URL contains `.neon.tech` → `@neondatabase/serverless` (for Vercel/edge)
+- Otherwise → standard `pg` pool (for local Docker Postgres)
+
+Do not change this detection logic.
+
+## Migrations
+
+```bash
+pnpm db:push      # dev: push schema directly (no migration files)
+pnpm db:generate  # generate migration SQL files
+pnpm db:migrate   # apply migrations (production)
+```
+
+Always run `pnpm db:push` after schema changes in development.

--- a/.cursor/rules/env.mdc
+++ b/.cursor/rules/env.mdc
@@ -1,0 +1,54 @@
+---
+description: Environment variable conventions — how to read, add, and validate env vars in this codebase
+globs:
+  - "packages/env/**"
+  - ".env*"
+  - "**/env.ts"
+alwaysApply: false
+---
+
+# Environment Variables
+
+## Reading env vars
+
+**Never use `process.env` directly in application code.** Always import from the env package:
+
+```typescript
+// Server-side (API, Trigger.dev tasks, services)
+import { env } from "@harmonia/env/server";
+const url = env.HARMONIA_DATABASE_URL;
+
+// In a specific app
+import { apiEnv } from "@harmonia/env/presets/api";
+```
+
+The env package validates all vars at startup with Zod. Missing required vars fail fast.
+
+## Adding a new env var
+
+1. Add it to `.env.example` with a comment
+2. Add Zod schema to the relevant module in `packages/env/src/modules/`:
+
+```typescript
+// packages/env/src/modules/my-module.ts
+import { z } from "zod";
+export const myModule = {
+  server: {
+    HARMONIA_MY_NEW_VAR: z.string().min(1),
+  },
+} as const;
+```
+
+3. Export from `packages/env/src/modules/index.ts`
+4. Spread into the appropriate preset in `packages/env/src/presets/api.ts` (or web/dashboard)
+5. If it's a new client-side var: also add to `createNextjsRuntimeEnv()` in `utils/runtime-env.ts` using literal property access (required for Next.js bundling)
+
+## Naming rules
+
+- Server vars: `HARMONIA_{NAME}` — e.g. `HARMONIA_GROQ_API_KEY`
+- Client vars: `NEXT_PUBLIC_HARMONIA_{NAME}` — e.g. `NEXT_PUBLIC_HARMONIA_API_URL`
+- Never add vars without the `HARMONIA_` prefix
+
+## Trigger.dev vars
+
+`HARMONIA_TRIGGER_SECRET_KEY` and `HARMONIA_TRIGGER_PROJECT_REF` are mapped to `TRIGGER_SECRET_KEY` and `TRIGGER_PROJECT_REF` by `scripts/run-trigger-dev.mjs`. This mapping is intentional — Trigger.dev CLI reads the standard names.

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,36 @@
+---
+description: Harmonia monorepo overview, dev commands, and hard rules every contributor must follow
+alwaysApply: true
+---
+
+# Harmonia — Project Rules
+
+## Stack
+
+pnpm + Turborepo monorepo. Three Next.js 15 (App Router) apps — `api` (port 3002), `dashboard` (port 3003), `web` (port 3001). Shared packages: `db` (Drizzle + Postgres), `orpc` (type-safe API), `auth` (Better Auth), `common` (services + Trigger.dev tasks), `env` (Zod env validation), `ui` (shadcn/ui), `logger` (Pino), `tracing` (OpenTelemetry).
+
+## Dev commands
+
+- `pnpm dev:api` — API + Trigger.dev worker
+- `pnpm dev:ad` — API + dashboard + Trigger.dev
+- `pnpm dev:all` — everything
+- `pnpm db:push` — sync schema to local Postgres
+- `pnpm db:setup` — start Docker Postgres + push schema
+- `pnpm check-types` — tsc across all packages
+- `pnpm check` / `pnpm lint` / `pnpm format` — Biome
+
+## Hard rules
+
+1. **Never `process.env` directly.** Use `import { env } from "@harmonia/env/server"` or the app preset.
+2. **Never `groq()` without explicit key.** Use `createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY })` from `@ai-sdk/groq`.
+3. **Never write the full `progress` JSONB column directly in concurrent code.** Use `updateStageProgress(runId, stage, value)` (JSONB merge).
+4. **No Inngest.** Background jobs use `@trigger.dev/sdk/v3` only.
+5. **Env vars are always prefixed `HARMONIA_` or `NEXT_PUBLIC_HARMONIA_`.** Never add unprefixed vars.
+
+## Code style
+
+- Biome formatter: **tabs**, double quotes, auto-organised imports
+- TypeScript strict mode + `noUncheckedIndexedAccess`
+- Tailwind classes sorted by Biome (via `clsx`, `cva`, `cn`)
+- Commit prefixes: `feat:` `fix:` `chore:` `perf:` `refactor:`
+- No comments unless the WHY is non-obvious

--- a/.cursor/rules/trigger.mdc
+++ b/.cursor/rules/trigger.mdc
@@ -1,0 +1,63 @@
+---
+description: Trigger.dev v4 task patterns, stage structure, and pipeline orchestration
+globs:
+  - "**/trigger/**"
+  - "apps/api/trigger.config.ts"
+alwaysApply: false
+---
+
+# Trigger.dev Patterns
+
+## Task structure
+
+```typescript
+import { task } from "@trigger.dev/sdk/v3";
+import { checkCancelled, updateRun, updateStageProgress } from "../../../services/organize";
+
+export const myStageTask = task({
+  id: "organize-stage-my-stage",       // must be unique, kebab-case
+  retry: { maxAttempts: 2, minTimeoutInMs: 2000, factor: 2 },
+  run: async ({ userId, runId }: { userId: string; runId: number }) => {
+    await checkCancelled(runId, userId);                    // respect cancellation
+    await updateRun(runId, { currentStage: "my-stage" });  // update DB stage label
+    return await myServiceFunction(userId, async (p) => {
+      await updateStageProgress(runId, "my-stage", p);     // JSONB merge progress
+    });
+  },
+});
+```
+
+## Pipeline orchestration (parent task)
+
+The parent `organize-pipeline` task calls each stage sequentially with `.triggerAndWait()`:
+
+```typescript
+await syncStageTask.triggerAndWait({ userId, runId });
+await lyricsStageTask.triggerAndWait({ userId, runId });
+// ...
+```
+
+Each stage is a separate run in the Trigger.dev dashboard with its own logs and retry state.
+
+## Adding a new stage
+
+1. Create `packages/common/src/trigger/tasks/stages/my-stage.ts`
+2. Export from `apps/api/src/trigger/organize.ts` (CLI discovery)
+3. Add export to `packages/common/package.json` exports map
+4. Add `.triggerAndWait()` call in `packages/common/src/trigger/tasks/organize.ts`
+
+## Progress writes
+
+Use `updateStageProgress` (not `updateRun`) for in-progress updates from within a stage task. This uses the Postgres `||` JSONB merge so concurrent stages never overwrite each other's keys.
+
+## Running locally
+
+```bash
+pnpm trigger:dev   # reads HARMONIA_TRIGGER_* from .env, maps to TRIGGER_* for the CLI
+```
+
+The worker registers 8 tasks: `organize-pipeline` + 7 stage tasks (`organize-stage-sync`, `organize-stage-lyrics`, `organize-stage-classify`, `organize-stage-embed`, `organize-stage-cluster`, `organize-stage-generate`, `organize-stage-match`).
+
+## SDK version
+
+Using `@trigger.dev/sdk@^4.4.4`. Always use `createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY })` inside tasks — the worker process only has `HARMONIA_GROQ_API_KEY`, not `GROQ_API_KEY`.

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -1,0 +1,57 @@
+---
+description: TypeScript conventions, import aliases, Zod schema naming, and type patterns used across the monorepo
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
+alwaysApply: false
+---
+
+# TypeScript Conventions
+
+## Import aliases
+
+Within each app (`api`, `dashboard`, `web`), use `@/*` for local imports:
+```typescript
+import { Button } from "@/components/ui/button";
+import { useOrganize } from "@/hooks/mutations/use-organize";
+import { env } from "@/lib/env";
+```
+
+Across packages, use workspace package names:
+```typescript
+import { db } from "@harmonia/db";
+import { track } from "@harmonia/db/schema/track";
+import { env } from "@harmonia/env/server";
+import { auth } from "@harmonia/core";
+import { logger } from "@harmonia/logger";
+```
+
+## Zod schema naming
+
+- Input schemas: `{entity}{Action}Input` — e.g. `playlistGetByIdInput`
+- Output schemas: `{entity}{Action}OutputSchema` — e.g. `playlistGetByIdOutputSchema`
+- Inferred types: `type PlaylistGetById = z.infer<typeof playlistGetByIdOutputSchema>`
+- Enums: `{entity}{Field}Enum` — e.g. `pipelineStatusEnum`
+
+Schemas live in `packages/common/src/schemas/{entity}/` with an `index.ts` barrel.
+
+## Type patterns
+
+```typescript
+// Prefer explicit return types on exported functions
+export async function doThing(id: string): Promise<Result> { ... }
+
+// Use `satisfies` to validate object shapes without widening
+const config = { ... } satisfies Config;
+
+// Prefer `as const` for literal arrays/objects
+const STAGES = ["sync", "lyrics", "classify"] as const;
+type Stage = (typeof STAGES)[number];
+```
+
+## File naming
+
+- Components: `kebab-case.tsx` (exports are PascalCase)
+- Hooks: `use-{name}.ts`
+- Utilities: `{name}.ts`
+- Schema files: `{entity}.ts` (e.g. `playlist.ts`, `track.ts`)

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,62 @@
+# Harmonia — Windsurf Rules
+
+## Project
+
+pnpm + Turborepo monorepo. Three Next.js 15 App Router apps: `api` (3002), `dashboard` (3003), `web` (3001). Packages: `db` (Drizzle+Postgres), `orpc` (type-safe RPC), `auth` (Better Auth), `common` (services + Trigger.dev tasks), `env` (Zod env validation), `ui` (shadcn/ui), `logger` (Pino).
+
+## Hard rules
+
+- **Never `process.env` directly.** Use `import { env } from "@harmonia/env/server"`.
+- **Never `groq()` without explicit key.** Use `createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY })`.
+- **Never Inngest.** Background jobs use `@trigger.dev/sdk/v3` only.
+- **All env vars prefixed `HARMONIA_` or `NEXT_PUBLIC_HARMONIA_`.** No bare names.
+- **JSONB progress writes: use `updateStageProgress(runId, stage, val)`.** Never overwrite the full column in concurrent code.
+
+## Dev commands
+
+- `pnpm dev:api` — API + Trigger.dev worker
+- `pnpm dev:ad` — API + dashboard + Trigger.dev
+- `pnpm db:push` — sync Drizzle schema to local Postgres
+- `pnpm check-types` — tsc across all packages
+- `pnpm check` — Biome lint + format
+
+## Code style
+
+- Biome: **tabs**, double quotes, auto-organised imports, sorted Tailwind classes
+- TypeScript strict mode + `noUncheckedIndexedAccess`
+- Commits: `feat:` `fix:` `chore:` `perf:` `refactor:`
+- No comments unless the WHY is non-obvious
+
+## Imports
+
+- Within each app: `@/*` alias for local files
+- Across packages: `@harmonia/db`, `@harmonia/env/server`, `@harmonia/core`, `@harmonia/logger`, `@harmonia/orpc`
+
+## oRPC (API)
+
+- Procedures: `publicProcedure` → `protectedProcedure` → `cronOrAuthProcedure`
+- Routers in `packages/orpc/src/routers/protected/` or `public/`
+- Schema names: `{entity}{Action}Input` / `{entity}{Action}OutputSchema`
+- Client: `useQuery(orpc.{router}.{method}.queryOptions())` with TanStack Query v5
+
+## Database (Drizzle)
+
+- Schema in `packages/db/src/schema/`
+- All user-owned tables need `userId` with `onDelete: "cascade"`
+- Indexes for all foreign keys and common filter columns
+- JSONB merge: `sql\`COALESCE(col, '{}'::jsonb) || ${val}::jsonb\``
+- After schema changes: `pnpm db:push`
+
+## Trigger.dev tasks
+
+- Task files in `packages/common/src/trigger/tasks/stages/`
+- Always call `checkCancelled(runId, userId)` first
+- Use `updateStageProgress` (not `updateRun`) for in-progress updates
+- Export new tasks from `apps/api/src/trigger/organize.ts` for CLI discovery
+
+## Components
+
+- Dashboard components: `dashboard-{feature}-{role}.tsx`, always co-locate a skeleton variant
+- State: TanStack Query for server state, Zustand for client state
+- Toasts: `sonner` — `toast.error()` for failures only (no success toast on pipeline launch)
+- `"use client"` only when needed (browser APIs, event handlers, hooks)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,187 @@
+# Harmonia — Claude Code Context
+
+## What this is
+
+Harmonia is a music organization app that syncs a user's Spotify library, classifies tracks with AI, clusters them by similarity, and auto-generates playlists. It is a **pnpm + Turborepo monorepo** with three Next.js apps and a set of shared packages.
+
+---
+
+## Monorepo layout
+
+```
+apps/
+  api         Next.js API server (port 3002) — oRPC, Better Auth, Trigger.dev webhook
+  dashboard   Next.js dashboard (port 3003) — authenticated user UI
+  web         Next.js web app   (port 3001) — public-facing pages
+
+packages/
+  auth        Better Auth singleton + Spotify OAuth config
+  common      Shared schemas, types, services, Trigger.dev task definitions
+  config      Shared tsconfig.base.json
+  core        Initialises auth; re-exports the singleton for the whole monorepo
+  db          Drizzle ORM schema + migrations + DB client
+  env         Zod-validated env presets (never use process.env directly — see below)
+  logger      Pino structured logger
+  orpc        oRPC routers, procedures, context, and client
+  tracing     OpenTelemetry instrumentation
+  ui          shadcn/ui component library + shared Tailwind config
+```
+
+---
+
+## Dev commands
+
+```bash
+pnpm dev:api          # API + Trigger.dev worker (most common)
+pnpm dev:ad           # API + dashboard + Trigger.dev worker
+pnpm dev:all          # all three apps + Trigger.dev worker
+pnpm dev:web          # web app only (no Trigger.dev)
+
+pnpm db:push          # push Drizzle schema to local Postgres
+pnpm db:studio        # open Drizzle Studio UI
+pnpm db:generate      # generate migration files
+pnpm db:migrate       # run migrations (production)
+pnpm db:setup         # start local Docker Postgres + push schema
+
+pnpm trigger:dev      # start Trigger.dev worker alone (maps HARMONIA_TRIGGER_* → TRIGGER_*)
+pnpm check-types      # run tsc --noEmit across all packages
+pnpm check            # Biome check + fix
+pnpm lint             # Biome lint + fix
+pnpm format           # Biome format + fix
+```
+
+---
+
+## Hard rules (things that have burned us before)
+
+1. **Never `process.env` directly.** Always import from `@harmonia/env/server` or the app-specific preset. The env package validates at startup and provides typed access.
+
+2. **Never the default `groq()` factory from `@ai-sdk/groq`.** Use `createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY })`. The default reads `GROQ_API_KEY` which is not set — only `HARMONIA_GROQ_API_KEY` is.
+
+3. **Never write to the full `progress` column directly in a concurrent context.** Use `updateStageProgress(runId, stage, value)` which uses the Postgres JSONB `||` merge operator so concurrent stages never overwrite each other.
+
+4. **`inngest` is gone.** Background jobs use `@trigger.dev/sdk/v3`. The Trigger.dev dev worker is started automatically by the `dev:api` script via `concurrently`.
+
+5. **The DB driver is conditional.** `packages/db/src/index.ts` uses `@neondatabase/serverless` when the URL contains `.neon.tech`, and standard `pg` otherwise. Do not change this logic.
+
+---
+
+## Environment variables
+
+All env vars are prefixed `HARMONIA_` (server) or `NEXT_PUBLIC_HARMONIA_` (client).
+
+```bash
+HARMONIA_DATABASE_URL              # PostgreSQL connection string
+HARMONIA_BETTER_AUTH_SECRET        # Better Auth secret
+HARMONIA_SPOTIFY_CLIENT_ID/SECRET  # Spotify OAuth
+HARMONIA_OPENAI_API_KEY            # OpenAI embeddings
+HARMONIA_GROQ_API_KEY              # Groq LLM (classify, metadata, playlists)
+HARMONIA_TRIGGER_SECRET_KEY        # Trigger.dev (mapped → TRIGGER_SECRET_KEY by scripts/run-trigger-dev.mjs)
+HARMONIA_TRIGGER_PROJECT_REF       # Trigger.dev project ref
+HARMONIA_CRON_SECRET               # Cron job auth header
+HARMONIA_OTEL_*                    # OpenTelemetry config
+
+NEXT_PUBLIC_HARMONIA_NODE_ENV      # "local" | "development" | "production"
+NEXT_PUBLIC_HARMONIA_API_URL       # API base URL
+NEXT_PUBLIC_HARMONIA_WEB_URL       # Web app URL
+NEXT_PUBLIC_HARMONIA_DASHBOARD_URL # Dashboard URL
+NEXT_PUBLIC_HARMONIA_ALLOWED_ORIGIN # CORS origin (supports wildcards)
+```
+
+To add a new env var: add it to `.env.example`, add a Zod schema in the relevant `packages/env/src/modules/*.ts` module, and add it to the appropriate preset in `packages/env/src/presets/`.
+
+---
+
+## Adding an oRPC route
+
+1. Add Zod schemas to `packages/common/src/schemas/{entity}/`
+2. Add the handler in `packages/orpc/src/routers/protected/` (or `public/` if no auth needed)
+3. Export from the router's `index.ts`
+4. The route is automatically available on the client via `@harmonia/orpc/client`
+
+```typescript
+// packages/orpc/src/routers/protected/playlists.ts
+export const playlistsRouter = {
+  list: protectedProcedure
+    .input(playlistListInput)
+    .output(z.array(playlistListItemSchema))
+    .handler(async ({ context }) => {
+      return await db.select().from(playlist).where(eq(playlist.userId, context.session.user.id));
+    }),
+};
+```
+
+Procedure hierarchy: `publicProcedure` → `protectedProcedure` → `cronOrAuthProcedure`
+
+---
+
+## Adding a Drizzle schema table
+
+```typescript
+// packages/db/src/schema/my-table.ts
+import { pgTable, text, serial, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const myTable = pgTable("my_table", {
+  id: serial("id").primaryKey(),
+  userId: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+```
+
+Then export from `packages/db/src/schema/index.ts` and run `pnpm db:push`.
+
+---
+
+## Adding a Trigger.dev stage task
+
+```typescript
+// packages/common/src/trigger/tasks/stages/my-stage.ts
+import { task } from "@trigger.dev/sdk/v3";
+import { checkCancelled, updateRun, updateStageProgress } from "../../../services/organize";
+
+export const myStageTask = task({
+  id: "organize-stage-my-stage",
+  retry: { maxAttempts: 2, minTimeoutInMs: 2000, factor: 2 },
+  run: async ({ userId, runId }: { userId: string; runId: number }) => {
+    await checkCancelled(runId, userId);
+    await updateRun(runId, { currentStage: "my-stage" });
+    return await myServiceFunction(userId, async (p) => {
+      await updateStageProgress(runId, "my-stage", p);
+    });
+  },
+});
+```
+
+Then export from `apps/api/src/trigger/organize.ts` and add `.triggerAndWait()` in the parent `organize-pipeline` task.
+
+---
+
+## Code style
+
+- **Formatter**: Biome — tabs for indentation, double quotes, auto-organised imports
+- **Linting**: Biome recommended + strict style rules (`noParameterAssign`, `useAsConstAssertion`, etc.)
+- **Tailwind classes**: sorted automatically by Biome (`clsx`, `cva`, `cn` functions)
+- **TypeScript**: strict mode, `noUncheckedIndexedAccess`, `noUnusedLocals`
+- **Commits**: `feat:`, `fix:`, `chore:`, `perf:`, `refactor:` prefixes
+- **No comments** unless the WHY is non-obvious
+
+---
+
+## Key package imports
+
+```typescript
+import { db } from "@harmonia/db";
+import { track } from "@harmonia/db/schema/track";
+import { env } from "@harmonia/env/server";           // server-side env
+import { auth } from "@harmonia/core";                 // Better Auth singleton
+import { logger } from "@harmonia/logger";             // Pino logger
+import { protectedProcedure } from "@harmonia/orpc";  // oRPC procedures
+import { organizePipeline } from "@harmonia/common/trigger/tasks/organize";
+```
+
+Within each app, use `@/*` for local imports:
+```typescript
+import { Button } from "@/components/ui/button";
+import { useOrganize } from "@/hooks/mutations/use-organize";
+```


### PR DESCRIPTION
Closes #45

## What's added

### `CLAUDE.md`
Full project context for Claude Code CLI — loaded automatically at the start of every session. Covers monorepo layout, dev commands, the 5 hard rules (no bare `process.env`, explicit Groq key, no Inngest, HARMONIA_ prefix, JSONB merge for progress), patterns for adding routes/schema/tasks, and key package imports.

### `.cursor/rules/*.mdc` (7 files)
Glob-targeted rules for Cursor IDE:

| File | Attaches to |
|---|---|
| `project.mdc` | Always (stack overview, commands, hard rules) |
| `typescript.mdc` | `**/*.ts`, `**/*.tsx` |
| `api.mdc` | `packages/orpc/**`, `apps/api/**` |
| `database.mdc` | `packages/db/**` |
| `components.mdc` | `apps/*/src/components/**`, `packages/ui/**` |
| `env.mdc` | `packages/env/**`, `.env*` |
| `trigger.mdc` | `**/trigger/**`, `trigger.config.ts` |

### `.windsurfrules`
Single-file concise distillation for Windsurf (within the 6k char limit).

## Test plan

- [ ] Start a fresh Claude Code session — `CLAUDE.md` should be loaded automatically
- [ ] Open a Drizzle schema file in Cursor — `database.mdc` should attach
- [ ] Open a trigger task file in Cursor — `trigger.mdc` should attach
- [ ] Ask Claude/Cursor/Windsurf "how do I add a new oRPC route?" — answer should match actual patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive developer guidelines for API endpoint design, component structure, database schema patterns, environment variable management, TypeScript conventions, and Trigger.dev integration.

* **Chores**
  * Added editor configuration rules for Cursor and Windsurf IDEs to standardize project development practices and workflows across the monorepo.

---

**Note:** These changes are internal developer documentation and do not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->