### PR TITLE
docs(rules): document undocumented real patterns + Zod v4/pgvector conventions

### DIFF
--- a/.cursor/rules/01-naming-conventions.mdc
+++ b/.cursor/rules/01-naming-conventions.mdc
@@ -28,6 +28,7 @@ All files use **kebab-case**.
 - Export: `DashboardLibraryAnalysis`
 - Always co-locate a skeleton: `DashboardLibraryAnalysisSkeleton`
 - `"use client"` only when browser APIs, event handlers, or hooks are used
+- Props: `type Props = { ... }` — never `interface Props`
 
 ## Schema Naming (Zod)
 
@@ -36,6 +37,7 @@ All files use **kebab-case**.
 - Inferred types: `type PlaylistGetById = z.infer<typeof playlistGetByIdOutputSchema>`
 - Enums: `{entity}{Field}Enum` — e.g. `pipelineStatusEnum`
 - Metadata schemas: `{entity}MetadataSchema` — e.g. `playlistMetadataSchema`
+- Use Zod v4 top-level string formats — `z.email()`, `z.url()`, `z.uuid()` — not the `z.string().email()` chain form
 
 ## Import Aliases
 

--- a/.cursor/rules/02-code-patterns.mdc
+++ b/.cursor/rules/02-code-patterns.mdc
@@ -133,6 +133,21 @@ Never use `as SomeType` or `as unknown as SomeType` casts. Rely on TypeScript's 
 - If two types don't align structurally, fix the type definition rather than casting around it.
 - The only accepted `as` uses are temporary escape hatches for genuine pgvector / jsonb raw-SQL constraints, documented with an explicit comment explaining why narrowing is impossible.
 
+## Indexed Access (`noUncheckedIndexedAccess`)
+
+`array[0]` and destructured array elements are typed `T | undefined`. Never silence this with `!` or `.at()` — the repo has zero non-null assertions and zero `.at()` calls. Use one of:
+
+```typescript
+// Aggregate/lookup queries: optional-chain into a default
+const total = rows[0]?.count ?? 0;
+
+// Single-row selects expected to exist: destructure, then guard
+const [row] = await db.select().from(user).where(eq(user.id, userId));
+if (!row || row.banned || !row.isApproved) {
+  throw new ORPCError("FORBIDDEN");
+}
+```
+
 ## No Comments Rule
 
 No comments unless the WHY is non-obvious: a hidden constraint, a workaround for a specific bug, behaviour that would surprise a reader. One line max — if it needs more, it belongs in the relevant `.cursor/rules/*.mdc` doc, not the code.

--- a/.cursor/rules/apps/dashboard.mdc
+++ b/.cursor/rules/apps/dashboard.mdc
@@ -58,6 +58,12 @@ Returning approved users reach `/login` without an invite cookie. Invite flow: e
 - Always co-locate a skeleton: `export function DashboardXyzSkeleton() { ... }`
 - Extract inline components out of page files into `components/app/`
 
+## Loading States
+
+- **RSC prefetch boundaries** (server component wraps a client fetcher): `<Suspense fallback={<XSkeleton />}>` — see `app/(dashboard)/page.tsx` wrapping `DashboardLibraryStatsWrapper`.
+- **Client components using `useQuery`**: manual guard, not `useSuspenseQuery` — `if (isLoading) return <XSkeleton />;` / `if (!data) return <XSkeleton />;` (see `dashboard-insights-content.tsx`). Do not introduce `useSuspenseQuery` inside already-client-rendered trees.
+- No barrel `index.ts` under `components/app/` or `components/shared/` — import each component from its direct file path.
+
 ## Data Fetching
 
 - Server state: TanStack Query v5 via `orpc` client (`@/shared/api/orpc`)

