### PR TITLE
docs(rules): clarify comment/constant conventions, add shadcn best practices

### DIFF
--- a/.cursor/rules/01-naming-conventions.mdc
+++ b/.cursor/rules/01-naming-conventions.mdc
@@ -62,6 +62,8 @@ const MAX_TRACKS_PER_ARTIST = 4;
 const EMBEDDING_BATCH_SIZE = 64;
 ```
 
+Only export a constant into a package's `constants/*.ts` file if it's used from 2+ files. A constant used in exactly one file stays local to that file (unexported, no separate constants-file entry).
+
 ## Commits
 
 `feat:` `fix:` `chore:` `perf:` `refactor:` prefixes. No scope required.

--- a/.cursor/rules/02-code-patterns.mdc
+++ b/.cursor/rules/02-code-patterns.mdc
@@ -135,4 +135,4 @@ Never use `as SomeType` or `as unknown as SomeType` casts. Rely on TypeScript's 
 
 ## No Comments Rule
 
-No comments unless the WHY is non-obvious: a hidden constraint, a workaround for a specific bug, behaviour that would surprise a reader.
+No comments unless the WHY is non-obvious: a hidden constraint, a workaround for a specific bug, behaviour that would surprise a reader. One line max — if it needs more, it belongs in the relevant `.cursor/rules/*.mdc` doc, not the code.

--- a/.cursor/rules/packages/ui.mdc
+++ b/.cursor/rules/packages/ui.mdc
@@ -39,3 +39,22 @@ Do NOT use `<Card>` for settings sections, stat blocks, or metadata rows.
 - Copy-paste shadcn component source into app directories — extend via props instead
 - Use native `<button>`, `<input>`, `<a>` when a shadcn equivalent exists
 - Use inline styles — Tailwind utilities only
+- Use `Dialog` for destructive confirmation — use `AlertDialog`
+- Nest `Card` inside `Card`
+- Reach for ad-hoc hex colors — use theme tokens (`bg-background`, `text-muted-foreground`, `border-border`, `ring-ring`)
+- Ship empty/loading/error states without a designed treatment (`Skeleton`, `Alert`, `ErrorState`)
+
+## Reach For This First
+
+| Use case | Components |
+|---|---|
+| Settings page | `Tabs` + `Card` + `Form` |
+| Data table / CRUD | `Table` + `DropdownMenu` + `Sheet` + `AlertDialog` |
+| Detail page | header + `Badge` + `Separator` + `Card` |
+| Global search | `Command` + `Dialog` |
+| Mobile nav / filters | `Sheet` |
+
+## Gotchas
+
+- `Avatar` has no `size` prop — size via Tailwind (`className="h-6 w-6"`), not a variant.
+- `Tooltip` needs a `TooltipProvider` ancestor for shared `delayDuration`/skip-delay behavior across adjacent tooltips — wrap once at the app root layout, not per-component.


### PR DESCRIPTION
Small conventions clarification, prompted by feedback while fixing #143/#144/#145:

- **No Comments Rule**: cap at one line — longer explanations belong in the relevant `.cursor/rules/*.mdc` doc, not code.
- **Constants**: only export a constant to a package's `constants/*.ts` when it's used from 2+ files; single-consumer constants stay local.
- **`ui.mdc`**: added a Do Not list, a "Reach For This First" component table, and two gotchas (`Avatar` has no `size` prop, `Tooltip` needs a root `TooltipProvider`) pulled from shadcn best practices.

Related follow-up audits filed separately: #149 (repo-wide comment/constant trim), #150 (shadcn compliance gaps found while writing this).