### PR TITLE
perf: skip Vercel builds when app's dependency subtree is unchanged

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"ignoreCommand": "npx turbo-ignore"
+}

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"ignoreCommand": "npx turbo-ignore"
+}


### PR DESCRIPTION
Only two Vercel projects exist for this monorepo (\`harmonia-api\`, rootDirectory \`apps/api\`; \`harmonia-dashboard\`, rootDirectory \`apps/dashboard\`) — confirmed via \`vercel project ls\`, and matches the two Vercel status checks that show up on every PR.

Right now both rebuild on every push regardless of what actually changed. Adds \`ignoreCommand: "npx turbo-ignore"\` to each app's \`vercel.json\`. \`turbo-ignore\` (Vercel's own package) reads the Turborepo dependency graph, checks it against the last successful deployment for that project, and skips the build entirely if nothing in that app's actual dependency subtree changed — e.g. a \`web\`-only or \`admin\`-only change should no longer trigger an api/dashboard rebuild.

Confirmed \`apps/api/package.json\` and \`apps/dashboard/package.json\` names ("api", "dashboard") match what \`turbo-ignore\` auto-detects from cwd during a Vercel build, so no extra workspace argument needed.

Complements #154 (CI: Turborepo remote cache) — different problem: that one speeds up work that still has to happen, this one skips work that doesn't need to happen at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration for the API and dashboard applications.
  * Improved deployment change detection to help skip unnecessary builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->