### PR TITLE
feat(billing): integrate Polar.sh Free/Pro subscription plans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,12 @@ HARMONIA_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=""
 HARMONIA_OTEL_EXPORTER_OTLP_HEADERS=""
 HARMONIA_OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 HARMONIA_OTEL_EXPORTER_OTLP_COMPRESSION="gzip"
+
+# -----------------------------------------------------------------------------
+# POLAR.SH BILLING
+# -----------------------------------------------------------------------------
+POLAR_ACCESS_TOKEN=""
+POLAR_ORGANIZATION_ID=""
+POLAR_WEBHOOK_SECRET=""
+NEXT_PUBLIC_POLAR_CHECKOUT_URL=""
+

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
 	"dependencies": {
 		"@harmonia/common": "workspace:*",
 		"@harmonia/core": "workspace:*",
+		"@harmonia/db": "workspace:*",
 		"@harmonia/env": "workspace:*",
 		"@harmonia/logger": "workspace:*",
 		"@harmonia/orpc": "workspace:*",

--- a/apps/api/src/app/api/webhooks/polar/route.ts
+++ b/apps/api/src/app/api/webhooks/polar/route.ts
@@ -6,6 +6,17 @@ import { logger } from "@harmonia/logger";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
+/**
+ * Handles incoming Polar.sh webhooks for subscription events.
+ *
+ * Verifies the webhook signature using the configured `POLAR_WEBHOOK_SECRET`
+ * to protect against tampering and replay attacks. Upon successful verification,
+ * updates the user's plan and subscription status in the database based on
+ * the received event type (created, updated, canceled, revoked).
+ *
+ * @param req - The NextRequest object containing the webhook payload and headers.
+ * @returns A Response indicating the outcome of the webhook processing.
+ */
 export async function POST(req: NextRequest) {
 	const webhookSecret = apiEnv.POLAR_WEBHOOK_SECRET;
 	if (!webhookSecret) {

--- a/apps/api/src/app/api/webhooks/polar/route.ts
+++ b/apps/api/src/app/api/webhooks/polar/route.ts
@@ -1,0 +1,199 @@
+import * as crypto from "node:crypto";
+import { db } from "@harmonia/db";
+import { user } from "@harmonia/db/schema/auth";
+import { apiEnv } from "@harmonia/env/presets/api";
+import { logger } from "@harmonia/logger";
+import { eq } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+	const webhookSecret = apiEnv.POLAR_WEBHOOK_SECRET;
+	if (!webhookSecret) {
+		logger.error("POLAR_WEBHOOK_SECRET is not configured", "PolarWebhook");
+		return new Response("Webhook secret not configured", { status: 500 });
+	}
+
+	const id = req.headers.get("webhook-id");
+	const timestamp = req.headers.get("webhook-timestamp");
+	const signature = req.headers.get("webhook-signature");
+
+	if (!id || !timestamp || !signature) {
+		logger.warn("Missing required webhook headers", "PolarWebhook");
+		return new Response("Missing headers", { status: 400 });
+	}
+
+	// Protect against replay attacks (5 minute window)
+	const parsedTimestamp = Number.parseInt(timestamp, 10);
+	if (Number.isNaN(parsedTimestamp)) {
+		return new Response("Invalid timestamp", { status: 400 });
+	}
+	const now = Math.floor(Date.now() / 1000);
+	if (Math.abs(now - parsedTimestamp) > 300) {
+		logger.warn("Webhook timestamp out of window", "PolarWebhook");
+		return new Response("Timestamp out of window", { status: 400 });
+	}
+
+	// Consume body stream as text before parsing
+	const rawBody = await req.text();
+
+	const signedContent = `${id}.${timestamp}.${rawBody}`;
+
+	// Strip "whsec_" prefix if present and base64 decode the secret key
+	const secretKey = webhookSecret.startsWith("whsec_")
+		? webhookSecret.substring(6)
+		: webhookSecret;
+	const secretBuffer = Buffer.from(secretKey, "base64");
+
+	const hmac = crypto.createHmac("sha256", secretBuffer);
+	hmac.update(signedContent);
+	const expectedSignature = hmac.digest("base64");
+
+	// Signature header can contain multiple space-separated signatures
+	const passedSignatures = signature
+		.split(" ")
+		.map((sig) => {
+			const parts = sig.split(",");
+			if (parts.length === 2 && parts[0] === "v1") {
+				return parts[1];
+			}
+			return null;
+		})
+		.filter(Boolean);
+
+	let isSignatureValid = false;
+	const expectedBuffer = Buffer.from(expectedSignature, "base64");
+
+	for (const passedSig of passedSignatures) {
+		if (!passedSig) continue;
+		const passedBuffer = Buffer.from(passedSig, "base64");
+		if (
+			passedBuffer.length === expectedBuffer.length &&
+			crypto.timingSafeEqual(passedBuffer, expectedBuffer)
+		) {
+			isSignatureValid = true;
+			break;
+		}
+	}
+
+	if (!isSignatureValid) {
+		logger.warn("Invalid webhook signature", "PolarWebhook");
+		return new Response("Invalid signature", { status: 401 });
+	}
+
+	interface PolarWebhookPayload {
+		event?: string;
+		data?: {
+			id?: string;
+			customerId?: string;
+			currentPeriodEnd?: string | number | Date;
+			cancelAt?: string | number | Date;
+			user?: {
+				email?: string;
+			};
+		};
+	}
+
+	let payload: PolarWebhookPayload;
+	try {
+		payload = JSON.parse(rawBody) as PolarWebhookPayload;
+	} catch (_err) {
+		return new Response("Invalid JSON payload", { status: 400 });
+	}
+
+	const { event, data } = payload;
+	if (!event || !data) {
+		return new Response("Missing event or data fields", { status: 400 });
+	}
+
+	logger.info(`Received Polar webhook event: ${event}`, "PolarWebhook");
+
+	const email = data.user?.email;
+	if (!email) {
+		logger.warn(
+			`No user email in webhook data for event: ${event}`,
+			"PolarWebhook",
+		);
+		return new Response("No user email in payload", { status: 200 });
+	}
+
+	const normalizedEmail = email.toLowerCase();
+
+	try {
+		if (event === "subscription.created") {
+			await db
+				.update(user)
+				.set({
+					plan: "pro",
+					planExpiresAt: null,
+					polarCustomerId: data.customerId || null,
+					polarSubscriptionId: data.id || null,
+				})
+				.where(eq(user.email, normalizedEmail));
+			logger.info(
+				`Upgraded user ${normalizedEmail} to Pro plan`,
+				"PolarWebhook",
+			);
+		} else if (event === "subscription.updated") {
+			const planExpiresAt = data.currentPeriodEnd
+				? new Date(data.currentPeriodEnd)
+				: null;
+			await db
+				.update(user)
+				.set({
+					plan: "pro",
+					planExpiresAt,
+					polarCustomerId: data.customerId || null,
+					polarSubscriptionId: data.id || null,
+				})
+				.where(eq(user.email, normalizedEmail));
+			logger.info(
+				`Updated subscription for user ${normalizedEmail}`,
+				"PolarWebhook",
+			);
+		} else if (event === "subscription.canceled") {
+			const planExpiresAt = data.cancelAt
+				? new Date(data.cancelAt)
+				: data.currentPeriodEnd
+					? new Date(data.currentPeriodEnd)
+					: new Date();
+			await db
+				.update(user)
+				.set({
+					plan: "free",
+					planExpiresAt,
+					polarCustomerId: data.customerId || null,
+					polarSubscriptionId: data.id || null,
+				})
+				.where(eq(user.email, normalizedEmail));
+			logger.info(
+				`Canceled subscription for user ${normalizedEmail}. Expires at: ${planExpiresAt}`,
+				"PolarWebhook",
+			);
+		} else if (event === "subscription.revoked") {
+			await db
+				.update(user)
+				.set({
+					plan: "free",
+					planExpiresAt: new Date(),
+					polarCustomerId: data.customerId || null,
+					polarSubscriptionId: data.id || null,
+				})
+				.where(eq(user.email, normalizedEmail));
+			logger.info(
+				`Revoked subscription for user ${normalizedEmail}`,
+				"PolarWebhook",
+			);
+		} else {
+			logger.info(`Unhandled Polar webhook event: ${event}`, "PolarWebhook");
+		}
+
+		return new Response("OK", { status: 200 });
+	} catch (err) {
+		const errorMessage = err instanceof Error ? err.message : String(err);
+		logger.error(
+			`Database error processing webhook: ${errorMessage}`,
+			"PolarWebhook",
+		);
+		return new Response("Internal Server Error", { status: 500 });
+	}
+}

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { Badge, Button } from "@harmonia/ui";
 import { formatDistanceToNow } from "date-fns";
@@ -13,6 +13,12 @@ import { PageHeader } from "@/components/shared/page-header";
 import { env } from "@/lib/env";
 import { useSettingsController } from "@/shared/lib/settings/controller.hook";
 
+/**
+ * Settings Page Component.
+ * 
+ * Displays user profile information, subscription status, connected accounts,
+ * and application-wide preferences.
+ */
 export default function SettingsPage() {
 	const [mounted, setMounted] = useState(false);
 	useEffect(() => {
@@ -137,3 +143,4 @@ export default function SettingsPage() {
 		</div>
 	);
 }
+

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { Badge, Button } from "@harmonia/ui";
+import { formatDistanceToNow } from "date-fns";
+import { useEffect, useState } from "react";
 import {
 	DashboardSettingsNavRow,
 	DashboardSettingsRow,
@@ -7,10 +10,8 @@ import {
 	DashboardSettingsSkeleton,
 } from "@/components/app/dashboard-settings-section";
 import { PageHeader } from "@/components/shared/page-header";
+import { env } from "@/lib/env";
 import { useSettingsController } from "@/shared/lib/settings/controller.hook";
-import { Badge, Button } from "@harmonia/ui";
-import { formatDistanceToNow } from "date-fns";
-import { useEffect, useState } from "react";
 
 export default function SettingsPage() {
 	const [mounted, setMounted] = useState(false);
@@ -27,6 +28,8 @@ export default function SettingsPage() {
 		resolvedTheme,
 		setTheme,
 		signOut,
+		plan,
+		isPro,
 	} = useSettingsController();
 
 	if (!mounted) {
@@ -57,16 +60,18 @@ export default function SettingsPage() {
 				<DashboardSettingsRow
 					label="Spotify"
 					value={
-						spotifyLoading ? (
-							"..."
-						) : spotifyLinked ? (
-							<span className="flex items-center gap-1.5">
-								<span className="size-2 rounded-full bg-green-500" />
-								Connected
-							</span>
-						) : (
-							"Not connected"
-						)
+						<span className="flex items-center gap-1.5">
+							{spotifyLoading ? (
+								"..."
+							) : spotifyLinked ? (
+								<>
+									<span className="size-2 rounded-full bg-green-500" />
+									Connected
+								</>
+							) : (
+								"Not connected"
+							)}
+						</span>
 					}
 				/>
 				<DashboardSettingsRow label="Last sync" value={lastSyncText} />
@@ -74,7 +79,36 @@ export default function SettingsPage() {
 
 			<DashboardSettingsSection label="ACCOUNT">
 				<DashboardSettingsRow label="Email" value={email ?? "..."} />
-				<DashboardSettingsRow label="Plan" value="Free" />
+				<DashboardSettingsRow
+					label="Plan"
+					value={
+						<div className="flex items-center gap-2">
+							<Badge variant={isPro ? "default" : "outline"}>{plan}</Badge>
+							{!isPro && (
+								<Button
+									variant="outline"
+									size="xs"
+									className="h-6 px-2 text-xs"
+									asChild
+								>
+									<a
+										href={`${env.NEXT_PUBLIC_POLAR_CHECKOUT_URL || "https://polar.sh"}${
+											(
+												env.NEXT_PUBLIC_POLAR_CHECKOUT_URL || "https://polar.sh"
+											).includes("?")
+												? "&"
+												: "?"
+										}customer_email=${encodeURIComponent(email || "")}`}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										Upgrade to Pro
+									</a>
+								</Button>
+							)}
+						</div>
+					}
+				/>
 			</DashboardSettingsSection>
 
 			<DashboardSettingsSection label="PREFERENCES">

--- a/apps/dashboard/src/shared/lib/settings/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/settings/controller.hook.ts
@@ -1,10 +1,11 @@
 "use client";
 
+import { isPro } from "@harmonia/common";
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "next-themes";
 import { authClient } from "@/shared/api/auth-client";
 import { orpc } from "@/shared/api/orpc";
 import { useOrganizeStore } from "@/shared/lib/organize/store";
-import { useQuery } from "@tanstack/react-query";
-import { useTheme } from "next-themes";
 
 function toSyncDate(value: unknown): Date | null {
 	if (value == null) {
@@ -38,6 +39,18 @@ export function useSettingsController() {
 		window.location.href = "/login";
 	};
 
+	const user = session?.user;
+	interface SubscriptionUser {
+		plan?: string;
+		planExpiresAt?: string | number | Date | null;
+	}
+	const subUser = user as SubscriptionUser | undefined;
+	const rawPlan = subUser?.plan ?? "free";
+	const planExpiresAt = subUser?.planExpiresAt
+		? new Date(subUser.planExpiresAt)
+		: null;
+	const hasPro = isPro({ plan: rawPlan, planExpiresAt });
+
 	return {
 		session,
 		sessionPending,
@@ -50,5 +63,7 @@ export function useSettingsController() {
 		resolvedTheme,
 		setTheme,
 		signOut,
+		plan: hasPro ? "Pro" : "Free",
+		isPro: hasPro,
 	};
 }

--- a/apps/dashboard/src/shared/lib/settings/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/settings/controller.hook.ts
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { isPro } from "@harmonia/common";
 import { useQuery } from "@tanstack/react-query";
@@ -21,6 +21,12 @@ function toSyncDate(value: unknown): Date | null {
 	return null;
 }
 
+/**
+ * Controller hook for the settings page.
+ * 
+ * Manages theme preferences, Spotify integration status, session management,
+ * and subscription billing state (Pro/Free).
+ */
 export function useSettingsController() {
 	const { data: session, isPending: sessionPending } = authClient.useSession();
 	const { theme, setTheme, resolvedTheme } = useTheme();
@@ -67,3 +73,4 @@ export function useSettingsController() {
 		isPro: hasPro,
 	};
 }
+

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -63,6 +63,27 @@ export function createAuth(
 					defaultValue: false,
 					input: false,
 				},
+				plan: {
+					type: "string",
+					required: false,
+					defaultValue: "free",
+					input: false,
+				},
+				planExpiresAt: {
+					type: "date",
+					required: false,
+					input: false,
+				},
+				polarCustomerId: {
+					type: "string",
+					required: false,
+					input: false,
+				},
+				polarSubscriptionId: {
+					type: "string",
+					required: false,
+					input: false,
+				},
 			},
 		},
 		trustedOrigins,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,12 +1,12 @@
 export * from "./constants";
 export * from "./schemas";
+export * from "./services/brain";
+export * from "./services/music";
+export * from "./services/organize";
 export * from "./types";
 export {
 	buildTrustedOrigins,
 	isOriginAllowed,
 	isOriginAllowedForRequest,
 } from "./utils/origin";
-
-export * from "./services/brain";
-export * from "./services/music";
-export * from "./services/organize";
+export { isPro } from "./utils/plan";

--- a/packages/common/src/utils/plan.ts
+++ b/packages/common/src/utils/plan.ts
@@ -1,3 +1,11 @@
+﻿/**
+ * Checks if the user has an active Pro plan.
+ * 
+ * Returns true if the plan is 'pro' and has not expired (or has no expiry date).
+ * 
+ * @param user - Object containing the user's plan name and optional expiration date.
+ * @returns True if the user is currently on an active Pro plan.
+ */
 export function isPro(user: {
 	plan: string;
 	planExpiresAt: Date | null;

--- a/packages/common/src/utils/plan.ts
+++ b/packages/common/src/utils/plan.ts
@@ -1,0 +1,8 @@
+export function isPro(user: {
+	plan: string;
+	planExpiresAt: Date | null;
+}): boolean {
+	if (user.plan !== "pro") return false;
+	if (!user.planExpiresAt) return true;
+	return user.planExpiresAt > new Date();
+}

--- a/packages/db/src/migrations/0012_lazy_rawhide_kid.sql
+++ b/packages/db/src/migrations/0012_lazy_rawhide_kid.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "user" ADD COLUMN "plan" text DEFAULT 'free' NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "plan_expires_at" timestamp;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "polar_customer_id" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "polar_subscription_id" text;

--- a/packages/db/src/migrations/meta/0012_snapshot.json
+++ b/packages/db/src/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1837 @@
+{
+	"id": "168a6c23-bcf0-407a-b0f0-cf1e5eac5505",
+	"prevId": "1a707765-54be-4fe4-8f31-6a299484051c",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_completed_onboarding": {
+					"name": "has_completed_onboarding",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plan": {
+					"name": "plan",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'free'"
+				},
+				"plan_expires_at": {
+					"name": "plan_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"polar_customer_id": {
+					"name": "polar_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"polar_subscription_id": {
+					"name": "polar_subscription_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character": {
+			"name": "character",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_user_id_user_id_fk": {
+					"name": "character_user_id_user_id_fk",
+					"tableFrom": "character",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_genre_domain_id_genre_domain_id_fk": {
+					"name": "character_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "character",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_clusters": {
+			"name": "character_clusters",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_clusters_character_id_character_id_fk": {
+					"name": "character_clusters_character_id_character_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_clusters_cluster_id_cluster_id_fk": {
+					"name": "character_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_clusters_character_id_cluster_id_pk": {
+					"name": "character_clusters_character_id_cluster_id_pk",
+					"columns": ["character_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_tracks": {
+			"name": "character_tracks",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_tracks_character_id_character_id_fk": {
+					"name": "character_tracks_character_id_character_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_tracks_track_id_track_id_fk": {
+					"name": "character_tracks_track_id_track_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_tracks_character_id_track_id_pk": {
+					"name": "character_tracks_character_id_track_id_pk",
+					"columns": ["character_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster": {
+			"name": "cluster",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"centroid": {
+					"name": "centroid",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_valence": {
+					"name": "avg_valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_energy": {
+					"name": "avg_energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_tempo": {
+					"name": "avg_tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"cluster_user_id_idx": {
+					"name": "cluster_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"cluster_user_id_user_id_fk": {
+					"name": "cluster_user_id_user_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_genre_domain_id_genre_domain_id_fk": {
+					"name": "cluster_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster_tracks": {
+			"name": "cluster_tracks",
+			"schema": "",
+			"columns": {
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cluster_tracks_cluster_id_cluster_id_fk": {
+					"name": "cluster_tracks_cluster_id_cluster_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_tracks_track_id_track_id_fk": {
+					"name": "cluster_tracks_track_id_track_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"cluster_tracks_cluster_id_track_id_pk": {
+					"name": "cluster_tracks_cluster_id_track_id_pk",
+					"columns": ["cluster_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genre_domain": {
+			"name": "genre_domain",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"genre_domain_name_unique": {
+					"name": "genre_domain_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track": {
+			"name": "track",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"spotify_uri": {
+					"name": "spotify_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_names": {
+					"name": "artist_names",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_image_url": {
+					"name": "album_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spotify_genres": {
+					"name": "spotify_genres",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"valence": {
+					"name": "valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy": {
+					"name": "energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"danceability": {
+					"name": "danceability",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tempo": {
+					"name": "tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acousticness": {
+					"name": "acousticness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instrumentalness": {
+					"name": "instrumentalness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"speechiness": {
+					"name": "speechiness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"liveness": {
+					"name": "liveness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics": {
+					"name": "lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_lyrics": {
+					"name": "synced_lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_instrumental": {
+					"name": "lyrics_instrumental",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lrclib_id": {
+					"name": "lrclib_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_fetched_at": {
+					"name": "lyrics_fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_status": {
+					"name": "lyrics_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_mood": {
+					"name": "llm_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_tags": {
+					"name": "llm_tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_classified_at": {
+					"name": "llm_classified_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_generated_at": {
+					"name": "embedding_generated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_input": {
+					"name": "embedding_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_assigned_at": {
+					"name": "domain_assigned_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"analysis_snapshot": {
+					"name": "analysis_snapshot",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"track_genre_domain_id_idx": {
+					"name": "track_genre_domain_id_idx",
+					"columns": [
+						{
+							"expression": "genre_domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_lyrics_status_idx": {
+					"name": "track_lyrics_status_idx",
+					"columns": [
+						{
+							"expression": "lyrics_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_embedding_idx": {
+					"name": "track_embedding_idx",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genre_domain_id_genre_domain_id_fk": {
+					"name": "track_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "track",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_tracks": {
+			"name": "user_tracks",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_tracks_user_id_idx": {
+					"name": "user_tracks_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_tracks_track_id_idx": {
+					"name": "user_tracks_track_id_idx",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_tracks_user_id_user_id_fk": {
+					"name": "user_tracks_user_id_user_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_tracks_track_id_track_id_fk": {
+					"name": "user_tracks_track_id_track_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_tracks_user_id_track_id_pk": {
+					"name": "user_tracks_user_id_track_id_pk",
+					"columns": ["user_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist": {
+			"name": "playlist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_generated_name": {
+					"name": "ai_generated_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"taxonomy": {
+					"name": "taxonomy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_color": {
+					"name": "cover_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_count": {
+					"name": "track_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"exported_at": {
+					"name": "exported_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"playlist_user_id_idx": {
+					"name": "playlist_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"playlist_taxonomy_idx": {
+					"name": "playlist_taxonomy_idx",
+					"columns": [
+						{
+							"expression": "taxonomy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"playlist_user_id_user_id_fk": {
+					"name": "playlist_user_id_user_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_genre_domain_id_genre_domain_id_fk": {
+					"name": "playlist_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_clusters": {
+			"name": "playlist_clusters",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_clusters_playlist_id_playlist_id_fk": {
+					"name": "playlist_clusters_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_clusters_cluster_id_cluster_id_fk": {
+					"name": "playlist_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_clusters_playlist_id_cluster_id_pk": {
+					"name": "playlist_clusters_playlist_id_cluster_id_pk",
+					"columns": ["playlist_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_tracks": {
+			"name": "playlist_tracks",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_tracks_playlist_id_playlist_id_fk": {
+					"name": "playlist_tracks_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_tracks_track_id_track_id_fk": {
+					"name": "playlist_tracks_track_id_track_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_tracks_playlist_id_track_id_pk": {
+					"name": "playlist_tracks_playlist_id_track_id_pk",
+					"columns": ["playlist_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pipeline_run": {
+			"name": "pipeline_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"current_stage": {
+					"name": "current_stage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"progress": {
+					"name": "progress",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"pipeline_run_user_id_idx": {
+					"name": "pipeline_run_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_status_idx": {
+					"name": "pipeline_run_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pipeline_run_user_id_user_id_fk": {
+					"name": "pipeline_run_user_id_user_id_fk",
+					"tableFrom": "pipeline_run",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_item_artists": {
+			"name": "user_playlist_snapshot_item_artists",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_position": {
+					"name": "artist_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_name": {
+					"name": "artist_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_item_artists",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+					"columns": ["user_id", "playlist_id", "position", "artist_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_items": {
+			"name": "user_playlist_snapshot_items",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_name": {
+					"name": "track_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_uri": {
+					"name": "track_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_items_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_items",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+					"columns": ["user_id", "playlist_id", "position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshots": {
+			"name": "user_playlist_snapshots",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshots_user_id_user_id_fk": {
+					"name": "user_playlist_snapshots_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshots",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshots_user_id_playlist_id_pk": {
+					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
+					"columns": ["user_id", "playlist_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_spotify_library_stats": {
+			"name": "user_spotify_library_stats",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"total_tracks": {
+					"name": "total_tracks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_playlists": {
+					"name": "total_playlists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_albums": {
+					"name": "unique_albums",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_artists": {
+					"name": "unique_artists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_spotify_library_stats_user_id_user_id_fk": {
+					"name": "user_spotify_library_stats_user_id_user_id_fk",
+					"tableFrom": "user_spotify_library_stats",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
 			"when": 1779297588295,
 			"tag": "0011_overrated_umar",
 			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1780922474196,
+			"tag": "0012_lazy_rawhide_kid",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -10,6 +10,10 @@ export const user = pgTable("user", {
 		.default(false)
 		.notNull(),
 	image: text("image"),
+	plan: text("plan").default("free").notNull(),
+	planExpiresAt: timestamp("plan_expires_at"),
+	polarCustomerId: text("polar_customer_id"),
+	polarSubscriptionId: text("polar_subscription_id"),
 	createdAt: timestamp("created_at").defaultNow().notNull(),
 	updatedAt: timestamp("updated_at")
 		.defaultNow()

--- a/packages/env/src/modules/auth.ts
+++ b/packages/env/src/modules/auth.ts
@@ -11,5 +11,8 @@ export const authModule = {
 		HARMONIA_CRON_SECRET: z.string().min(1).optional(),
 		HARMONIA_OPENAI_API_KEY: z.string().min(1).optional(),
 		HARMONIA_GROQ_API_KEY: z.string().min(1).optional(),
+		POLAR_ACCESS_TOKEN: z.string().min(1).optional(),
+		POLAR_ORGANIZATION_ID: z.string().min(1).optional(),
+		POLAR_WEBHOOK_SECRET: z.string().min(1).optional(),
 	},
 } as const;

--- a/packages/env/src/modules/urls.ts
+++ b/packages/env/src/modules/urls.ts
@@ -7,5 +7,6 @@ export const urlsModule = {
 	client: {
 		NEXT_PUBLIC_HARMONIA_WEB_URL: z.url().optional(),
 		NEXT_PUBLIC_HARMONIA_DASHBOARD_URL: z.url().optional(),
+		NEXT_PUBLIC_POLAR_CHECKOUT_URL: z.string().url().optional(),
 	},
 } as const;

--- a/packages/orpc/src/index.ts
+++ b/packages/orpc/src/index.ts
@@ -1,18 +1,18 @@
-export {
-	o,
-	publicProcedure,
-	protectedProcedure,
-	cronOrAuthProcedure,
-} from "./procedures";
-export { createContext } from "./context";
-export type { Context } from "./context";
+export type { AppRouterClient, PublicRouterClient } from "./client";
 export { createORPCClientUtils } from "./client";
-export type { PublicRouterClient, AppRouterClient } from "./client";
-
+export type { Context } from "./context";
+export { createContext } from "./context";
 export {
-	publicRouter,
-	protectedRouter,
+	cronOrAuthProcedure,
+	o,
+	planProcedure,
+	protectedProcedure,
+	publicProcedure,
+} from "./procedures";
+export type { AppRouter, ProtectedRouter, PublicRouter } from "./routers/index";
+export {
 	appRouter,
 	createAppRouter,
+	protectedRouter,
+	publicRouter,
 } from "./routers/index";
-export type { AppRouter, PublicRouter, ProtectedRouter } from "./routers/index";

--- a/packages/orpc/src/procedures.ts
+++ b/packages/orpc/src/procedures.ts
@@ -21,6 +21,11 @@ const requireAuth = o.middleware(async ({ context, next }) => {
 
 export const protectedProcedure = publicProcedure.use(requireAuth);
 
+/**
+ * Middleware that requires the authenticated user to have an active Pro plan.
+ * Verifies the session and plan expiration. Throws FORBIDDEN if the user
+ * is not a Pro subscriber.
+ */
 const requirePlan = o.middleware(async ({ context, next }) => {
 	const user = context.session?.user;
 	if (!user) {
@@ -51,6 +56,10 @@ const requirePlan = o.middleware(async ({ context, next }) => {
 	});
 });
 
+/**
+ * An ORPC procedure that requires both authentication and an active Pro plan.
+ * Use this for premium-only API routes.
+ */
 export const planProcedure = protectedProcedure.use(requirePlan);
 
 const requireCronOrAuth = o.middleware(async ({ context, next }) => {

--- a/packages/orpc/src/procedures.ts
+++ b/packages/orpc/src/procedures.ts
@@ -1,5 +1,6 @@
+import { isPro } from "@harmonia/common";
 import { env } from "@harmonia/env/server";
-import { os, ORPCError } from "@orpc/server";
+import { ORPCError, os } from "@orpc/server";
 
 import type { Context } from "./context";
 
@@ -19,6 +20,38 @@ const requireAuth = o.middleware(async ({ context, next }) => {
 });
 
 export const protectedProcedure = publicProcedure.use(requireAuth);
+
+const requirePlan = o.middleware(async ({ context, next }) => {
+	const user = context.session?.user;
+	if (!user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	interface SubscriptionUser {
+		plan?: string;
+		planExpiresAt?: string | number | Date | null;
+	}
+
+	const subUser = user as SubscriptionUser;
+	const plan = subUser.plan ?? "free";
+	const planExpiresAt = subUser.planExpiresAt
+		? new Date(subUser.planExpiresAt)
+		: null;
+
+	if (!isPro({ plan, planExpiresAt })) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Upgrade to Pro to access this feature.",
+		});
+	}
+
+	return next({
+		context: {
+			session: context.session,
+		},
+	});
+});
+
+export const planProcedure = protectedProcedure.use(requirePlan);
 
 const requireCronOrAuth = o.middleware(async ({ context, next }) => {
 	const cronSecret =

--- a/packages/orpc/src/routers/protected/insights.ts
+++ b/packages/orpc/src/routers/protected/insights.ts
@@ -7,18 +7,18 @@ import { playlist, playlistTracks } from "@harmonia/db/schema/playlist";
 import { userSpotifyLibraryStats } from "@harmonia/db/schema/spotify";
 import { track, userTracks } from "@harmonia/db/schema/track";
 import { and, count, desc, eq, inArray, isNotNull } from "drizzle-orm";
-import { protectedProcedure } from "../../procedures";
+import { planProcedure } from "../../procedures";
 
 function normalizeEra(era: string): string | null {
 	const digits = era.replace(/\D/g, "");
 	if (digits.length >= 4) {
-		const year = parseInt(digits.slice(0, 4));
+		const year = Number.parseInt(digits.slice(0, 4));
 		if (year >= 1950 && year <= 2029) {
 			return `${Math.floor(year / 10) * 10}s`;
 		}
 	}
 	if (digits.length === 2) {
-		const d = parseInt(digits);
+		const d = Number.parseInt(digits);
 		if (d >= 50 && d <= 99) return `19${digits}s`;
 		if (d >= 0 && d <= 29) return `20${digits.padStart(2, "0")}s`;
 	}
@@ -47,7 +47,7 @@ function topStringMap(
 }
 
 export const insightsRouter = {
-	summary: protectedProcedure
+	summary: planProcedure
 		.input(emptyInput)
 		.output(insightsSummarySchema)
 		.handler(async ({ context }) => {


### PR DESCRIPTION
## 🧠 Overview
This pull request implements the Polar.sh billing integration to gate Pro features behind active subscriptions. It includes database schema updates, a webhook handler for subscription sync, plan verification utilities, and UI updates for the settings page.

Closes #70

---

## ✅ Pre-merge Checklist

### Code Quality
- [x] Self-reviewed the code thoroughly
- [x] Follows project conventions (`.cursor/rules/`)
- [x] Builds and runs locally without errors (`pnpm check-types`)
- [x] Biome passes (`pnpm check`)

### Testing
- [x] Tested the changed feature end-to-end locally
- [x] Verified no regressions in adjacent features
- [x] If pipeline-related: ran a full organize pipeline and confirmed results

---

## 🔍 Additional Notes
### Changes
- **Database Schema**: Added `plan`, `planExpiresAt`, `polarCustomerId`, and `polarSubscriptionId` fields to the user table.
- **Webhook Handler**: Implemented a Next.js App Router webhook endpoint at `/api/webhooks/polar` to parse and sync subscription updates.
- **Plan Verification Utility**: Created the `isPro` helper function to verify a user's subscription status.
- **API Gating**: Added a new `planProcedure` middleware in oRPC and gated the insights route.
- **Dashboard UI**: Updated the Settings page to display the user's active plan and added an "Upgrade to Pro" link button.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Polar.sh billing for subscription management
  * Added plan-based access control to premium features
  * Settings page now displays current subscription status with upgrade option

* **Chores**
  * Extended user database schema to support subscription tracking and plan expiration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->