### PR TITLE
refactor: make track a global shared resource (remove userId, preserve on db:reset)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"db:migrate": "turbo -F @harmonia/db db:migrate",
 		"db:setup": "docker compose -f ./docker/docker-compose.yml up -d && pnpm db:push",
 		"db:reset": "turbo -F @harmonia/db db:reset",
+		"db:reset:all": "turbo -F @harmonia/db db:reset:all",
 		"db:nuke": "turbo -F @harmonia/db db:nuke",
 		"check": "biome check --write .",
 		"lint": "biome lint --write .",

--- a/packages/common/src/schemas/track/output.ts
+++ b/packages/common/src/schemas/track/output.ts
@@ -36,7 +36,6 @@ export type TracksListOutput = z.infer<typeof tracksListOutputSchema>;
 
 export const trackGetByIdOutputSchema = z.object({
 	id: z.string(),
-	userId: z.string(),
 	spotifyUri: z.string(),
 	name: z.string(),
 	artistNames: z.string(),

--- a/packages/common/src/services/brain/classifier.ts
+++ b/packages/common/src/services/brain/classifier.ts
@@ -5,7 +5,7 @@ import type {
 import type { ClassifyProgress } from "@harmonia/common/types";
 import { db } from "@harmonia/db";
 import { genreDomain } from "@harmonia/db/schema/genre-domain";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import pLimit from "p-limit";
@@ -24,12 +24,17 @@ export async function classifyTracksBatch(
 	userId: string,
 	onProgress?: (progress: ClassifyProgress) => Promise<void>,
 ): Promise<ClassifyProgress> {
+	const userTrackIds = db
+		.select({ trackId: userTracks.trackId })
+		.from(userTracks)
+		.where(eq(userTracks.userId, userId));
+
 	const allPending = await db
 		.select({ id: track.id })
 		.from(track)
 		.where(
 			and(
-				eq(track.userId, userId),
+				inArray(track.id, userTrackIds),
 				isNull(track.llmClassifiedAt),
 				inArray(track.lyricsStatus, ["found", "not_found"]),
 			),
@@ -57,11 +62,7 @@ export async function classifyTracksBatch(
 					.select()
 					.from(track)
 					.where(
-						and(
-							eq(track.userId, userId),
-							inArray(track.id, batchIds),
-							isNull(track.llmClassifiedAt),
-						),
+						and(inArray(track.id, batchIds), isNull(track.llmClassifiedAt)),
 					);
 
 				if (pendingTracks.length === 0) return;
@@ -177,13 +178,7 @@ export async function classifyTracksBatch(
 									},
 								},
 							})
-							.where(
-								and(
-									eq(track.userId, userId),
-									eq(track.id, trackId),
-									isNull(track.llmClassifiedAt),
-								),
-							),
+							.where(and(eq(track.id, trackId), isNull(track.llmClassifiedAt))),
 					),
 				);
 
@@ -234,11 +229,7 @@ export async function classifyTrackIds(
 					.select()
 					.from(track)
 					.where(
-						and(
-							eq(track.userId, userId),
-							inArray(track.id, batchIds),
-							isNull(track.llmClassifiedAt),
-						),
+						and(inArray(track.id, batchIds), isNull(track.llmClassifiedAt)),
 					);
 
 				if (pendingTracks.length === 0) return;
@@ -342,13 +333,7 @@ export async function classifyTrackIds(
 									modelVersions: { llm: CLASSIFICATION_LLM_MODEL },
 								},
 							})
-							.where(
-								and(
-									eq(track.userId, userId),
-									eq(track.id, trackId),
-									isNull(track.llmClassifiedAt),
-								),
-							),
+							.where(and(eq(track.id, trackId), isNull(track.llmClassifiedAt))),
 					),
 				);
 

--- a/packages/common/src/services/brain/classifier.ts
+++ b/packages/common/src/services/brain/classifier.ts
@@ -62,7 +62,10 @@ export async function classifyTracksBatch(
 					.select()
 					.from(track)
 					.where(
-						and(inArray(track.id, batchIds), isNull(track.llmClassifiedAt)),
+						and(
+							inArray(track.id, batchIds),
+							isNull(track.llmClassifiedAt),
+						),
 					);
 
 				if (pendingTracks.length === 0) return;
@@ -178,7 +181,12 @@ export async function classifyTracksBatch(
 									},
 								},
 							})
-							.where(and(eq(track.id, trackId), isNull(track.llmClassifiedAt))),
+							.where(
+										and(
+											eq(track.id, trackId),
+											isNull(track.llmClassifiedAt),
+										),
+									),
 					),
 				);
 
@@ -229,7 +237,10 @@ export async function classifyTrackIds(
 					.select()
 					.from(track)
 					.where(
-						and(inArray(track.id, batchIds), isNull(track.llmClassifiedAt)),
+						and(
+							inArray(track.id, batchIds),
+							isNull(track.llmClassifiedAt),
+						),
 					);
 
 				if (pendingTracks.length === 0) return;
@@ -333,7 +344,12 @@ export async function classifyTrackIds(
 									modelVersions: { llm: CLASSIFICATION_LLM_MODEL },
 								},
 							})
-							.where(and(eq(track.id, trackId), isNull(track.llmClassifiedAt))),
+							.where(
+										and(
+											eq(track.id, trackId),
+											isNull(track.llmClassifiedAt),
+										),
+									),
 					),
 				);
 

--- a/packages/common/src/services/brain/clustering.ts
+++ b/packages/common/src/services/brain/clustering.ts
@@ -2,9 +2,9 @@ import type { ClusterProgress } from "@harmonia/common/types";
 import { db } from "@harmonia/db";
 import { cluster, clusterTracks } from "@harmonia/db/schema/cluster";
 import { genreDomain } from "@harmonia/db/schema/genre-domain";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
