### PR TITLE
refactor: remove unused Card imports, document Card vs flat section rule

### DIFF
--- a/.cursor/rules/apps/dashboard.mdc
+++ b/.cursor/rules/apps/dashboard.mdc
@@ -58,6 +58,14 @@ apps/dashboard/src/
 - No `toast.success()` on pipeline launch (drawer opening is feedback enough)
 - Error toasts always provide a "Copy" action for the error message
 
+## Container Patterns
+
+- **`DashboardSettingsSection`** (`components/app/dashboard-settings-section.tsx`) — bordered container with uppercase section label. Use for settings, metadata, or any grouped-rows page section.
+- **`DashboardSettingsRow`** — label left, value right with `border-b`. Use inside `DashboardSettingsSection`.
+- **`DashboardSettingsNavRow`** — tappable row with label, subtitle, and `chevronRight`. Use for preference rows that open a sub-action.
+- **`DashboardPlaylistDetailSectionLabel`** — standalone label + `Separator`. Use when only a section header is needed without a bordered container.
+- Inline row dividers: `border-b py-4 last:border-b-0` directly on each row element.
+
 ## Navigation
 
 - Routes defined in `@harmonia/common/utils/routes` as `DASHBOARD_ROUTES`

--- a/.cursor/rules/packages/ui.mdc
+++ b/.cursor/rules/packages/ui.mdc
@@ -27,6 +27,13 @@ import { Button } from "@harmonia/ui";
 - Dark mode: `dark:` prefix (managed by `next-themes`)
 - **Tabs** for indentation (enforced by Biome)
 
+## Card vs. Flat Section
+
+- **`<Card>`** — use for elevated interactive surfaces: grids of clickable items, feature highlight blocks. Uses `ring-1 ring-foreground/10` with `rounded-none`. Sizes: `default`, `sm`.
+- **Flat bordered section** (`DashboardSettingsSection` or inline `border` + section label) — use for informational grouped rows: settings, metadata, stats. Uses CSS `border` at full opacity with `border-b py-4 last:border-b-0` on each row.
+
+Do NOT use `<Card>` for settings sections, stat blocks, or metadata rows.
+
 ## Do Not
 
 - Copy-paste shadcn component source into app directories — extend via props instead

--- a/apps/dashboard/src/app/(dashboard)/tracks/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/tracks/page.tsx
@@ -6,9 +6,6 @@ import { useTracksController } from "@/shared/lib/tracks/controller.hook";
 import {
 	Badge,
 	Button,
-	Card,
-	CardContent,
-	CardHeader,
 	Input,
 	Sheet,
 	SheetContent,


### PR DESCRIPTION
Closes #64

## Summary

Audit found the `Card` component was imported in `tracks/page.tsx` but never rendered anywhere in the dashboard. This PR cleans that up and documents the rule for when to use `Card` vs the flat bordered section pattern.

## Changes

| File | Change |
|---|---|
| `apps/dashboard/src/app/(dashboard)/tracks/page.tsx` | Remove unused `Card`, `CardContent`, `CardHeader` imports |
| `.cursor/rules/packages/ui.mdc` | Add **Card vs Flat Section** rule |
| `.cursor/rules/apps/dashboard.mdc` | Add **Container Patterns** section documenting `DashboardSettingsSection` and friends |

## Rule established

- **`<Card>`** → elevated interactive surfaces (clickable grids, feature blocks). Uses `ring-1 ring-foreground/10`.
- **Flat bordered section** (`DashboardSettingsSection` from #65) → informational grouped rows: settings, metadata, stats. Uses CSS `border` with `border-b py-4 last:border-b-0` rows.

## Test plan

- [ ] Tracks page renders correctly — no visual regression
- [ ] `npx tsc --noEmit` passes