### PR TITLE
fix(pipeline): surface degraded classify coverage instead of silent success

### DIFF
--- a/packages/common/src/schemas/pipeline/output.ts
+++ b/packages/common/src/schemas/pipeline/output.ts
@@ -34,7 +34,7 @@ export const pipelineClearAnalysisOutputSchema = z.object({
 	tracksUpdated: z.number(),
 });
 export type PipelineClearAnalysisOutput = z.infer<
-	typeof pipelineClearAnalysisOutputSchema
+  typeof pipelineClearAnalysisOutputSchema
 >;
 
 export const pipelineStatusEventSchema = z.discriminatedUnion("event", [
@@ -50,6 +50,13 @@ export const pipelineStatusEventSchema = z.discriminatedUnion("event", [
 		event: z.literal("completed"),
 		runId: z.number(),
 		progress: z.unknown(),
+		completedAt: z.date().nullable(),
+	}),
+	z.object({
+		event: z.literal("partial"),
+		runId: z.number(),
+		progress: z.unknown(),
+		warning: z.string().nullable(),
 		completedAt: z.date().nullable(),
 	}),
 	z.object({

--- a/packages/common/src/services/organize/run-organize.ts
+++ b/packages/common/src/services/organize/run-organize.ts
@@ -44,6 +44,9 @@ import {
 } from "../brain";
 import { fetchLyricsForPendingTracks, syncLibraryTracks } from "../music";
 
+/** Minimum fraction of tracks that must be classified for the pipeline to be considered healthy. */
+const MIN_CLASSIFY_RATIO = 0.1;
+
 export async function updateRun(
 	runId: number,
 	data: {
@@ -142,6 +145,26 @@ export async function runOrganizeForUser({
 		);
 		progress.classify = classifyResult;
 		await updateRun(runId, { progress });
+
+		// Gate: if classification coverage is critically low, mark as degraded
+		if (
+			classifyResult.total > 0 &&
+			classifyResult.classified / classifyResult.total < MIN_CLASSIFY_RATIO
+		) {
+			const coverage = ((classifyResult.classified / classifyResult.total) * 100).toFixed(1);
+			const warning = `Classify stage coverage critically low: ${classifyResult.classified}/${classifyResult.total} tracks (${coverage}%). Pipeline result is degraded — re-run recommended.`;
+
+			await updateRun(runId, {
+				status: "partial",
+				currentStage: null,
+				progress,
+				error: warning,
+				completedAt: new Date(),
+			});
+
+			logger.warn({ userId, runId, coverage }, "Organize pipeline completed with degraded classify coverage");
+			return { userId, runId, status: "partial" as const, warning };
+		}
 
 		await checkCancelled(runId, userId);
 		await updateRun(runId, { currentStage: "embed" });

--- a/packages/common/src/trigger/tasks/organize.ts
+++ b/packages/common/src/trigger/tasks/organize.ts
@@ -9,6 +9,9 @@ import { lyricsStageTask } from "./stages/lyrics";
 import { matchStageTask } from "./stages/match";
 import { syncStageTask } from "./stages/sync";
 
+/** Minimum fraction of tracks that must be classified for the pipeline to be considered healthy. */
+const MIN_CLASSIFY_RATIO = 0.1;
+
 export const organizePipeline = task({
 	id: "organize-pipeline",
 	retry: { maxAttempts: 1 },
@@ -18,7 +21,29 @@ export const organizePipeline = task({
 
 			await syncStageTask.triggerAndWait({ userId, runId });
 			await lyricsStageTask.triggerAndWait({ userId, runId });
-			await classifyStageTask.triggerAndWait({ userId, runId });
+			const classifyResult = await classifyStageTask.triggerAndWait({ userId, runId });
+
+			// Gate: if classification coverage is critically low, mark as degraded
+			if (
+				classifyResult &&
+				typeof classifyResult.total === "number" &&
+				typeof classifyResult.classified === "number" &&
+				classifyResult.total > 0 &&
+				classifyResult.classified / classifyResult.total < MIN_CLASSIFY_RATIO
+			) {
+				const coverage = ((classifyResult.classified / classifyResult.total) * 100).toFixed(1);
+				const warning = `Classify stage coverage critically low: ${classifyResult.classified}/${classifyResult.total} tracks (${coverage}%). Pipeline result is degraded — re-run recommended.`;
+
+				await updateRun(runId, {
+					status: "partial",
+					currentStage: null,
+					error: warning,
+					completedAt: new Date(),
+				});
+
+				return { userId, runId, status: "partial" as const, warning };
+			}
+
 			await embedStageTask.triggerAndWait({ userId, runId });
 			await clusterStageTask.triggerAndWait({ userId, runId });
 			await generateStageTask.triggerAndWait({ userId, runId });


### PR DESCRIPTION
## Problem

Fixes #101

When the classify stage fails completely (all workers error), the pipeline continues through embed -> cluster -> generate -> match, each logging "nothing to do" and succeeding. The user sees `status: completed` with zero playlists and no indication anything went wrong.

## Changes

### 1. Classify threshold gate (`organize.ts` + `run-organize.ts`)
- After the classify stage completes, checks if `classified / total < 0.1` (less than 10% coverage)
- If so, short-circuits remaining stages and marks the run as `partial` with a descriptive warning
- Warning message includes exact coverage numbers: `Classify stage coverage critically low: 0/3353 tracks (0.0%). Pipeline result is degraded - re-run recommended.`

### 2. Partial status event (`output.ts`)
- Added `partial` event variant to `pipelineStatusEventSchema` discriminated union
- Includes `warning` field so the dashboard can display the degradation reason

### Constants
- `MIN_CLASSIFY_RATIO = 0.1` - threshold is conservative (10%) to avoid false positives on small libraries

## Testing

The fix is verified by the logic: if classify returns `{ classified: 0, total: 3353 }`, the pipeline will now stop with status `partial` instead of proceeding to embed/cluster/generate/match and reporting `completed`.

---
Wallet: zp6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline now detects when classification quality falls below minimum threshold and returns a "partial" completion status with warning message.
  * Pipeline execution halts after classification stage if coverage is insufficient, preventing downstream processing with incomplete data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FindMalek/harmonia/pull/102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->