-import { and, eq, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 
 import Clustering from "density-clustering";
 
@@ -21,10 +21,15 @@ export async function runClustering(
 ): Promise<ClusterProgress> {
 	const stats: ClusterProgress = { clusters: 0, noise: 0, totalTracks: 0 };
 
+	const userTrackIds = db
+		.select({ trackId: userTracks.trackId })
+		.from(userTracks)
+		.where(eq(userTracks.userId, userId));
+
 	const tracks = await db
 		.select()
 		.from(track)
-		.where(and(eq(track.userId, userId), isNotNull(track.embedding)));
+		.where(and(inArray(track.id, userTrackIds), isNotNull(track.embedding)));
 
 	if (tracks.length === 0) {
 		logger.info({ userId }, "No tracks with embeddings; skipping clustering");

--- a/packages/common/src/services/brain/embeddings.ts
+++ b/packages/common/src/services/brain/embeddings.ts
@@ -67,7 +67,12 @@ export async function embedTracksBatch(
 				const pendingTracks = await db
 					.select()
 					.from(track)
-					.where(and(inArray(track.id, batchIds), isNull(track.embedding)));
+					.where(
+						and(
+							inArray(track.id, batchIds),
+							isNull(track.embedding),
+						),
+					);
 
 				if (pendingTracks.length === 0) return;
 
@@ -185,7 +190,8 @@ export async function embedTracksBatch(
 								embedding_input = ${input.text},
 								analysis_snapshot = ${snapshotJson}::jsonb,
 								updated_at = NOW()
-							WHERE id = ${input.id}
+							WHERE user_id = ${userId}
+							  AND id = ${input.id}
 							  AND embedding IS NULL
 						`);
 					}),
@@ -359,7 +365,8 @@ export async function embedTrackIds(
 								embedding_input = ${input.text},
 								analysis_snapshot = ${snapshotJson}::jsonb,
 								updated_at = NOW()
-							WHERE id = ${input.id}
+							WHERE user_id = ${userId}
+							  AND id = ${input.id}
 							  AND embedding IS NULL
 						`);
 					}),

--- a/packages/common/src/services/brain/embeddings.ts
+++ b/packages/common/src/services/brain/embeddings.ts
@@ -1,7 +1,7 @@
 import type { EmbedProgress } from "@harmonia/common/types";
 import { getLlmTags } from "@harmonia/common/types";
 import { db } from "@harmonia/db";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { env } from "@harmonia/env/server";
 import { logger } from "@harmonia/logger";
 import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
@@ -37,10 +37,15 @@ export async function embedTracksBatch(
 		return stats;
 	}
 
+	const userTrackIds = db
+		.select({ trackId: userTracks.trackId })
+		.from(userTracks)
+		.where(eq(userTracks.userId, userId));
+
 	const allPending = await db
 		.select({ id: track.id })
 		.from(track)
-		.where(and(eq(track.userId, userId), isNull(track.embedding)));
+		.where(and(inArray(track.id, userTrackIds), isNull(track.embedding)));
 
 	const total = allPending.length;
 
@@ -62,13 +67,7 @@ export async function embedTracksBatch(
 				const pendingTracks = await db
 					.select()
 					.from(track)
-					.where(
-						and(
-							eq(track.userId, userId),
-							inArray(track.id, batchIds),
-							isNull(track.embedding),
-						),
-					);
+					.where(and(inArray(track.id, batchIds), isNull(track.embedding)));
 
 				if (pendingTracks.length === 0) return;
 
@@ -186,8 +185,7 @@ export async function embedTracksBatch(
 								embedding_input = ${input.text},
 								analysis_snapshot = ${snapshotJson}::jsonb,
 								updated_at = NOW()
-							WHERE user_id = ${userId}
-							  AND id = ${input.id}
+							WHERE id = ${input.id}
 							  AND embedding IS NULL
 						`);
 					}),
@@ -245,7 +243,6 @@ export async function embedTrackIds(
 					.from(track)
 					.where(
 						and(
-							eq(track.userId, userId),
 							inArray(track.id, batchIds),
 							isNull(track.embedding),
 							isNotNull(track.llmClassifiedAt),
@@ -362,8 +359,7 @@ export async function embedTrackIds(
 								embedding_input = ${input.text},
 								analysis_snapshot = ${snapshotJson}::jsonb,
 								updated_at = NOW()
-							WHERE user_id = ${userId}
-							  AND id = ${input.id}
+							WHERE id = ${input.id}
 							  AND embedding IS NULL
 						`);
 					}),

--- a/packages/common/src/services/brain/track-matcher.ts
+++ b/packages/common/src/services/brain/track-matcher.ts
@@ -5,9 +5,9 @@ import {
 	playlistClusters,
 	playlistTracks,
 } from "@harmonia/db/schema/playlist";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
-import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
 import { TRACK_MATCH_SIMILARITY_THRESHOLD } from "../../constants/brain";
 
@@ -41,13 +41,18 @@ export async function matchNewTracksToPlaylists(
 
 	const assignedTrackIds = new Set(existingAssignments.map((r) => r.trackId));
 
+	const userTrackIds = db
+		.select({ trackId: userTracks.trackId })
+		.from(userTracks)
+		.where(eq(userTracks.userId, userId));
+
 	const unassignedTracks = await db
 		.select({
 			id: track.id,
 			embedding: track.embedding,
 		})
 		.from(track)
-		.where(and(eq(track.userId, userId), isNotNull(track.embedding)));
+		.where(and(inArray(track.id, userTrackIds), isNotNull(track.embedding)));
 
 	const tracksToMatch = unassignedTracks.filter(
 		(t) => !assignedTrackIds.has(t.id),

--- a/packages/common/src/services/music/lyrics/fetch-lyrics.ts
+++ b/packages/common/src/services/music/lyrics/fetch-lyrics.ts
@@ -1,6 +1,6 @@
 import type { LyricsProgress } from "@harmonia/common/types";
 import { db } from "@harmonia/db";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { and, count, eq, inArray, isNull, or } from "drizzle-orm";
 import pLimit from "p-limit";
@@ -30,8 +30,13 @@ export async function fetchLyricsForPendingTracks(
 	};
 	const limit = pLimit(LYRICS_CONCURRENCY);
 
+	const userTrackIds = db
+		.select({ trackId: userTracks.trackId })
+		.from(userTracks)
+		.where(eq(userTracks.userId, userId));
+
 	const lyricsPendingPredicate = and(
-		eq(track.userId, userId),
+		inArray(track.id, userTrackIds),
 		or(eq(track.lyricsStatus, "pending"), isNull(track.lyricsStatus)),
 		isNull(track.lyrics),
 	);
@@ -80,7 +85,7 @@ export async function fetchLyricsForPendingTracks(
 								lyricsStatus: "not_found",
 								lyricsFetchedAt: new Date(),
 							})
-							.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+							.where(eq(track.id, t.id));
 						stats.notFound++;
 						stats.processed++;
 					} catch (err) {
@@ -110,7 +115,7 @@ export async function fetchLyricsForPendingTracks(
 								lyricsStatus: "not_found",
 								lyricsFetchedAt: new Date(),
 							})
-							.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+							.where(eq(track.id, t.id));
 						stats.notFound++;
 					} else {
 						await db
@@ -123,7 +128,7 @@ export async function fetchLyricsForPendingTracks(
 								lyricsStatus: "found",
 								lyricsFetchedAt: new Date(),
 							})
-							.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+							.where(eq(track.id, t.id));
 						stats.found++;
 					}
 				} catch (err) {
@@ -140,7 +145,7 @@ export async function fetchLyricsForPendingTracks(
 							lyricsStatus: "not_found",
 							lyricsFetchedAt: new Date(),
 						})
-						.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+						.where(eq(track.id, t.id));
 					stats.notFound++;
 				}
 
