### PR TITLE
hide library analysis until first pipeline run

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-library-analysis.tsx
+++ b/apps/dashboard/src/components/app/dashboard-library-analysis.tsx
@@ -14,7 +14,9 @@ function DashboardLibraryAnalysisProgressSkeleton() {
 export function DashboardLibraryAnalysis() {
 	const { runs } = usePipelineController();
 	const hasCompletedRun =
-		runs.data?.some((r) => r.status === "completed") ?? false;
+		runs.data?.some(
+			(r) => r.status === "completed" || r.status === "running"
+		) ?? false;
 	const activeRunId = useOrganizeStore((s) => s.activeRunId);
 	const { liveProgress: ctxLiveProgress } = usePipelineProgress();
 	const activeRun =

--- a/apps/dashboard/src/components/app/dashboard-library-analysis.tsx
+++ b/apps/dashboard/src/components/app/dashboard-library-analysis.tsx
@@ -13,6 +13,8 @@ function DashboardLibraryAnalysisProgressSkeleton() {
 
 export function DashboardLibraryAnalysis() {
 	const { runs } = usePipelineController();
+	const hasCompletedRun =
+		runs.data?.some((r) => r.status === "completed") ?? false;
 	const activeRunId = useOrganizeStore((s) => s.activeRunId);
 	const { liveProgress: ctxLiveProgress } = usePipelineProgress();
 	const activeRun =
@@ -40,6 +42,8 @@ export function DashboardLibraryAnalysis() {
 	const analyzedPercentage =
 		totalTracks > 0 ? (tracksAnalyzed / totalTracks) * 100 : 0;
 	const embedPercentage = totalTracks > 0 ? (embedded / totalTracks) * 100 : 0;
+
+	if (runs.isLoading || !hasCompletedRun) return null;
 
 	return (
 		<div className="space-y-4 ">


### PR DESCRIPTION
## 🧠 Overview
<!-- Briefly describe what this PR does and why -->

Closes #

---

## ✅ Pre-merge Checklist

### Code Quality
- [ ] Self-reviewed the code thoroughly
- [ ] Follows project conventions (`.cursor/rules/`)
- [ ] Builds and runs locally without errors (`pnpm check-types`)
- [ ] Biome passes (`pnpm check`)

### Testing
- [ ] Tested the changed feature end-to-end locally
- [ ] Verified no regressions in adjacent features
- [ ] If pipeline-related: ran a full organize pipeline and confirmed results

---

## 🔍 Additional Notes
<!-- Anything reviewers should be aware of — breaking changes, migrations needed, follow-up issues -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Library Analysis section in the dashboard now displays only after at least one pipeline run has completed successfully, preventing display of incomplete progress information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FindMalek/harmonia/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->