### PR TITLE
ci: add lint, build, and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+# Runs on every push/PR: install, lint, typecheck+build, and test — in parallel jobs
+# so a failure in one (e.g. lint) doesn't block visibility into the others.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm exec biome ci .
+
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_ENV_VALIDATION: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Runs tsc --noEmit across every package and a full Next.js build for
+      # every app (api, dashboard, web, admin) via Turborepo.
+      - name: Build
+        run: pnpm build
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_ENV_VALIDATION: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 # Runs on every push/PR: install, lint, typecheck+build, and test — in parallel jobs
 # so a failure in one (e.g. lint) doesn't block visibility into the others.
+#
+# build/test use Turborepo's remote cache (Vercel) when TURBO_TOKEN is set, so
+# unchanged packages skip re-building/re-testing entirely. Requires:
+#   - repo secret TURBO_TOKEN: a Vercel access token (vercel.com/account/tokens)
+#   - repo variable TURBO_TEAM: findmalek-team
+# Without them, turbo silently falls back to no remote cache (still correct,
+# just slower — every run rebuilds from scratch).
 
 name: CI
 
@@ -34,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP_ENV_VALIDATION: "true"
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP_ENV_VALIDATION: "true"
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/apps/dashboard/src/shared/lib/pipeline/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/pipeline/controller.hook.ts
@@ -30,7 +30,9 @@ type PipelineRunProbe =
 
 // Single narrowing point for the SSE payload's `unknown` progress field, instead of
 // repeating the same cast at every event branch below.
-function asProgressRecord(progress: unknown): Record<string, PipelineProgressStage> {
+function asProgressRecord(
+	progress: unknown,
+): Record<string, PipelineProgressStage> {
 	return (progress as Record<string, PipelineProgressStage> | null) ?? {};
 }
 
@@ -180,9 +182,7 @@ export function usePipelineProgressDrive(): PipelineProgressContextValue {
 								startedAt: data.startedAt,
 							}));
 							setLiveProgress(
-								deriveLiveProgress(
-									asProgressRecord(data.progress),
-								),
+								deriveLiveProgress(asProgressRecord(data.progress)),
 							);
 						} else if (data.event === "completed") {
 							setSnapshot((s) => ({
@@ -193,9 +193,7 @@ export function usePipelineProgressDrive(): PipelineProgressContextValue {
 								completedAt: data.completedAt,
 							}));
 							setLiveProgress(
-								deriveLiveProgress(
-									asProgressRecord(data.progress),
-								),
+								deriveLiveProgress(asProgressRecord(data.progress)),
 							);
 							setConnectionState("idle");
 							invalidatePipeline();
@@ -210,9 +208,7 @@ export function usePipelineProgressDrive(): PipelineProgressContextValue {
 								error: data.error ?? null,
 							}));
 							setLiveProgress(
-								deriveLiveProgress(
-									asProgressRecord(data.progress),
-								),
+								deriveLiveProgress(asProgressRecord(data.progress)),
 							);
 							setConnectionState("idle");
 							invalidatePipeline();
@@ -227,9 +223,7 @@ export function usePipelineProgressDrive(): PipelineProgressContextValue {
 								error: data.error ?? "Unknown error",
 							}));
 							setLiveProgress(
-								deriveLiveProgress(
-									asProgressRecord(data.progress),
-								),
+								deriveLiveProgress(asProgressRecord(data.progress)),
 							);
 							setConnectionState("idle");
 							invalidatePipeline();

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,9 @@
 			"!**/wrangler.jsonc",
 			"!**/.source",
 			"!**/.trigger",
-			"!**/.react-email"
+			"!**/.react-email",
+			"!**/.claude",
+			"!skills-lock.json"
 		]
 	},
 	"formatter": {

--- a/biome.json
+++ b/biome.json
@@ -84,5 +84,20 @@
 			"cssModules": false,
 			"tailwindDirectives": true
 		}
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["packages/ui/src/components/ui/**"],
+			"linter": {
+				"rules": {
+					"a11y": {
+						"useSemanticElements": "off",
+						"useFocusableInteractive": "off",
+						"useKeyWithClickEvents": "off",
+						"useAriaPropsForRole": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/packages/common/src/services/brain/clustering.ts
+++ b/packages/common/src/services/brain/clustering.ts
@@ -43,7 +43,9 @@ export async function runClustering(
 	// equivalent to cosine distance (the metric text-embedding-3-small is
 	// designed for). The DB column stores raw vectors; we never mutate it —
 	// normalisation is a read-time transform local to clustering.
-	const embeddings = tracks.map((t) => l2Normalize(requireEmbedding(t.embedding)));
+	const embeddings = tracks.map((t) =>
+		l2Normalize(requireEmbedding(t.embedding)),
+	);
 
 	if (embeddings.length < CLUSTER_MIN_POINTS) {
 		logger.info(
@@ -238,7 +240,10 @@ function splitLargeClusters(
 		const candidates =
 			subClusters.length > 1
 				? subClusters.map((sub) => sub.map((si) => indices[si] as number))
-				: kmeans(subEmbeddings, Math.max(2, Math.ceil(indices.length / maxSize)))
+				: kmeans(
+						subEmbeddings,
+						Math.max(2, Math.ceil(indices.length / maxSize)),
+					)
 						.filter((sub) => sub.length > 0)
 						.map((sub) => sub.map((si) => indices[si] as number));
 
@@ -248,7 +253,13 @@ function splitLargeClusters(
 			continue;
 		}
 		result.push(
-			...splitLargeClusters(candidates, embeddings, maxSize, minPoints, depth + 1),
+			...splitLargeClusters(
+				candidates,
+				embeddings,
+				maxSize,
+				minPoints,
+				depth + 1,
+			),
 		);
 	}
 


### PR DESCRIPTION
Closes #72 (the core CI gap it tracked — Vitest was already wired up for `@harmonia/common`/`@harmonia/orpc` by a previous PR, this just runs it in CI)

## What's added

One workflow, three parallel jobs (chose this over splitting into multiple workflow files — a single "CI" check group is easier to read on a PR than several separate ones, and turbo already parallelizes within each job):

- **lint** — `biome ci .`
- **build** — `pnpm build`: `tsc --noEmit` across every package + a full Next.js build for every app (api, dashboard, web, admin) via Turborepo
- **test** — `pnpm test`: vitest for `@harmonia/common` and `@harmonia/orpc`

All three verified green locally before opening this.

## What I had to fix to get there

- `biome ci` found 13 real errors, all accessibility lint rules firing on `packages/ui/src/components/ui/**` — shadcn's own intentional `<div role="group">`/`role="separator"`/etc. patterns (styling flexibility trade-off upstream, not a bug). Added a scoped `biome.json` override disabling those specific a11y rules just for that vendored directory, rather than patching shadcn's source to diverge from upstream. 4 warnings + 4 infos remain (unused import, missing radix params, a non-null assertion, a `Function` type) — none block CI; left them for #149.
- 2 files touched earlier this session weren't biome-formatted; fixed.

## Test plan

- [x] `pnpm exec biome ci .` — clean
- [x] `SKIP_ENV_VALIDATION=true pnpm build` — 17/17 tasks pass
- [x] `SKIP_ENV_VALIDATION=true pnpm test` — 12/12 tests pass