@@ -208,7 +213,6 @@ export async function fetchLyricsForTrackIds(
 			.from(track)
 			.where(
 				and(
-					eq(track.userId, userId),
 					inArray(track.id, batchIds),
 					or(eq(track.lyricsStatus, "pending"), isNull(track.lyricsStatus)),
 					isNull(track.lyrics),
@@ -234,7 +238,7 @@ export async function fetchLyricsForTrackIds(
 						await db
 							.update(track)
 							.set({ lyricsStatus: "not_found", lyricsFetchedAt: new Date() })
-							.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+							.where(eq(track.id, t.id));
 						stats.notFound++;
 						stats.processed++;
 					} catch (err) {
@@ -261,7 +265,7 @@ export async function fetchLyricsForTrackIds(
 						await db
 							.update(track)
 							.set({ lyricsStatus: "not_found", lyricsFetchedAt: new Date() })
-							.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+							.where(eq(track.id, t.id));
 						stats.notFound++;
 					} else {
 						await db
@@ -274,7 +278,7 @@ export async function fetchLyricsForTrackIds(
 								lyricsStatus: "found",
 								lyricsFetchedAt: new Date(),
 							})
-							.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+							.where(eq(track.id, t.id));
 						stats.found++;
 					}
 				} catch (err) {
@@ -288,7 +292,7 @@ export async function fetchLyricsForTrackIds(
 					await db
 						.update(track)
 						.set({ lyricsStatus: "not_found", lyricsFetchedAt: new Date() })
-						.where(and(eq(track.userId, userId), eq(track.id, t.id)));
+						.where(eq(track.id, t.id));
 					stats.notFound++;
 				}
 

--- a/packages/common/src/services/music/spotify/library-sync.ts
+++ b/packages/common/src/services/music/spotify/library-sync.ts
@@ -9,7 +9,7 @@ import {
 	userPlaylistSnapshots,
 	userSpotifyLibraryStats,
 } from "@harmonia/db/schema/spotify";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { sql } from "drizzle-orm";
 import pLimit from "p-limit";
@@ -348,7 +348,6 @@ export async function syncLibraryTracks(
 	const now = new Date();
 	const values = tracks.map((t) => ({
 		id: t.id,
-		userId,
 		spotifyUri: t.uri,
 		name: t.name,
 		artistNames: t.artistNames,
@@ -368,7 +367,6 @@ export async function syncLibraryTracks(
 			.onConflictDoUpdate({
 				target: track.id,
 				set: {
-					userId: sql`excluded.user_id`,
 					spotifyUri: sql`excluded.spotify_uri`,
 					name: sql`excluded.name`,
 					artistNames: sql`excluded.artist_names`,
@@ -379,6 +377,14 @@ export async function syncLibraryTracks(
 					updatedAt: sql`excluded.updated_at`,
 				},
 			});
+	}
+
+	for (let i = 0; i < tracks.length; i += TRACK_UPSERT_BATCH_SIZE) {
+		const batch = tracks.slice(i, i + TRACK_UPSERT_BATCH_SIZE);
+		await db
+			.insert(userTracks)
+			.values(batch.map((t) => ({ userId, trackId: t.id })))
+			.onConflictDoNothing();
 	}
 
 	const result: SyncProgress & { stats?: SpotifyLibraryStats } = {

--- a/packages/common/src/trigger/tasks/stages/classify.ts
+++ b/packages/common/src/trigger/tasks/stages/classify.ts
@@ -1,5 +1,5 @@
 import { db } from "@harmonia/db";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { queue, task } from "@trigger.dev/sdk/v3";
 import { and, eq, inArray, isNull } from "drizzle-orm";
@@ -60,12 +60,17 @@ export const classifyStageTask = task({
 		await checkCancelled(runId, userId);
 		await updateRun(runId, { currentStage: "classify" });
 
+		const userTrackIds = db
+			.select({ trackId: userTracks.trackId })
+			.from(userTracks)
+			.where(eq(userTracks.userId, userId));
+
 		const allPending = await db
 			.select({ id: track.id })
 			.from(track)
 			.where(
 				and(
-					eq(track.userId, userId),
+					inArray(track.id, userTrackIds),
 					isNull(track.llmClassifiedAt),
 					inArray(track.lyricsStatus, ["found", "not_found"]),
 				),

--- a/packages/common/src/trigger/tasks/stages/embed.ts
+++ b/packages/common/src/trigger/tasks/stages/embed.ts
@@ -1,8 +1,8 @@
 import { db } from "@harmonia/db";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { queue, task } from "@trigger.dev/sdk/v3";
-import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 
 import { embedTrackIds } from "../../../services/brain";
 import {
@@ -56,12 +56,17 @@ export const embedStageTask = task({
 		await updateRun(runId, { currentStage: "embed" });
 
 		// Only embed tracks that have been classified (llmClassifiedAt IS NOT NULL)
+		const userTrackIds = db
+			.select({ trackId: userTracks.trackId })
+			.from(userTracks)
+			.where(eq(userTracks.userId, userId));
+
 		const allPending = await db
 			.select({ id: track.id })
 			.from(track)
 			.where(
 				and(
-					eq(track.userId, userId),
+					inArray(track.id, userTrackIds),
 					isNull(track.embedding),
 					isNotNull(track.llmClassifiedAt),
 				),

--- a/packages/common/src/trigger/tasks/stages/lyrics.ts
+++ b/packages/common/src/trigger/tasks/stages/lyrics.ts
@@ -1,8 +1,8 @@
 import { db } from "@harmonia/db";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { queue, task } from "@trigger.dev/sdk/v3";
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, inArray, isNull, or } from "drizzle-orm";
 
 import { fetchLyricsForTrackIds } from "../../../services/music";
 import {
@@ -70,12 +70,17 @@ export const lyricsStageTask = task({
 		await checkCancelled(runId, userId);
 		await updateRun(runId, { currentStage: "lyrics" });
 
+		const userTrackIds = db
+			.select({ trackId: userTracks.trackId })
+			.from(userTracks)
+			.where(eq(userTracks.userId, userId));
+
 		const allPending = await db
 			.select({ id: track.id })
 			.from(track)
 			.where(
 				and(
-					eq(track.userId, userId),
+					inArray(track.id, userTrackIds),
 					or(eq(track.lyricsStatus, "pending"), isNull(track.lyricsStatus)),
 					isNull(track.lyrics),
 				),

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
 		"db:migrate": "drizzle-kit migrate",
 		"db:mark-migrations-applied": "node scripts/mark-migrations-applied.mjs",
 		"db:reset": "tsx scripts/db-reset.ts",
+		"db:reset:all": "tsx scripts/db-reset.ts --all",
 		"db:nuke": "node scripts/db-nuke.mjs"
 	},
 	"dependencies": {

--- a/packages/db/scripts/db-reset.ts
+++ b/packages/db/scripts/db-reset.ts
@@ -24,9 +24,12 @@ const TABLES_TO_TRUNCATE = [
 	"character_clusters",
 	"character",
 	"pipeline_run",
-	"track",
+	"user_tracks",
 	"todo",
 ] as const;
+
+// Include track only with --all (tracks hold expensive computed data)
+const EXTRA_ALL_TABLES = ["track"] as const;
 
 function assertSafeResetHost(databaseUrl: string): void {
 	const parsed = new URL(databaseUrl);
@@ -50,12 +53,17 @@ function assertSafeResetHost(databaseUrl: string): void {
 async function main(): Promise<void> {
 	assertSafeResetHost(dbEnv.HARMONIA_DATABASE_URL);
 
+	const includeAll = process.argv.includes("--all");
+	const tables = includeAll
+		? ([...TABLES_TO_TRUNCATE, ...EXTRA_ALL_TABLES] as const)
+		: TABLES_TO_TRUNCATE;
+
 	const pool = new Pool({ connectionString: dbEnv.HARMONIA_DATABASE_URL });
-	const quotedTables = TABLES_TO_TRUNCATE.map((t) => `"${t}"`).join(", ");
+	const quotedTables = tables.map((t) => `"${t}"`).join(", ");
 	const sql = `TRUNCATE TABLE ${quotedTables} RESTART IDENTITY CASCADE`;
 
 	console.info(
-		`db:reset: truncating ${String(TABLES_TO_TRUNCATE.length)} tables`,
+		`db:reset: truncating ${String(tables.length)} tables${includeAll ? " (--all: includes track)" : ""}`,
 	);
 
 	try {
@@ -65,7 +73,9 @@ async function main(): Promise<void> {
 			await client.query(sql);
 			await client.query("COMMIT");
 			console.info(
-				"db:reset: done (auth, genre_domain, drizzle migrations unchanged)",
+				includeAll
+					? "db:reset: done (auth, genre_domain, drizzle migrations unchanged)"
+					: "db:reset: done (auth, genre_domain, track, drizzle migrations unchanged)",
 			);
 		} catch (err) {
 			await client.query("ROLLBACK");

--- a/packages/db/src/migrations/0010_giant_phalanx.sql
+++ b/packages/db/src/migrations/0010_giant_phalanx.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "user_tracks" (
+	"user_id" text NOT NULL,
+	"track_id" text NOT NULL,
+	"added_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_tracks_user_id_track_id_pk" PRIMARY KEY("user_id","track_id")
+);
+--> statement-breakpoint
+ALTER TABLE "track" DROP CONSTRAINT "track_user_id_user_id_fk";
+--> statement-breakpoint
+DROP INDEX "track_user_id_idx";--> statement-breakpoint
+ALTER TABLE "user_tracks" ADD CONSTRAINT "user_tracks_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_tracks" ADD CONSTRAINT "user_tracks_track_id_track_id_fk" FOREIGN KEY ("track_id") REFERENCES "public"."track"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_tracks_user_id_idx" ON "user_tracks" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "user_tracks_track_id_idx" ON "user_tracks" USING btree ("track_id");--> statement-breakpoint
+ALTER TABLE "track" DROP COLUMN "user_id";

--- a/packages/db/src/migrations/0010_small_network.sql
+++ b/packages/db/src/migrations/0010_small_network.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "user_tracks" (
+	"user_id" text NOT NULL,
+	"track_id" text NOT NULL,
+	"added_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_tracks_user_id_track_id_pk" PRIMARY KEY("user_id","track_id")
+);
+--> statement-breakpoint
+ALTER TABLE "track" DROP CONSTRAINT "track_user_id_user_id_fk";
+--> statement-breakpoint
+DROP INDEX "track_user_id_idx";--> statement-breakpoint
+ALTER TABLE "user_tracks" ADD CONSTRAINT "user_tracks_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_tracks" ADD CONSTRAINT "user_tracks_track_id_track_id_fk" FOREIGN KEY ("track_id") REFERENCES "public"."track"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "user_tracks_user_id_idx" ON "user_tracks" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "track" DROP COLUMN "user_id";

--- a/packages/db/src/migrations/meta/0010_snapshot.json
+++ b/packages/db/src/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1845 @@
+{
+	"id": "2d08eff6-cc1e-4db2-a51f-8af3346cdc0f",
+	"prevId": "8037dfe8-24a5-4425-b50e-42f370e04f59",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_completed_onboarding": {
+					"name": "has_completed_onboarding",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character": {
+			"name": "character",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_user_id_user_id_fk": {
+					"name": "character_user_id_user_id_fk",
+					"tableFrom": "character",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_genre_domain_id_genre_domain_id_fk": {
+					"name": "character_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "character",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_clusters": {
+			"name": "character_clusters",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_clusters_character_id_character_id_fk": {
+					"name": "character_clusters_character_id_character_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_clusters_cluster_id_cluster_id_fk": {
+					"name": "character_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_clusters_character_id_cluster_id_pk": {
+					"name": "character_clusters_character_id_cluster_id_pk",
+					"columns": ["character_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_tracks": {
+			"name": "character_tracks",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_tracks_character_id_character_id_fk": {
+					"name": "character_tracks_character_id_character_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_tracks_track_id_track_id_fk": {
+					"name": "character_tracks_track_id_track_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_tracks_character_id_track_id_pk": {
+					"name": "character_tracks_character_id_track_id_pk",
+					"columns": ["character_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster": {
+			"name": "cluster",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"centroid": {
+					"name": "centroid",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_valence": {
+					"name": "avg_valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_energy": {
+					"name": "avg_energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_tempo": {
+					"name": "avg_tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"cluster_user_id_idx": {
+					"name": "cluster_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"cluster_user_id_user_id_fk": {
+					"name": "cluster_user_id_user_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_genre_domain_id_genre_domain_id_fk": {
+					"name": "cluster_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster_tracks": {
+			"name": "cluster_tracks",
+			"schema": "",
+			"columns": {
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cluster_tracks_cluster_id_cluster_id_fk": {
+					"name": "cluster_tracks_cluster_id_cluster_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_tracks_track_id_track_id_fk": {
+					"name": "cluster_tracks_track_id_track_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"cluster_tracks_cluster_id_track_id_pk": {
+					"name": "cluster_tracks_cluster_id_track_id_pk",
+					"columns": ["cluster_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genre_domain": {
+			"name": "genre_domain",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"genre_domain_name_unique": {
+					"name": "genre_domain_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.todo": {
+			"name": "todo",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed": {
+					"name": "completed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"todo_user_id_user_id_fk": {
+					"name": "todo_user_id_user_id_fk",
+					"tableFrom": "todo",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track": {
+			"name": "track",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"spotify_uri": {
+					"name": "spotify_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_names": {
+					"name": "artist_names",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_image_url": {
+					"name": "album_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spotify_genres": {
+					"name": "spotify_genres",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"valence": {
+					"name": "valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy": {
+					"name": "energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"danceability": {
+					"name": "danceability",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tempo": {
+					"name": "tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acousticness": {
+					"name": "acousticness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instrumentalness": {
+					"name": "instrumentalness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"speechiness": {
+					"name": "speechiness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"liveness": {
+					"name": "liveness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics": {
+					"name": "lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_lyrics": {
+					"name": "synced_lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_instrumental": {
+					"name": "lyrics_instrumental",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lrclib_id": {
+					"name": "lrclib_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_fetched_at": {
+					"name": "lyrics_fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_status": {
+					"name": "lyrics_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_mood": {
+					"name": "llm_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_tags": {
+					"name": "llm_tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_classified_at": {
+					"name": "llm_classified_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_generated_at": {
+					"name": "embedding_generated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_input": {
+					"name": "embedding_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_assigned_at": {
+					"name": "domain_assigned_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"analysis_snapshot": {
+					"name": "analysis_snapshot",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"track_genre_domain_id_idx": {
+					"name": "track_genre_domain_id_idx",
+					"columns": [
+						{
+							"expression": "genre_domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_lyrics_status_idx": {
+					"name": "track_lyrics_status_idx",
+					"columns": [
+						{
+							"expression": "lyrics_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_embedding_idx": {
+					"name": "track_embedding_idx",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genre_domain_id_genre_domain_id_fk": {
+					"name": "track_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "track",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_tracks": {
+			"name": "user_tracks",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_tracks_user_id_idx": {
+					"name": "user_tracks_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_tracks_user_id_user_id_fk": {
+					"name": "user_tracks_user_id_user_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_tracks_track_id_track_id_fk": {
+					"name": "user_tracks_track_id_track_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_tracks_user_id_track_id_pk": {
+					"name": "user_tracks_user_id_track_id_pk",
+					"columns": ["user_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist": {
+			"name": "playlist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_generated_name": {
+					"name": "ai_generated_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"taxonomy": {
+					"name": "taxonomy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_color": {
+					"name": "cover_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_count": {
+					"name": "track_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"exported_at": {
+					"name": "exported_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"playlist_user_id_idx": {
+					"name": "playlist_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"playlist_taxonomy_idx": {
+					"name": "playlist_taxonomy_idx",
+					"columns": [
+						{
+							"expression": "taxonomy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"playlist_user_id_user_id_fk": {
+					"name": "playlist_user_id_user_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_genre_domain_id_genre_domain_id_fk": {
+					"name": "playlist_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_clusters": {
+			"name": "playlist_clusters",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_clusters_playlist_id_playlist_id_fk": {
+					"name": "playlist_clusters_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_clusters_cluster_id_cluster_id_fk": {
+					"name": "playlist_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_clusters_playlist_id_cluster_id_pk": {
+					"name": "playlist_clusters_playlist_id_cluster_id_pk",
+					"columns": ["playlist_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_tracks": {
+			"name": "playlist_tracks",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_tracks_playlist_id_playlist_id_fk": {
+					"name": "playlist_tracks_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_tracks_track_id_track_id_fk": {
+					"name": "playlist_tracks_track_id_track_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_tracks_playlist_id_track_id_pk": {
+					"name": "playlist_tracks_playlist_id_track_id_pk",
+					"columns": ["playlist_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pipeline_run": {
+			"name": "pipeline_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"current_stage": {
+					"name": "current_stage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"progress": {
+					"name": "progress",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"pipeline_run_user_id_idx": {
+					"name": "pipeline_run_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_status_idx": {
+					"name": "pipeline_run_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pipeline_run_user_id_user_id_fk": {
+					"name": "pipeline_run_user_id_user_id_fk",
+					"tableFrom": "pipeline_run",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_item_artists": {
+			"name": "user_playlist_snapshot_item_artists",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_position": {
+					"name": "artist_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_name": {
+					"name": "artist_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_item_artists",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+					"columns": ["user_id", "playlist_id", "position", "artist_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_items": {
+			"name": "user_playlist_snapshot_items",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_name": {
+					"name": "track_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_uri": {
+					"name": "track_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_items_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_items",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+					"columns": ["user_id", "playlist_id", "position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshots": {
+			"name": "user_playlist_snapshots",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshots_user_id_user_id_fk": {
+					"name": "user_playlist_snapshots_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshots",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshots_user_id_playlist_id_pk": {
+					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
+					"columns": ["user_id", "playlist_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_spotify_library_stats": {
+			"name": "user_spotify_library_stats",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"total_tracks": {
+					"name": "total_tracks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_playlists": {
+					"name": "total_playlists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_albums": {
+					"name": "unique_albums",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_artists": {
+					"name": "unique_artists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_spotify_library_stats_user_id_user_id_fk": {
+					"name": "user_spotify_library_stats_user_id_user_id_fk",
+					"tableFrom": "user_spotify_library_stats",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/0010_snapshot.json
+++ b/packages/db/src/migrations/meta/0010_snapshot.json
@@ -1,1845 +1,2004 @@
 {
-	"id": "2d08eff6-cc1e-4db2-a51f-8af3346cdc0f",
-	"prevId": "8037dfe8-24a5-4425-b50e-42f370e04f59",
-	"version": "7",
-	"dialect": "postgresql",
-	"tables": {
-		"public.account": {
-			"name": "account",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"account_id": {
-					"name": "account_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"provider_id": {
-					"name": "provider_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"access_token": {
-					"name": "access_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"refresh_token": {
-					"name": "refresh_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"id_token": {
-					"name": "id_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"access_token_expires_at": {
-					"name": "access_token_expires_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"refresh_token_expires_at": {
-					"name": "refresh_token_expires_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scope": {
-					"name": "scope",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"password": {
-					"name": "password",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"account_userId_idx": {
-					"name": "account_userId_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"account_user_id_user_id_fk": {
-					"name": "account_user_id_user_id_fk",
-					"tableFrom": "account",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.session": {
-			"name": "session",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"token": {
-					"name": "token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"ip_address": {
-					"name": "ip_address",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_agent": {
-					"name": "user_agent",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"session_userId_idx": {
-					"name": "session_userId_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"session_user_id_user_id_fk": {
-					"name": "session_user_id_user_id_fk",
-					"tableFrom": "session",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"session_token_unique": {
-					"name": "session_token_unique",
-					"nullsNotDistinct": false,
-					"columns": ["token"]
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.user": {
-			"name": "user",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"email": {
-					"name": "email",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"email_verified": {
-					"name": "email_verified",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"has_completed_onboarding": {
-					"name": "has_completed_onboarding",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"image": {
-					"name": "image",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"user_email_unique": {
-					"name": "user_email_unique",
-					"nullsNotDistinct": false,
-					"columns": ["email"]
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.verification": {
-			"name": "verification",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"identifier": {
-					"name": "identifier",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"value": {
-					"name": "value",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {
-				"verification_identifier_idx": {
-					"name": "verification_identifier_idx",
-					"columns": [
-						{
-							"expression": "identifier",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.character": {
-			"name": "character",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "serial",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"description": {
-					"name": "description",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"genre_domain_id": {
-					"name": "genre_domain_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"energy_curve": {
-					"name": "energy_curve",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"is_generated": {
-					"name": "is_generated",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"spotify_playlist_id": {
-					"name": "spotify_playlist_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"character_user_id_user_id_fk": {
-					"name": "character_user_id_user_id_fk",
-					"tableFrom": "character",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"character_genre_domain_id_genre_domain_id_fk": {
-					"name": "character_genre_domain_id_genre_domain_id_fk",
-					"tableFrom": "character",
-					"tableTo": "genre_domain",
-					"columnsFrom": ["genre_domain_id"],
-					"columnsTo": ["id"],
-					"onDelete": "no action",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.character_clusters": {
-			"name": "character_clusters",
-			"schema": "",
-			"columns": {
-				"character_id": {
-					"name": "character_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"cluster_id": {
-					"name": "cluster_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"weight": {
-					"name": "weight",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"character_clusters_character_id_character_id_fk": {
-					"name": "character_clusters_character_id_character_id_fk",
-					"tableFrom": "character_clusters",
-					"tableTo": "character",
-					"columnsFrom": ["character_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"character_clusters_cluster_id_cluster_id_fk": {
-					"name": "character_clusters_cluster_id_cluster_id_fk",
-					"tableFrom": "character_clusters",
-					"tableTo": "cluster",
-					"columnsFrom": ["cluster_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"character_clusters_character_id_cluster_id_pk": {
-					"name": "character_clusters_character_id_cluster_id_pk",
-					"columns": ["character_id", "cluster_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.character_tracks": {
-			"name": "character_tracks",
-			"schema": "",
-			"columns": {
-				"character_id": {
-					"name": "character_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_id": {
-					"name": "track_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"character_tracks_character_id_character_id_fk": {
-					"name": "character_tracks_character_id_character_id_fk",
-					"tableFrom": "character_tracks",
-					"tableTo": "character",
-					"columnsFrom": ["character_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"character_tracks_track_id_track_id_fk": {
-					"name": "character_tracks_track_id_track_id_fk",
-					"tableFrom": "character_tracks",
-					"tableTo": "track",
-					"columnsFrom": ["track_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"character_tracks_character_id_track_id_pk": {
-					"name": "character_tracks_character_id_track_id_pk",
-					"columns": ["character_id", "track_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.cluster": {
-			"name": "cluster",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "serial",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"genre_domain_id": {
-					"name": "genre_domain_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"centroid": {
-					"name": "centroid",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"size": {
-					"name": "size",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"avg_valence": {
-					"name": "avg_valence",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"avg_energy": {
-					"name": "avg_energy",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"avg_tempo": {
-					"name": "avg_tempo",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {
-				"cluster_user_id_idx": {
-					"name": "cluster_user_id_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"cluster_user_id_user_id_fk": {
-					"name": "cluster_user_id_user_id_fk",
-					"tableFrom": "cluster",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"cluster_genre_domain_id_genre_domain_id_fk": {
-					"name": "cluster_genre_domain_id_genre_domain_id_fk",
-					"tableFrom": "cluster",
-					"tableTo": "genre_domain",
-					"columnsFrom": ["genre_domain_id"],
-					"columnsTo": ["id"],
-					"onDelete": "no action",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.cluster_tracks": {
-			"name": "cluster_tracks",
-			"schema": "",
-			"columns": {
-				"cluster_id": {
-					"name": "cluster_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_id": {
-					"name": "track_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"cluster_tracks_cluster_id_cluster_id_fk": {
-					"name": "cluster_tracks_cluster_id_cluster_id_fk",
-					"tableFrom": "cluster_tracks",
-					"tableTo": "cluster",
-					"columnsFrom": ["cluster_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"cluster_tracks_track_id_track_id_fk": {
-					"name": "cluster_tracks_track_id_track_id_fk",
-					"tableFrom": "cluster_tracks",
-					"tableTo": "track",
-					"columnsFrom": ["track_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"cluster_tracks_cluster_id_track_id_pk": {
-					"name": "cluster_tracks_cluster_id_track_id_pk",
-					"columns": ["cluster_id", "track_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.genre_domain": {
-			"name": "genre_domain",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "serial",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"description": {
-					"name": "description",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"genre_domain_name_unique": {
-					"name": "genre_domain_name_unique",
-					"nullsNotDistinct": false,
-					"columns": ["name"]
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.todo": {
-			"name": "todo",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "serial",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"text": {
-					"name": "text",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"completed": {
-					"name": "completed",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"todo_user_id_user_id_fk": {
-					"name": "todo_user_id_user_id_fk",
-					"tableFrom": "todo",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.track": {
-			"name": "track",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"spotify_uri": {
-					"name": "spotify_uri",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"artist_names": {
-					"name": "artist_names",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"album_name": {
-					"name": "album_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"album_image_url": {
-					"name": "album_image_url",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"duration_ms": {
-					"name": "duration_ms",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"spotify_genres": {
-					"name": "spotify_genres",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"genre_domain_id": {
-					"name": "genre_domain_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"valence": {
-					"name": "valence",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"energy": {
-					"name": "energy",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"danceability": {
-					"name": "danceability",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"tempo": {
-					"name": "tempo",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"acousticness": {
-					"name": "acousticness",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"instrumentalness": {
-					"name": "instrumentalness",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"speechiness": {
-					"name": "speechiness",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"liveness": {
-					"name": "liveness",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"key": {
-					"name": "key",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"mode": {
-					"name": "mode",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"lyrics": {
-					"name": "lyrics",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"synced_lyrics": {
-					"name": "synced_lyrics",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"lyrics_instrumental": {
-					"name": "lyrics_instrumental",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"lrclib_id": {
-					"name": "lrclib_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"lyrics_fetched_at": {
-					"name": "lyrics_fetched_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"lyrics_status": {
-					"name": "lyrics_status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"llm_mood": {
-					"name": "llm_mood",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"llm_tags": {
-					"name": "llm_tags",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"llm_classified_at": {
-					"name": "llm_classified_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"embedding": {
-					"name": "embedding",
-					"type": "vector(1536)",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"embedding_generated_at": {
-					"name": "embedding_generated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"embedding_input": {
-					"name": "embedding_input",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"domain_assigned_at": {
-					"name": "domain_assigned_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"analysis_snapshot": {
-					"name": "analysis_snapshot",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"track_genre_domain_id_idx": {
-					"name": "track_genre_domain_id_idx",
-					"columns": [
-						{
-							"expression": "genre_domain_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				},
-				"track_lyrics_status_idx": {
-					"name": "track_lyrics_status_idx",
-					"columns": [
-						{
-							"expression": "lyrics_status",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				},
-				"track_embedding_idx": {
-					"name": "track_embedding_idx",
-					"columns": [
-						{
-							"expression": "embedding",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last",
-							"opclass": "vector_cosine_ops"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "hnsw",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"track_genre_domain_id_genre_domain_id_fk": {
-					"name": "track_genre_domain_id_genre_domain_id_fk",
-					"tableFrom": "track",
-					"tableTo": "genre_domain",
-					"columnsFrom": ["genre_domain_id"],
-					"columnsTo": ["id"],
-					"onDelete": "no action",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.user_tracks": {
-			"name": "user_tracks",
-			"schema": "",
-			"columns": {
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_id": {
-					"name": "track_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"added_at": {
-					"name": "added_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {
-				"user_tracks_user_id_idx": {
-					"name": "user_tracks_user_id_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"user_tracks_user_id_user_id_fk": {
-					"name": "user_tracks_user_id_user_id_fk",
-					"tableFrom": "user_tracks",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"user_tracks_track_id_track_id_fk": {
-					"name": "user_tracks_track_id_track_id_fk",
-					"tableFrom": "user_tracks",
-					"tableTo": "track",
-					"columnsFrom": ["track_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"user_tracks_user_id_track_id_pk": {
-					"name": "user_tracks_user_id_track_id_pk",
-					"columns": ["user_id", "track_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.playlist": {
-			"name": "playlist",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "serial",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"ai_generated_name": {
-					"name": "ai_generated_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"description": {
-					"name": "description",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"theme": {
-					"name": "theme",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"taxonomy": {
-					"name": "taxonomy",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"genre_domain_id": {
-					"name": "genre_domain_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"energy_curve": {
-					"name": "energy_curve",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"cover_color": {
-					"name": "cover_color",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"tags": {
-					"name": "tags",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"track_count": {
-					"name": "track_count",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"is_generated": {
-					"name": "is_generated",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"spotify_playlist_id": {
-					"name": "spotify_playlist_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"exported_at": {
-					"name": "exported_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"playlist_user_id_idx": {
-					"name": "playlist_user_id_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				},
-				"playlist_taxonomy_idx": {
-					"name": "playlist_taxonomy_idx",
-					"columns": [
-						{
-							"expression": "taxonomy",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"playlist_user_id_user_id_fk": {
-					"name": "playlist_user_id_user_id_fk",
-					"tableFrom": "playlist",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"playlist_genre_domain_id_genre_domain_id_fk": {
-					"name": "playlist_genre_domain_id_genre_domain_id_fk",
-					"tableFrom": "playlist",
-					"tableTo": "genre_domain",
-					"columnsFrom": ["genre_domain_id"],
-					"columnsTo": ["id"],
-					"onDelete": "no action",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.playlist_clusters": {
-			"name": "playlist_clusters",
-			"schema": "",
-			"columns": {
-				"playlist_id": {
-					"name": "playlist_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"cluster_id": {
-					"name": "cluster_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"weight": {
-					"name": "weight",
-					"type": "real",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"playlist_clusters_playlist_id_playlist_id_fk": {
-					"name": "playlist_clusters_playlist_id_playlist_id_fk",
-					"tableFrom": "playlist_clusters",
-					"tableTo": "playlist",
-					"columnsFrom": ["playlist_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"playlist_clusters_cluster_id_cluster_id_fk": {
-					"name": "playlist_clusters_cluster_id_cluster_id_fk",
-					"tableFrom": "playlist_clusters",
-					"tableTo": "cluster",
-					"columnsFrom": ["cluster_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"playlist_clusters_playlist_id_cluster_id_pk": {
-					"name": "playlist_clusters_playlist_id_cluster_id_pk",
-					"columns": ["playlist_id", "cluster_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.playlist_tracks": {
-			"name": "playlist_tracks",
-			"schema": "",
-			"columns": {
-				"playlist_id": {
-					"name": "playlist_id",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_id": {
-					"name": "track_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"playlist_tracks_playlist_id_playlist_id_fk": {
-					"name": "playlist_tracks_playlist_id_playlist_id_fk",
-					"tableFrom": "playlist_tracks",
-					"tableTo": "playlist",
-					"columnsFrom": ["playlist_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				},
-				"playlist_tracks_track_id_track_id_fk": {
-					"name": "playlist_tracks_track_id_track_id_fk",
-					"tableFrom": "playlist_tracks",
-					"tableTo": "track",
-					"columnsFrom": ["track_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"playlist_tracks_playlist_id_track_id_pk": {
-					"name": "playlist_tracks_playlist_id_track_id_pk",
-					"columns": ["playlist_id", "track_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.pipeline_run": {
-			"name": "pipeline_run",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "serial",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'pending'"
-				},
-				"current_stage": {
-					"name": "current_stage",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"progress": {
-					"name": "progress",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"error": {
-					"name": "error",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"started_at": {
-					"name": "started_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"completed_at": {
-					"name": "completed_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {
-				"pipeline_run_user_id_idx": {
-					"name": "pipeline_run_user_id_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				},
-				"pipeline_run_status_idx": {
-					"name": "pipeline_run_status_idx",
-					"columns": [
-						{
-							"expression": "status",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"concurrently": false,
-					"method": "btree",
-					"with": {}
-				}
-			},
-			"foreignKeys": {
-				"pipeline_run_user_id_user_id_fk": {
-					"name": "pipeline_run_user_id_user_id_fk",
-					"tableFrom": "pipeline_run",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.user_playlist_snapshot_item_artists": {
-			"name": "user_playlist_snapshot_item_artists",
-			"schema": "",
-			"columns": {
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"playlist_id": {
-					"name": "playlist_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"artist_position": {
-					"name": "artist_position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"artist_id": {
-					"name": "artist_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"artist_name": {
-					"name": "artist_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
-					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
-					"tableFrom": "user_playlist_snapshot_item_artists",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
-					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
-					"columns": ["user_id", "playlist_id", "position", "artist_position"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.user_playlist_snapshot_items": {
-			"name": "user_playlist_snapshot_items",
-			"schema": "",
-			"columns": {
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"playlist_id": {
-					"name": "playlist_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"snapshot_id": {
-					"name": "snapshot_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"position": {
-					"name": "position",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_id": {
-					"name": "track_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_name": {
-					"name": "track_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"track_uri": {
-					"name": "track_uri",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"album_id": {
-					"name": "album_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"album_name": {
-					"name": "album_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"duration_ms": {
-					"name": "duration_ms",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"user_playlist_snapshot_items_user_id_user_id_fk": {
-					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
-					"tableFrom": "user_playlist_snapshot_items",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
-					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
-					"columns": ["user_id", "playlist_id", "position"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.user_playlist_snapshots": {
-			"name": "user_playlist_snapshots",
-			"schema": "",
-			"columns": {
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"playlist_id": {
-					"name": "playlist_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"snapshot_id": {
-					"name": "snapshot_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"user_playlist_snapshots_user_id_user_id_fk": {
-					"name": "user_playlist_snapshots_user_id_user_id_fk",
-					"tableFrom": "user_playlist_snapshots",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {
-				"user_playlist_snapshots_user_id_playlist_id_pk": {
-					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
-					"columns": ["user_id", "playlist_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.user_spotify_library_stats": {
-			"name": "user_spotify_library_stats",
-			"schema": "",
-			"columns": {
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"total_tracks": {
-					"name": "total_tracks",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"total_playlists": {
-					"name": "total_playlists",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"unique_albums": {
-					"name": "unique_albums",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"unique_artists": {
-					"name": "unique_artists",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"user_spotify_library_stats_user_id_user_id_fk": {
-					"name": "user_spotify_library_stats_user_id_user_id_fk",
-					"tableFrom": "user_spotify_library_stats",
-					"tableTo": "user",
-					"columnsFrom": ["user_id"],
-					"columnsTo": ["id"],
-					"onDelete": "cascade",
-					"onUpdate": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		}
-	},
-	"enums": {},
-	"schemas": {},
-	"sequences": {},
-	"roles": {},
-	"policies": {},
-	"views": {},
-	"_meta": {
-		"columns": {},
-		"schemas": {},
-		"tables": {}
-	}
+  "id": "abe63d35-b61f-4246-a504-94b717f4e5f9",
+  "prevId": "8037dfe8-24a5-4425-b50e-42f370e04f59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_completed_onboarding": {
+          "name": "has_completed_onboarding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character": {
+      "name": "character",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre_domain_id": {
+          "name": "genre_domain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_curve": {
+          "name": "energy_curve",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_generated": {
+          "name": "is_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spotify_playlist_id": {
+          "name": "spotify_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_user_id_user_id_fk": {
+          "name": "character_user_id_user_id_fk",
+          "tableFrom": "character",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_genre_domain_id_genre_domain_id_fk": {
+          "name": "character_genre_domain_id_genre_domain_id_fk",
+          "tableFrom": "character",
+          "tableTo": "genre_domain",
+          "columnsFrom": [
+            "genre_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_clusters": {
+      "name": "character_clusters",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_clusters_character_id_character_id_fk": {
+          "name": "character_clusters_character_id_character_id_fk",
+          "tableFrom": "character_clusters",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_clusters_cluster_id_cluster_id_fk": {
+          "name": "character_clusters_cluster_id_cluster_id_fk",
+          "tableFrom": "character_clusters",
+          "tableTo": "cluster",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_clusters_character_id_cluster_id_pk": {
+          "name": "character_clusters_character_id_cluster_id_pk",
+          "columns": [
+            "character_id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_tracks": {
+      "name": "character_tracks",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_tracks_character_id_character_id_fk": {
+          "name": "character_tracks_character_id_character_id_fk",
+          "tableFrom": "character_tracks",
+          "tableTo": "character",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_tracks_track_id_track_id_fk": {
+          "name": "character_tracks_track_id_track_id_fk",
+          "tableFrom": "character_tracks",
+          "tableTo": "track",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_tracks_character_id_track_id_pk": {
+          "name": "character_tracks_character_id_track_id_pk",
+          "columns": [
+            "character_id",
+            "track_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster": {
+      "name": "cluster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_domain_id": {
+          "name": "genre_domain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_valence": {
+          "name": "avg_valence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_energy": {
+          "name": "avg_energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_tempo": {
+          "name": "avg_tempo",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cluster_user_id_idx": {
+          "name": "cluster_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cluster_user_id_user_id_fk": {
+          "name": "cluster_user_id_user_id_fk",
+          "tableFrom": "cluster",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_genre_domain_id_genre_domain_id_fk": {
+          "name": "cluster_genre_domain_id_genre_domain_id_fk",
+          "tableFrom": "cluster",
+          "tableTo": "genre_domain",
+          "columnsFrom": [
+            "genre_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cluster_tracks": {
+      "name": "cluster_tracks",
+      "schema": "",
+      "columns": {
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cluster_tracks_cluster_id_cluster_id_fk": {
+          "name": "cluster_tracks_cluster_id_cluster_id_fk",
+          "tableFrom": "cluster_tracks",
+          "tableTo": "cluster",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cluster_tracks_track_id_track_id_fk": {
+          "name": "cluster_tracks_track_id_track_id_fk",
+          "tableFrom": "cluster_tracks",
+          "tableTo": "track",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cluster_tracks_cluster_id_track_id_pk": {
+          "name": "cluster_tracks_cluster_id_track_id_pk",
+          "columns": [
+            "cluster_id",
+            "track_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genre_domain": {
+      "name": "genre_domain",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genre_domain_name_unique": {
+          "name": "genre_domain_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.todo": {
+      "name": "todo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "todo_user_id_user_id_fk": {
+          "name": "todo_user_id_user_id_fk",
+          "tableFrom": "todo",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.track": {
+      "name": "track",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spotify_uri": {
+          "name": "spotify_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_names": {
+          "name": "artist_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_image_url": {
+          "name": "album_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_genres": {
+          "name": "spotify_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre_domain_id": {
+          "name": "genre_domain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valence": {
+          "name": "valence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy": {
+          "name": "energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "danceability": {
+          "name": "danceability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tempo": {
+          "name": "tempo",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acousticness": {
+          "name": "acousticness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instrumentalness": {
+          "name": "instrumentalness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speechiness": {
+          "name": "speechiness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "liveness": {
+          "name": "liveness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics": {
+          "name": "lyrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_lyrics": {
+          "name": "synced_lyrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics_instrumental": {
+          "name": "lyrics_instrumental",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lrclib_id": {
+          "name": "lrclib_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics_fetched_at": {
+          "name": "lyrics_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics_status": {
+          "name": "lyrics_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_mood": {
+          "name": "llm_mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_tags": {
+          "name": "llm_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_classified_at": {
+          "name": "llm_classified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_generated_at": {
+          "name": "embedding_generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_input": {
+          "name": "embedding_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_assigned_at": {
+          "name": "domain_assigned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_snapshot": {
+          "name": "analysis_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "track_genre_domain_id_idx": {
+          "name": "track_genre_domain_id_idx",
+          "columns": [
+            {
+              "expression": "genre_domain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_lyrics_status_idx": {
+          "name": "track_lyrics_status_idx",
+          "columns": [
+            {
+              "expression": "lyrics_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_embedding_idx": {
+          "name": "track_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "track_genre_domain_id_genre_domain_id_fk": {
+          "name": "track_genre_domain_id_genre_domain_id_fk",
+          "tableFrom": "track",
+          "tableTo": "genre_domain",
+          "columnsFrom": [
+            "genre_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tracks": {
+      "name": "user_tracks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_tracks_user_id_idx": {
+          "name": "user_tracks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_tracks_track_id_idx": {
+          "name": "user_tracks_track_id_idx",
+          "columns": [
+            {
+              "expression": "track_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_tracks_user_id_user_id_fk": {
+          "name": "user_tracks_user_id_user_id_fk",
+          "tableFrom": "user_tracks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tracks_track_id_track_id_fk": {
+          "name": "user_tracks_track_id_track_id_fk",
+          "tableFrom": "user_tracks",
+          "tableTo": "track",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tracks_user_id_track_id_pk": {
+          "name": "user_tracks_user_id_track_id_pk",
+          "columns": [
+            "user_id",
+            "track_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist": {
+      "name": "playlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_generated_name": {
+          "name": "ai_generated_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taxonomy": {
+          "name": "taxonomy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre_domain_id": {
+          "name": "genre_domain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy_curve": {
+          "name": "energy_curve",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_color": {
+          "name": "cover_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_count": {
+          "name": "track_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_generated": {
+          "name": "is_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spotify_playlist_id": {
+          "name": "spotify_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exported_at": {
+          "name": "exported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_user_id_idx": {
+          "name": "playlist_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_taxonomy_idx": {
+          "name": "playlist_taxonomy_idx",
+          "columns": [
+            {
+              "expression": "taxonomy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_user_id_user_id_fk": {
+          "name": "playlist_user_id_user_id_fk",
+          "tableFrom": "playlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_genre_domain_id_genre_domain_id_fk": {
+          "name": "playlist_genre_domain_id_genre_domain_id_fk",
+          "tableFrom": "playlist",
+          "tableTo": "genre_domain",
+          "columnsFrom": [
+            "genre_domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_clusters": {
+      "name": "playlist_clusters",
+      "schema": "",
+      "columns": {
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cluster_id": {
+          "name": "cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playlist_clusters_playlist_id_playlist_id_fk": {
+          "name": "playlist_clusters_playlist_id_playlist_id_fk",
+          "tableFrom": "playlist_clusters",
+          "tableTo": "playlist",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_clusters_cluster_id_cluster_id_fk": {
+          "name": "playlist_clusters_cluster_id_cluster_id_fk",
+          "tableFrom": "playlist_clusters",
+          "tableTo": "cluster",
+          "columnsFrom": [
+            "cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "playlist_clusters_playlist_id_cluster_id_pk": {
+          "name": "playlist_clusters_playlist_id_cluster_id_pk",
+          "columns": [
+            "playlist_id",
+            "cluster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_tracks": {
+      "name": "playlist_tracks",
+      "schema": "",
+      "columns": {
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playlist_tracks_playlist_id_playlist_id_fk": {
+          "name": "playlist_tracks_playlist_id_playlist_id_fk",
+          "tableFrom": "playlist_tracks",
+          "tableTo": "playlist",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_tracks_track_id_track_id_fk": {
+          "name": "playlist_tracks_track_id_track_id_fk",
+          "tableFrom": "playlist_tracks",
+          "tableTo": "track",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "playlist_tracks_playlist_id_track_id_pk": {
+          "name": "playlist_tracks_playlist_id_track_id_pk",
+          "columns": [
+            "playlist_id",
+            "track_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_run": {
+      "name": "pipeline_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pipeline_run_user_id_idx": {
+          "name": "pipeline_run_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pipeline_run_status_idx": {
+          "name": "pipeline_run_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pipeline_run_user_id_user_id_fk": {
+          "name": "pipeline_run_user_id_user_id_fk",
+          "tableFrom": "pipeline_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_snapshot_item_artists": {
+      "name": "user_playlist_snapshot_item_artists",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_position": {
+          "name": "artist_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+          "name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+          "tableFrom": "user_playlist_snapshot_item_artists",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+          "name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+          "columns": [
+            "user_id",
+            "playlist_id",
+            "position",
+            "artist_position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_snapshot_items": {
+      "name": "user_playlist_snapshot_items",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_uri": {
+          "name": "track_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_playlist_snapshot_items_user_id_user_id_fk": {
+          "name": "user_playlist_snapshot_items_user_id_user_id_fk",
+          "tableFrom": "user_playlist_snapshot_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+          "name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+          "columns": [
+            "user_id",
+            "playlist_id",
+            "position"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlist_snapshots": {
+      "name": "user_playlist_snapshots",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_playlist_snapshots_user_id_user_id_fk": {
+          "name": "user_playlist_snapshots_user_id_user_id_fk",
+          "tableFrom": "user_playlist_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_playlist_snapshots_user_id_playlist_id_pk": {
+          "name": "user_playlist_snapshots_user_id_playlist_id_pk",
+          "columns": [
+            "user_id",
+            "playlist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_spotify_library_stats": {
+      "name": "user_spotify_library_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "total_tracks": {
+          "name": "total_tracks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_playlists": {
+          "name": "total_playlists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_albums": {
+          "name": "unique_albums",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_artists": {
+          "name": "unique_artists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_spotify_library_stats_user_id_user_id_fk": {
+          "name": "user_spotify_library_stats_user_id_user_id_fk",
+          "tableFrom": "user_spotify_library_stats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
 			"when": 1777718468788,
 			"tag": "0009_track_album_image_url",
 			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1779293721862,
+			"tag": "0010_small_network",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1,83 +1,83 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1772728003984,
-			"tag": "0000_cheerful_ironclad",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1741190400000,
-			"tag": "0001_add_todo_user_id",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1772744814165,
-			"tag": "0002_cloudy_medusa",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1772846331118,
-			"tag": "0003_colossal_piledriver",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1773002922495,
-			"tag": "0004_quiet_ezekiel",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1773003684593,
-			"tag": "0005_narrow_tarot",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1773347993927,
-			"tag": "0006_light_aaron_stack",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1773351837088,
-			"tag": "0007_funny_morbius",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1777714010150,
-			"tag": "0008_playlist_tags",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1777718468788,
-			"tag": "0009_track_album_image_url",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1779293721862,
-			"tag": "0010_small_network",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1772728003984,
+      "tag": "0000_cheerful_ironclad",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1741190400000,
+      "tag": "0001_add_todo_user_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772744814165,
+      "tag": "0002_cloudy_medusa",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772846331118,
+      "tag": "0003_colossal_piledriver",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1773002922495,
+      "tag": "0004_quiet_ezekiel",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1773003684593,
+      "tag": "0005_narrow_tarot",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1773347993927,
+      "tag": "0006_light_aaron_stack",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773351837088,
+      "tag": "0007_funny_morbius",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777714010150,
+      "tag": "0008_playlist_tags",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777718468788,
+      "tag": "0009_track_album_image_url",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1779296510248,
+      "tag": "0010_giant_phalanx",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/db/src/schema/track.ts
+++ b/packages/db/src/schema/track.ts
@@ -111,5 +111,6 @@ export const userTracks = pgTable(
 	(table) => [
 		primaryKey({ columns: [table.userId, table.trackId] }),
 		index("user_tracks_user_id_idx").on(table.userId),
+		index("user_tracks_track_id_idx").on(table.trackId),
 	],
 );

--- a/packages/db/src/schema/track.ts
+++ b/packages/db/src/schema/track.ts
@@ -4,6 +4,7 @@ import {
 	integer,
 	jsonb,
 	pgTable,
+	primaryKey,
 	real,
 	text,
 	timestamp,
@@ -18,9 +19,6 @@ export const track = pgTable(
 	{
 		// Identity
 		id: text("id").primaryKey(), // Spotify track ID
-		userId: text("user_id")
-			.notNull()
-			.references(() => user.id, { onDelete: "cascade" }),
 		spotifyUri: text("spotify_uri").notNull(),
 
 		// Core metadata (Spotify)
@@ -90,12 +88,28 @@ export const track = pgTable(
 			.notNull(),
 	},
 	(table) => [
-		index("track_user_id_idx").on(table.userId),
 		index("track_genre_domain_id_idx").on(table.genreDomainId),
 		index("track_lyrics_status_idx").on(table.lyricsStatus),
 		index("track_embedding_idx").using(
 			"hnsw",
 			table.embedding.op("vector_cosine_ops"),
 		),
+	],
+);
+
+export const userTracks = pgTable(
+	"user_tracks",
+	{
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		trackId: text("track_id")
+			.notNull()
+			.references(() => track.id, { onDelete: "cascade" }),
+		addedAt: timestamp("added_at").defaultNow().notNull(),
+	},
+	(table) => [
+		primaryKey({ columns: [table.userId, table.trackId] }),
+		index("user_tracks_user_id_idx").on(table.userId),
 	],
 );

--- a/packages/orpc/src/routers/protected/pipeline.ts
+++ b/packages/orpc/src/routers/protected/pipeline.ts
@@ -16,9 +16,9 @@ import { db } from "@harmonia/db";
 import { cluster } from "@harmonia/db/schema/cluster";
 import { pipelineRun } from "@harmonia/db/schema/pipeline-run";
 import { playlist } from "@harmonia/db/schema/playlist";
-import { track } from "@harmonia/db/schema/track";
+import { track, userTracks } from "@harmonia/db/schema/track";
 import { eventIterator } from "@orpc/server";
-import { and, count, desc, eq, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../procedures";
 
@@ -160,6 +160,11 @@ export const pipelineRouter = {
 		.handler(async ({ context }) => {
 			const userId = context.session.user.id;
 
+			const userTrackIds = db
+				.select({ trackId: userTracks.trackId })
+				.from(userTracks)
+				.where(eq(userTracks.userId, userId));
+
 			const [trackStats] = await db
 				.select({
 					total: count(),
@@ -168,7 +173,7 @@ export const pipelineRouter = {
 					embedded: count(track.embeddingGeneratedAt),
 				})
 				.from(track)
-				.where(eq(track.userId, userId));
+				.where(inArray(track.id, userTrackIds));
 
 			const [clusterStats] = await db
 				.select({ total: count() })
@@ -180,7 +185,7 @@ export const pipelineRouter = {
 				.from(track)
 				.where(
 					and(
-						eq(track.userId, userId),
+						inArray(track.id, userTrackIds),
 						sql`(${track.lyricsStatus} = 'pending' OR ${track.lyricsStatus} IS NULL)`,
 					),
 				);
@@ -211,6 +216,11 @@ export const pipelineRouter = {
 
 			await db.delete(cluster).where(eq(cluster.userId, userId));
 
+			const userTrackIds = db
+				.select({ trackId: userTracks.trackId })
+				.from(userTracks)
+				.where(eq(userTracks.userId, userId));
+
 			const result = await db
 				.update(track)
 				.set({
@@ -224,7 +234,7 @@ export const pipelineRouter = {
 					embeddingInput: null,
 					analysisSnapshot: null,
 				})
-				.where(eq(track.userId, userId));
+				.where(inArray(track.id, userTrackIds));
 
 			return {
 				cleared: true,

--- a/packages/orpc/src/routers/protected/tracks.ts
+++ b/packages/orpc/src/routers/protected/tracks.ts
@@ -6,8 +6,8 @@ import {
 } from "@harmonia/common/schemas";
 import { db } from "@harmonia/db";
 import { clusterTracks } from "@harmonia/db/schema/cluster";
-import { track } from "@harmonia/db/schema/track";
-import { and, count, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { track, userTracks } from "@harmonia/db/schema/track";
+import { and, count, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure } from "../../procedures";
 
@@ -19,7 +19,12 @@ export const tracksRouter = {
 			const userId = context.session.user.id;
 			const offset = (input.page - 1) * input.pageSize;
 
-			const conditions = [eq(track.userId, userId)];
+			const userTrackIds = db
+				.select({ trackId: userTracks.trackId })
+				.from(userTracks)
+				.where(eq(userTracks.userId, userId));
+
+			const conditions = [inArray(track.id, userTrackIds)];
 
 			if (input.search) {
 				const searchCondition = or(
@@ -86,10 +91,15 @@ export const tracksRouter = {
 		.handler(async ({ input, context }) => {
 			const userId = context.session.user.id;
 
+			const userTrackIds = db
+				.select({ trackId: userTracks.trackId })
+				.from(userTracks)
+				.where(eq(userTracks.userId, userId));
+
 			const [result] = await db
 				.select()
 				.from(track)
-				.where(and(eq(track.id, input.id), eq(track.userId, userId)));
+				.where(and(eq(track.id, input.id), inArray(track.id, userTrackIds)));
 
 			if (!result) return null;
 


### PR DESCRIPTION
## 🧠 Overview
<!-- Briefly describe what this PR does and why -->

Closes #

---

## ✅ Pre-merge Checklist

### Code Quality
- [ ] Self-reviewed the code thoroughly
- [ ] Follows project conventions (`.cursor/rules/`)
- [ ] Builds and runs locally without errors (`pnpm check-types`)
- [ ] Biome passes (`pnpm check`)

### Testing
- [ ] Tested the changed feature end-to-end locally
- [ ] Verified no regressions in adjacent features
- [ ] If pipeline-related: ran a full organize pipeline and confirmed results

---

## 🔍 Additional Notes
<!-- Anything reviewers should be aware of — breaking changes, migrations needed, follow-up issues -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Optimized internal track data organization and query performance through structural improvements.
  * Simplified track API responses by removing the `userId` field.

* **Chores**
  * Added new database reset utility with enhanced reset options for development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FindMalek/harmonia/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->