### PR TITLE
feat: settings page — connected services, account, preferences

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -23,6 +23,7 @@
 		"better-auth": "catalog:",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"date-fns": "^4.1.0",
 		"dotenv": "catalog:",
 		"next": "catalog:",
 		"next-themes": "^0.4.6",

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -4,12 +4,19 @@ import {
 	DashboardSettingsNavRow,
 	DashboardSettingsRow,
 	DashboardSettingsSection,
+	DashboardSettingsSkeleton,
 } from "@/components/app/dashboard-settings-section";
 import { useSettingsController } from "@/shared/lib/settings/controller.hook";
 import { Badge, Button } from "@harmonia/ui";
 import { formatDistanceToNow } from "date-fns";
+import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
 	const {
 		email,
 		spotifyLinked,
@@ -21,10 +28,14 @@ export default function SettingsPage() {
 		signOut,
 	} = useSettingsController();
 
-	const lastSyncText = lastSync
-		? formatDistanceToNow(lastSync, { addSuffix: true })
-		: statsLoading
-			? "..."
+	if (!mounted) {
+		return <DashboardSettingsSkeleton />;
+	}
+
+	const lastSyncText = statsLoading
+		? "..."
+		: lastSync
+			? formatDistanceToNow(lastSync, { addSuffix: true })
 			: "Never";
 
 	const themeLabel =
@@ -71,9 +82,7 @@ export default function SettingsPage() {
 				<DashboardSettingsNavRow
 					label="Theme"
 					subtitle={themeLabel}
-					onClick={() =>
-						setTheme(resolvedTheme === "dark" ? "light" : "dark")
-					}
+					onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
 				/>
 				<DashboardSettingsRow
 					label="Analysis Frequency"

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -1,8 +1,97 @@
+"use client";
+
+import {
+	DashboardSettingsNavRow,
+	DashboardSettingsRow,
+	DashboardSettingsSection,
+} from "@/components/app/dashboard-settings-section";
+import { useSettingsController } from "@/shared/lib/settings/controller.hook";
+import { Badge, Button } from "@harmonia/ui";
+import { formatDistanceToNow } from "date-fns";
+
 export default function SettingsPage() {
+	const {
+		email,
+		spotifyLinked,
+		spotifyLoading,
+		lastSync,
+		statsLoading,
+		resolvedTheme,
+		setTheme,
+		signOut,
+	} = useSettingsController();
+
+	const lastSyncText = lastSync
+		? formatDistanceToNow(lastSync, { addSuffix: true })
+		: statsLoading
+			? "..."
+			: "Never";
+
+	const themeLabel =
+		resolvedTheme === "dark"
+			? "Dark"
+			: resolvedTheme === "light"
+				? "Light"
+				: "System default";
+
 	return (
-		<div className="flex flex-col gap-4">
-			<h1 className="font-bold text-3xl tracking-tight">Settings</h1>
-			<p className="text-muted-foreground">App settings and configuration.</p>
+		<div className="flex flex-col gap-6">
+			<div>
+				<h1 className="font-bold text-3xl tracking-tight">Settings</h1>
+				<p className="mt-1 text-muted-foreground text-sm">
+					Manage your account and app preferences.
+				</p>
+			</div>
+
+			<DashboardSettingsSection label="CONNECTED SERVICES">
+				<DashboardSettingsRow
+					label="Spotify"
+					value={
+						spotifyLoading ? (
+							"..."
+						) : spotifyLinked ? (
+							<span className="flex items-center gap-1.5">
+								<span className="size-2 rounded-full bg-green-500" />
+								Connected
+							</span>
+						) : (
+							"Not connected"
+						)
+					}
+				/>
+				<DashboardSettingsRow label="Last sync" value={lastSyncText} />
+			</DashboardSettingsSection>
+
+			<DashboardSettingsSection label="ACCOUNT">
+				<DashboardSettingsRow label="Email" value={email ?? "..."} />
+				<DashboardSettingsRow label="Plan" value="Free" />
+			</DashboardSettingsSection>
+
+			<DashboardSettingsSection label="PREFERENCES">
+				<DashboardSettingsNavRow
+					label="Theme"
+					subtitle={themeLabel}
+					onClick={() =>
+						setTheme(resolvedTheme === "dark" ? "light" : "dark")
+					}
+				/>
+				<DashboardSettingsRow
+					label="Analysis Frequency"
+					value={
+						<Badge variant="outline" className="text-xs">
+							Coming soon
+						</Badge>
+					}
+				/>
+			</DashboardSettingsSection>
+
+			<Button
+				variant="destructive"
+				className="w-full"
+				onClick={() => void signOut()}
+			>
+				Sign out
+			</Button>
 		</div>
 	);
 }

--- a/apps/dashboard/src/components/app/dashboard-settings-section.tsx
+++ b/apps/dashboard/src/components/app/dashboard-settings-section.tsx
@@ -1,0 +1,95 @@
+import { cn } from "@/lib/utils";
+import { Icons, Separator } from "@harmonia/ui";
+import type * as React from "react";
+
+export function DashboardSettingsSection({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="border">
+			<div className="flex flex-col gap-2 px-4 pt-4 pb-2">
+				<span className="text-muted-foreground text-xs uppercase tracking-widest">
+					{label}
+				</span>
+				<Separator />
+			</div>
+			<div className="px-4 pb-4">{children}</div>
+		</div>
+	);
+}
+
+export function DashboardSettingsRow({
+	label,
+	value,
+	valueClassName,
+}: {
+	label: string;
+	value: React.ReactNode;
+	valueClassName?: string;
+}) {
+	return (
+		<div className="flex items-center justify-between border-b py-4 last:border-b-0">
+			<span className="text-muted-foreground text-sm">{label}</span>
+			<span className={cn("text-sm font-medium", valueClassName)}>{value}</span>
+		</div>
+	);
+}
+
+export function DashboardSettingsNavRow({
+	label,
+	subtitle,
+	onClick,
+}: {
+	label: string;
+	subtitle?: string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="flex w-full items-center justify-between border-b py-4 transition-colors last:border-b-0 hover:bg-muted/40"
+		>
+			<div className="text-left">
+				<p className="text-sm font-medium">{label}</p>
+				{subtitle && (
+					<p className="text-muted-foreground text-xs">{subtitle}</p>
+				)}
+			</div>
+			<Icons.chevronRight className="size-4 shrink-0 text-muted-foreground" />
+		</button>
+	);
+}
+
+export function DashboardSettingsSkeleton() {
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex flex-col gap-2">
+				<div className="h-8 w-32 animate-pulse rounded bg-muted" />
+				<div className="h-4 w-64 animate-pulse rounded bg-muted" />
+			</div>
+			{[1, 2, 3].map((i) => (
+				<div key={i} className="border">
+					<div className="px-4 pt-4 pb-2">
+						<div className="h-3 w-32 animate-pulse rounded bg-muted" />
+					</div>
+					<div className="px-4 pb-4">
+						{[1, 2].map((j) => (
+							<div
+								key={j}
+								className="flex items-center justify-between border-b py-4 last:border-b-0"
+							>
+								<div className="h-4 w-24 animate-pulse rounded bg-muted" />
+								<div className="h-4 w-28 animate-pulse rounded bg-muted" />
+							</div>
+						))}
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/dashboard/src/shared/lib/settings/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/settings/controller.hook.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { authClient } from "@/shared/api/auth-client";
+import { orpc } from "@/shared/api/orpc";
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "next-themes";
+
+export function useSettingsController() {
+	const { data: session, isPending: sessionPending } = authClient.useSession();
+	const { theme, setTheme, resolvedTheme } = useTheme();
+
+	const spotifyLinked = useQuery(
+		orpc.hasSpotifyLinked.queryOptions({ input: {} }),
+	);
+	const libraryStats = useQuery(
+		orpc.spotify.libraryStats.queryOptions({ input: {} }),
+	);
+
+	const signOut = async () => {
+		await authClient.signOut();
+		window.location.href = "/login";
+	};
+
+	return {
+		session,
+		sessionPending,
+		email: session?.user.email ?? null,
+		spotifyLinked: spotifyLinked.data ?? false,
+		spotifyLoading: spotifyLinked.isLoading,
+		lastSync: libraryStats.data?.updatedAt ?? null,
+		statsLoading: libraryStats.isLoading,
+		theme,
+		resolvedTheme,
+		setTheme,
+		signOut,
+	};
+}

--- a/apps/dashboard/src/shared/lib/settings/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/settings/controller.hook.ts
@@ -5,6 +5,20 @@ import { orpc } from "@/shared/api/orpc";
 import { useQuery } from "@tanstack/react-query";
 import { useTheme } from "next-themes";
 
+function toSyncDate(value: unknown): Date | null {
+	if (value == null) {
+		return null;
+	}
+	if (value instanceof Date) {
+		return Number.isNaN(value.getTime()) ? null : value;
+	}
+	if (typeof value === "string" || typeof value === "number") {
+		const d = new Date(value);
+		return Number.isNaN(d.getTime()) ? null : d;
+	}
+	return null;
+}
+
 export function useSettingsController() {
 	const { data: session, isPending: sessionPending } = authClient.useSession();
 	const { theme, setTheme, resolvedTheme } = useTheme();
@@ -27,7 +41,7 @@ export function useSettingsController() {
 		email: session?.user.email ?? null,
 		spotifyLinked: spotifyLinked.data ?? false,
 		spotifyLoading: spotifyLinked.isLoading,
-		lastSync: libraryStats.data?.updatedAt ?? null,
+		lastSync: toSyncDate(libraryStats.data?.updatedAt),
 		statsLoading: libraryStats.isLoading,
 		theme,
 		resolvedTheme,

--- a/packages/common/src/schemas/spotify/output.ts
+++ b/packages/common/src/schemas/spotify/output.ts
@@ -53,7 +53,7 @@ export const spotifyLibraryStatsSchema = z.object({
 	totalPlaylists: z.number(),
 	uniqueAlbums: z.number(),
 	uniqueArtists: z.number(),
-	updatedAt: z.date().nullable().optional(),
+	updatedAt: z.union([z.null(), z.coerce.date()]).optional(),
 });
 export type SpotifyLibraryStats = z.infer<typeof spotifyLibraryStatsSchema>;
 

--- a/packages/common/src/schemas/spotify/output.ts
+++ b/packages/common/src/schemas/spotify/output.ts
@@ -53,6 +53,7 @@ export const spotifyLibraryStatsSchema = z.object({
 	totalPlaylists: z.number(),
 	uniqueAlbums: z.number(),
 	uniqueArtists: z.number(),
+	updatedAt: z.date().nullable().optional(),
 });
 export type SpotifyLibraryStats = z.infer<typeof spotifyLibraryStatsSchema>;
 

--- a/packages/common/src/services/music/spotify/library-stats.ts
+++ b/packages/common/src/services/music/spotify/library-stats.ts
@@ -52,12 +52,14 @@ export async function refreshSpotifyLibraryStats(
 					totalPlaylists: cached.totalPlaylists,
 					uniqueAlbums: cached.uniqueAlbums,
 					uniqueArtists: cached.uniqueArtists,
+					updatedAt: cached.updatedAt ?? null,
 				}
 			: {
 					totalTracks: 0,
 					totalPlaylists: 0,
 					uniqueAlbums: 0,
 					uniqueArtists: 0,
+					updatedAt: null,
 				};
 	}
 
@@ -121,6 +123,7 @@ export async function refreshSpotifyLibraryStats(
 	);
 
 	const stats = toStats(trackIds, totalPlaylists, albumKeys, artistKeys);
+	const now = new Date();
 
 	await db
 		.insert(userSpotifyLibraryStats)
@@ -138,11 +141,11 @@ export async function refreshSpotifyLibraryStats(
 				totalPlaylists: stats.totalPlaylists,
 				uniqueAlbums: stats.uniqueAlbums,
 				uniqueArtists: stats.uniqueArtists,
-				updatedAt: new Date(),
+				updatedAt: now,
 			},
 		});
 
-	return stats;
+	return { ...stats, updatedAt: now };
 }
 
 /**
@@ -170,6 +173,7 @@ export async function getSpotifyLibraryStats(
 			totalPlaylists: cached.totalPlaylists,
 			uniqueAlbums: cached.uniqueAlbums,
 			uniqueArtists: cached.uniqueArtists,
+			updatedAt: cached.updatedAt ?? null,
 		};
 	}
 
@@ -180,6 +184,7 @@ export async function getSpotifyLibraryStats(
 			totalPlaylists: cached.totalPlaylists,
 			uniqueAlbums: cached.uniqueAlbums,
 			uniqueArtists: cached.uniqueArtists,
+			updatedAt: cached.updatedAt ?? null,
 		};
 
 		const existing = refreshLocks.get(userId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dotenv:
         specifier: 'catalog:'
         version: 17.3.1


### PR DESCRIPTION
Closes #63

## Summary

- Builds the settings page at `/settings` with three bordered sections matching the design mockup
- Extends `SpotifyLibraryStats` schema to expose `updatedAt` for "Last sync" display
- Introduces `DashboardSettingsSection`, `DashboardSettingsRow`, `DashboardSettingsNavRow` as the canonical flat-bordered container pattern (referenced in #64)
- Adds `useSettingsController()` to `shared/lib/settings/` following the domain controller pattern from #58

## Changes

| File | Change |
|---|---|
| `packages/common/src/schemas/spotify/output.ts` | Add `updatedAt?: Date \| null` to `spotifyLibraryStatsSchema` |
| `packages/common/src/services/music/spotify/library-stats.ts` | Return `updatedAt` from all paths |
| `shared/lib/settings/controller.hook.ts` | New controller: session, Spotify status, last sync, theme, sign out |
| `components/app/dashboard-settings-section.tsx` | New: `DashboardSettingsSection`, `DashboardSettingsRow`, `DashboardSettingsNavRow`, `DashboardSettingsSkeleton` |
| `app/(dashboard)/settings/page.tsx` | Full settings page implementation |
| `apps/dashboard/package.json` | Add `date-fns@^4.1.0` |

## Test plan

- [ ] Navigate to `/settings` — three sections render correctly
- [ ] Spotify row shows green dot when account is linked, "Not connected" otherwise
- [ ] Last sync shows relative time (e.g. "2 hours ago") after a pipeline run
- [ ] Email shows the signed-in user's email
- [ ] Theme toggle cycles dark ↔ light
- [ ] Sign out button redirects to `/login`
- [ ] `npx tsc --noEmit` passes