--- a/.cursor/rules/packages/db.mdc
+++ b/.cursor/rules/packages/db.mdc
@@ -27,6 +27,19 @@ export const myTable = pgTable("my_table", {
 - Always add indexes for foreign keys and common filter columns
 - Export from `packages/db/src/schema/index.ts`
 
+### Vector Columns (pgvector)
+
+```typescript
+// packages/db/src/schema/track.ts
+embedding: vector("embedding", { dimensions: 1536 }),
+// ...
+(table) => [
+  index("track_embedding_idx").using("hnsw", table.embedding.op("vector_cosine_ops")),
+]
+```
+
+Use `hnsw` with `vector_cosine_ops` — matches the cosine-distance clustering in `services/brain/clustering.ts`. Do not switch to `ivfflat`/`vector_l2_ops` without updating the distance operator used by the consuming query.
+
 ## Query Patterns
 
 ```typescript
@@ -85,3 +98,7 @@ Always run `pnpm db:push` after schema changes in development.
 When adding new user-owned tables under `packages/db/src/schema/`, extend `TABLES_TO_TRUNCATE` in `packages/db/scripts/db-reset.ts`.
 
 **Waitlist approval gate:** migration `0020_grandfather_user_approval.sql` sets `is_approved = true` for all existing users when deploying the closed-beta gate to a database that already has accounts. Run `pnpm db:migrate` in production after that deploy.
+
+### Hand-Written Migrations
+
+Data-seed or non-schema migrations (e.g. `0003_seed_genre_domain.sql`) are written by hand and share a numeric prefix with the adjacent `drizzle-kit generate` file — they are **not** added to `meta/_journal.json`, so `drizzle-kit migrate` never runs them automatically. If the target DB already has the underlying schema (e.g. it was set up via `db:push`), `db:migrate` will fail with "relation already exists"; run `pnpm db:mark-migrations-applied` first to backfill `drizzle.__drizzle_migrations` from the journal, then apply hand-written files manually.

--- a/.cursor/rules/packages/orpc.mdc
+++ b/.cursor/rules/packages/orpc.mdc
@@ -65,6 +65,20 @@ const { data } = useQuery(orpc.playlists.list.queryOptions());
 const { mutate } = useMutation(orpc.admin.waitlist.updateStatus.mutationOptions({ onError: toastError }));
 ```
 
+## Error Handling
+
+Throw `ORPCError` directly from handlers/middleware with a typed code — never a bare `Error`:
+
+```typescript
+import { ORPCError } from "@orpc/server";
+
+if (!row || row.banned || !row.isApproved) {
+  throw new ORPCError("FORBIDDEN");
+}
+```
+
+Codes in use: `UNAUTHORIZED`, `FORBIDDEN`, `BAD_REQUEST`, `TOO_MANY_REQUESTS`, `INTERNAL_SERVER_ERROR`. Domain errors that originate in `@harmonia/common` services (e.g. `PipelineCancelledError`) stay plain `Error` subclasses there — only the oRPC layer translates into `ORPCError`.
+
 ## Rate Limiting
 
 - Applied globally via `rateLimitMiddleware` on `publicProcedure`

--- a/.cursor/rules/packages/trigger.mdc
+++ b/.cursor/rules/packages/trigger.mdc
@@ -39,6 +39,40 @@ export const myStageTask = task({
 3. Add export to `packages/common/package.json` exports map
 4. Add `.triggerAndWait()` call in `packages/common/src/trigger/tasks/organize.ts`
 
+## Fan-Out Stages (embed, classify, lyrics)
+
+Stage tasks that fan out per-track work split into a coordinator task and a queued worker task, chunked and re-joined with `batchTriggerAndWait`:
+
+```typescript
+const embedWorkerQueue = queue({ name: "organize-embed-worker", concurrencyLimit: EMBED_WORKER_QUEUE_CONCURRENCY });
+
+export const embedWorkerTask = task({
+  id: "organize-worker-embed",
+  queue: embedWorkerQueue, // concurrency limit lives on the worker task
+  run: async ({ userId, runId, trackIds }: { userId: string; runId: number; trackIds: string[] }) => { ... },
+});
+
+// Coordinator: chunk pending ids, fan out, re-aggregate
+const batchResult = await embedWorkerTask.batchTriggerAndWait(
+  chunks.map((trackIds) => ({
+    payload: { userId, runId, trackIds },
+    options: {
+      idempotencyKey: workerIdempotencyKey("embed-worker", runId, trackIds),
+      idempotencyKeyTTL: "24h",
+    },
+  })),
+);
+for (const run of batchResult.runs) {
+  if (run.ok) embedded += run.output.embedded; else failedWorkers++;
+}
+```
+
+Reuse this coordinator/worker split (see `stages/classify.ts`, `stages/lyrics.ts`) rather than inventing a new fan-out pattern per stage.
+
+## Logging
+
+Import `logger` from `@harmonia/logger` in every task — never the Trigger.dev SDK's own logger.
+
 ## Env Key Mapping
 
 `HARMONIA_TRIGGER_SECRET_KEY` → `TRIGGER_SECRET_KEY` via `scripts/run-trigger-dev.mjs` (for the worker) and `scripts/with-root-env.mjs` (for the API process).


### PR DESCRIPTION
## Summary

Web-researched current (2025-2026) best practices for Drizzle/drizzle-kit + pgvector, Trigger.dev v3/v4, oRPC, Next.js 16 monorepos, `noUncheckedIndexedAccess`, and Zod v4 — then cross-referenced each against actual code in this repo (grepped, not assumed). Only additions with verifiable evidence in the codebase made it in; nothing aspirational.

## What changed and why

**`.cursor/rules/02-code-patterns.mdc`**
- Added an "Indexed Access" section documenting the `noUncheckedIndexedAccess` idiom already used everywhere: `rows[0]?.field ?? default` for aggregates, destructure-then-guard for expected single rows. Confirmed zero `!` non-null assertions and zero `.at()` calls across `packages/orpc` and `packages/common` — this was a real, consistent, but undocumented convention.

**`.cursor/rules/packages/db.mdc`**
- Documented the pgvector column/index pattern from `track.ts` (`vector(...)` + `hnsw` index + `vector_cosine_ops`), which backs the cosine-distance clustering logic.
- Documented that hand-written migrations (`0003_seed_genre_domain.sql`, `0010_small_network.sql`) intentionally bypass `meta/_journal.json` and don't auto-run via `drizzle-kit migrate` — and pointed at the existing `db:mark-migrations-applied` script as the recovery path. This script existed but wasn't referenced anywhere in the docs.

**`.cursor/rules/packages/orpc.mdc`**
- Documented the `ORPCError` typed-code convention (codes actually in use: `UNAUTHORIZED`, `FORBIDDEN`, `BAD_REQUEST`, `TOO_MANY_REQUESTS`, `INTERNAL_SERVER_ERROR`) and the boundary split with plain `Error` subclasses like `PipelineCancelledError` that live in `@harmonia/common` services.

**`.cursor/rules/packages/trigger.mdc`**
- Documented the coordinator/worker task split used by the embed/classify/lyrics fan-out stages: dedicated `queue()` with `concurrencyLimit` on the worker task, `batchTriggerAndWait` with per-item `idempotencyKey`/`idempotencyKeyTTL` from the coordinator. This pattern is repeated identically in three stages but had no written-down shape.
- Documented the `@harmonia/logger`-only convention for tasks (never Trigger.dev SDK's own logger) — consistent across every task file, previously unstated.

**`.cursor/rules/apps/dashboard.mdc`**
- Documented the actual Suspense split: RSC prefetch boundaries use `<Suspense>` (one instance, `app/(dashboard)/page.tsx`), but client components with `useQuery` use manual `isLoading`/`!data` guards, not `useSuspenseQuery`. Also documented that `components/app/` and `components/shared/` have no barrel `index.ts` — direct imports only.

**`.cursor/rules/01-naming-conventions.mdc`**
- Added `type Props` (never `interface Props`) — confirmed across every dashboard component checked, zero `interface` hits.
- Added the Zod v4 top-level string-format rule (`z.email()`, `z.url()`, `z.uuid()`) over the old `.string().email()` chain — the schemas directory is otherwise consistent on `z.infer`/discriminated unions, with exactly one file (`waitlist/input.ts`) still on the old form.

## What I deliberately left out

- `CREATE INDEX CONCURRENTLY` guidance for large-table pgvector indexes — no evidence in this repo of a table large enough to need it yet; would have been aspirational.
- Pushing oRPC's `.errors()` typed-error builder — the repo consistently uses bare `ORPCError` with codes instead, which works fine; adopting `.errors()` would be a design change, not a documentation gap.
- Redundant `globalEnv`/`globalPassThroughEnv` duplication in `turbo.json` — real, but a cleanup nit rather than a convention worth codifying.

## Test plan

- [ ] Skim each edited `.mdc` file renders/reads correctly
- [ ] No app code touched — diff is `.cursor/rules/**` only