### PR TITLE
feat(brain): update playlists in place instead of delete-and-recreate

### DIFF
--- a/apps/api/src/trigger/organize.ts
+++ b/apps/api/src/trigger/organize.ts
@@ -17,6 +17,7 @@ export {
 	embedStageTask,
 	embedWorkerTask,
 } from "@harmonia/common/trigger/tasks/stages/embed";
+export { exportStageTask } from "@harmonia/common/trigger/tasks/stages/export";
 export { generateStageTask } from "@harmonia/common/trigger/tasks/stages/generate";
 export {
 	lyricsStageTask,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -35,6 +35,9 @@
 		"./trigger/tasks/stages/match": {
 			"default": "./src/trigger/tasks/stages/match.ts"
 		},
+		"./trigger/tasks/stages/export": {
+			"default": "./src/trigger/tasks/stages/export.ts"
+		},
 		"./trigger/tasks/emails/send-organize-complete": {
 			"default": "./src/trigger/tasks/emails/send-organize-complete.ts"
 		},

--- a/packages/common/src/schemas/organize/output.ts
+++ b/packages/common/src/schemas/organize/output.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const organizeRunResultSchema = z.object({
 	userId: z.string(),
 	runId: z.number(),
-	status: z.enum(["completed", "partial", "failed", "cancelled"]),
+	status: z.enum(["completed", "partial", "failed", "cancelled", "skipped"]),
 	error: z.string().optional(),
 });
 export type OrganizeRunResult = z.infer<typeof organizeRunResultSchema>;

--- a/packages/common/src/services/brain/__tests__/playlist-matcher.test.ts
+++ b/packages/common/src/services/brain/__tests__/playlist-matcher.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	jaccardSimilarity,
+	matchClustersToPlaylists,
+} from "../playlist-matcher";
+
+function ids(...n: number[]): Set<string> {
+	return new Set(n.map((i) => `t${i}`));
+}
+
+describe("jaccardSimilarity", () => {
+	it("is 1 for two empty sets", () => {
+		expect(jaccardSimilarity(new Set(), new Set())).toBe(1);
+	});
+
+	it("is 0 for disjoint sets", () => {
+		expect(jaccardSimilarity(ids(1, 2, 3), ids(4, 5, 6))).toBe(0);
+	});
+
+	it("is 1 for identical sets", () => {
+		expect(jaccardSimilarity(ids(1, 2, 3), ids(1, 2, 3))).toBe(1);
+	});
+
+	it("computes partial overlap correctly", () => {
+		// {1,2,3,4} vs {3,4,5,6} -> intersection 2, union 6
+		expect(jaccardSimilarity(ids(1, 2, 3, 4), ids(3, 4, 5, 6))).toBeCloseTo(
+			2 / 6,
+		);
+	});
+
+	it("penalizes asymmetric size where overlap-coefficient would not", () => {
+		// A 10-track cluster sharing 8 tracks with an unrelated 75-track playlist
+		// scores LOW under Jaccard (correctly, since 67 of the playlist's tracks
+		// are unrelated), even though overlap-coefficient (8/min(10,75)=0.8)
+		// would misleadingly call this a strong match.
+		const cluster = ids(...Array.from({ length: 10 }, (_, i) => i));
+		const bigUnrelatedPlaylist = ids(
+			...Array.from({ length: 75 }, (_, i) => (i < 8 ? i : i + 100)),
+		);
+		const similarity = jaccardSimilarity(cluster, bigUnrelatedPlaylist);
+		// intersection=8, union=10+75-8=77
+		expect(similarity).toBeCloseTo(8 / 77);
+		expect(similarity).toBeLessThan(0.15);
+	});
+});
+
+describe("matchClustersToPlaylists", () => {
+	it("returns no matches when there are no existing playlists (first run)", () => {
+		const clusters = [{ clusterIndex: 0, trackIds: ids(1, 2, 3) }];
+		expect(matchClustersToPlaylists(clusters, [], 0.5)).toEqual([]);
+	});
+
+	it("matches a cluster with high overlap to its prior playlist", () => {
+		// old playlist 60 tracks, new cluster is 58 of those + 2 new ones
+		const oldIds = Array.from({ length: 60 }, (_, i) => i);
+		const newIds = [...oldIds.slice(0, 58), 1000, 1001];
+		const clusters = [{ clusterIndex: 0, trackIds: ids(...newIds) }];
+		const playlists = [{ playlistId: 42, trackIds: ids(...oldIds) }];
+
+		const matches = matchClustersToPlaylists(clusters, playlists, 0.5);
+		expect(matches).toHaveLength(1);
+		expect(matches[0]).toMatchObject({ clusterIndex: 0, playlistId: 42 });
+		expect(matches[0]?.similarity).toBeGreaterThan(0.9);
+	});
+
+	it("does not match when overlap is below threshold (genuinely new cluster)", () => {
+		const clusters = [{ clusterIndex: 0, trackIds: ids(1, 2, 3, 4, 5) }];
+		const playlists = [{ playlistId: 1, trackIds: ids(100, 101, 102) }];
+		expect(matchClustersToPlaylists(clusters, playlists, 0.5)).toEqual([]);
+	});
+
+	it("resolves a clean 50/50 split deterministically by larger absolute overlap", () => {
+		// Old playlist of 80 tracks splits into two new clusters of 40 each.
+		// Both have similarity 0.5 against the old playlist (subset relationship:
+		// intersection=40, union=80). Larger cluster should win the tie.
+		const oldIds = Array.from({ length: 80 }, (_, i) => i);
+		const clusterA = { clusterIndex: 0, trackIds: ids(...oldIds.slice(0, 40)) };
+		const clusterB = {
+			clusterIndex: 1,
+			trackIds: ids(...oldIds.slice(40, 80)),
+		};
+		const playlists = [{ playlistId: 1, trackIds: ids(...oldIds) }];
+
+		const matches = matchClustersToPlaylists(
+			[clusterA, clusterB],
+			playlists,
+			0.5,
+		);
+		// Both have identical similarity AND identical intersection size (40 vs 40)
+		// in this perfectly even split - so the final tie-break (clusterIndex) applies.
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.clusterIndex).toBe(0);
+		expect(matches[0]?.playlistId).toBe(1);
+		// Re-running with the same input must produce the same result (determinism).
+		const rerun = matchClustersToPlaylists(
+			[clusterA, clusterB],
+			playlists,
+			0.5,
+		);
+		expect(rerun).toEqual(matches);
+	});
+
+	it("prefers the cluster with larger absolute overlap on an uneven split", () => {
+		const oldIds = Array.from({ length: 80 }, (_, i) => i);
+		const bigHalf = { clusterIndex: 0, trackIds: ids(...oldIds.slice(0, 50)) };
+		const smallHalf = {
+			clusterIndex: 1,
+			trackIds: ids(...oldIds.slice(50, 80)),
+		};
+		const playlists = [{ playlistId: 1, trackIds: ids(...oldIds) }];
+
+		// bigHalf: intersection=50, union=80 -> 0.625
+		// smallHalf: intersection=30, union=80 -> 0.375
+		const matches = matchClustersToPlaylists(
+			[smallHalf, bigHalf],
+			playlists,
+			0.3,
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.clusterIndex).toBe(0); // bigHalf wins on higher similarity
+	});
+
+	it("assigns greedily so no cluster or playlist is matched twice", () => {
+		const clusterA = { clusterIndex: 0, trackIds: ids(1, 2, 3, 4) };
+		const clusterB = { clusterIndex: 1, trackIds: ids(1, 2, 3, 5) };
+		const playlistX = { playlistId: 10, trackIds: ids(1, 2, 3, 4) }; // identical to A
+		const playlistY = { playlistId: 20, trackIds: ids(1, 2, 3, 6) };
+
+		const matches = matchClustersToPlaylists(
+			[clusterA, clusterB],
+			[playlistX, playlistY],
+			0.3,
+		);
+
+		const usedClusters = new Set(matches.map((m) => m.clusterIndex));
+		const usedPlaylists = new Set(matches.map((m) => m.playlistId));
+		expect(usedClusters.size).toBe(matches.length);
+		expect(usedPlaylists.size).toBe(matches.length);
+		// clusterA <-> playlistX is the strongest pair (identical sets) and must win
+		expect(
+			matches.some((m) => m.clusterIndex === 0 && m.playlistId === 10),
+		).toBe(true);
+	});
+
+	it("leaves an existing playlist unmatched (orphaned) when no cluster is close enough", () => {
+		const clusters = [{ clusterIndex: 0, trackIds: ids(1, 2, 3) }];
+		const playlists = [
+			{ playlistId: 1, trackIds: ids(1, 2, 3) },
+			{ playlistId: 2, trackIds: ids(100, 101, 102) }, // no matching cluster this run
+		];
+		const matches = matchClustersToPlaylists(clusters, playlists, 0.5);
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.playlistId).toBe(1);
+	});
+});

--- a/packages/common/src/services/brain/playlist-generator.ts
+++ b/packages/common/src/services/brain/playlist-generator.ts
@@ -18,16 +18,47 @@ import { env } from "@harmonia/env/server";
 import { logger } from "@harmonia/logger";
 import { llml } from "@zenbase/llml";
 import { generateText, Output } from "ai";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import pLimit from "p-limit";
 import pRetry from "p-retry";
 import { parseJsonStringArray } from "../../utils/parse-json-string-array";
+import {
+	jaccardSimilarity,
+	matchClustersToPlaylists,
+} from "./playlist-matcher";
+
+// Below this track-overlap similarity, a cluster is treated as unrelated to
+// any existing playlist and gets a brand new one instead of an update.
+const PLAYLIST_MATCH_THRESHOLD = 0.5;
+
+// Below this track-overlap similarity between a matched playlist's old and
+// new track set, regenerate the LLM name/description — the content changed
+// enough that the old name may no longer fit. At or above it, keep the
+// existing name (avoids repeatedly re-naming a barely-changed playlist, and
+// saves the LLM call).
+const PLAYLIST_METADATA_REGEN_THRESHOLD = 0.8;
+
+type TrackRow = {
+	id: string;
+	name: string;
+	artistNames: string | null;
+	llmMood: string | null;
+	llmTags: unknown;
+};
+
+// GenerateProgress declares updatedPlaylistIds optional (other producers of
+// this shape may omit it); this function always populates it.
+type GenerateResult = GenerateProgress & { updatedPlaylistIds: number[] };
 
 export async function generatePlaylists(
 	userId: string,
-	onProgress?: (progress: GenerateProgress) => Promise<void>,
-): Promise<GenerateProgress> {
-	const stats: GenerateProgress = { playlists: 0, tracksOrganized: 0 };
+	onProgress?: (progress: GenerateResult) => Promise<void>,
+): Promise<GenerateResult> {
+	const stats: GenerateResult = {
+		playlists: 0,
+		tracksOrganized: 0,
+		updatedPlaylistIds: [],
+	};
 
 	if (!env.HARMONIA_GROQ_API_KEY) {
 		logger.warn(
@@ -47,16 +78,44 @@ export async function generatePlaylists(
 		return stats;
 	}
 
-	await db
-		.delete(playlist)
+	// Existing Harmonia playlists + their current track membership, so new
+	// clusters can be matched against them instead of every run recreating
+	// everything from scratch (issue #158). Fetched up front, before any
+	// per-cluster LLM/DB work, since matching needs the full picture at once.
+	const existingPlaylistRows = await db
+		.select({ id: playlist.id })
+		.from(playlist)
 		.where(and(eq(playlist.userId, userId), eq(playlist.isGenerated, true)));
 
-	const genLimit = pLimit(5);
+	const existingTrackSetsByPlaylist = new Map<number, Set<string>>();
+	for (const p of existingPlaylistRows) {
+		existingTrackSetsByPlaylist.set(p.id, new Set());
+	}
+	if (existingPlaylistRows.length > 0) {
+		const existingTrackRows = await db
+			.select({
+				playlistId: playlistTracks.playlistId,
+				trackId: playlistTracks.trackId,
+			})
+			.from(playlistTracks)
+			.where(
+				inArray(
+					playlistTracks.playlistId,
+					existingPlaylistRows.map((p) => p.id),
+				),
+			);
+		for (const row of existingTrackRows) {
+			existingTrackSetsByPlaylist.get(row.playlistId)?.add(row.trackId);
+		}
+	}
 
-	await Promise.all(
+	// Fetch each cluster's track rows up front (parallelized) so matching can
+	// run before the per-cluster generation loop decides create vs. update.
+	const fetchLimit = pLimit(5);
+	const clusterTrackRows = await Promise.all(
 		clusters.map((c) =>
-			genLimit(async () => {
-				const trackRows = await db
+			fetchLimit(async () => {
+				const rows = await db
 					.select({
 						id: track.id,
 						name: track.name,
@@ -68,156 +127,350 @@ export async function generatePlaylists(
 					.innerJoin(track, eq(track.id, clusterTracks.trackId))
 					.where(eq(clusterTracks.clusterId, c.id))
 					.orderBy(clusterTracks.position);
+				return { clusterId: c.id, rows };
+			}),
+		),
+	);
+	const trackRowsByClusterId = new Map(
+		clusterTrackRows.map((c) => [c.clusterId, c.rows]),
+	);
 
+	const matches = matchClustersToPlaylists(
+		clusters
+			.map((c, clusterIndex) => ({
+				clusterIndex,
+				trackIds: new Set(
+					(trackRowsByClusterId.get(c.id) ?? []).map((t) => t.id),
+				),
+			}))
+			.filter((c) => c.trackIds.size > 0),
+		existingPlaylistRows.map((p) => ({
+			playlistId: p.id,
+			trackIds: existingTrackSetsByPlaylist.get(p.id) ?? new Set(),
+		})),
+		PLAYLIST_MATCH_THRESHOLD,
+	);
+	const matchedPlaylistIdByClusterIndex = new Map(
+		matches.map((m) => [m.clusterIndex, m.playlistId]),
+	);
+
+	const genLimit = pLimit(5);
+
+	await Promise.all(
+		clusters.map((c, clusterIndex) =>
+			genLimit(async () => {
+				const trackRows = trackRowsByClusterId.get(c.id) ?? [];
 				if (trackRows.length === 0) return;
 
-				const meta = c.metadata as ClusterMeta | null;
+				const matchedPlaylistId =
+					matchedPlaylistIdByClusterIndex.get(clusterIndex);
 
-				const sampleTracks = trackRows.slice(0, 8).map((t) => {
-					const artists = parseJsonStringArray(t.artistNames);
-					return `${t.name} by ${artists.join(", ")}`;
-				});
-
-				const moods: string[] = [];
-				const themes: string[] = [];
-				const vibes: string[] = [];
-				for (const t of trackRows) {
-					if (t.llmMood) moods.push(t.llmMood);
-					const tags = getLlmTags(t.llmTags);
-					if (tags.themes) themes.push(...tags.themes);
-					if (tags.vibe) vibes.push(...tags.vibe);
+				if (matchedPlaylistId !== undefined) {
+					const updated = await updateExistingPlaylist({
+						playlistId: matchedPlaylistId,
+						clusterId: c.id,
+						meta: c.metadata as ClusterMeta | null,
+						trackRows,
+						oldTrackIds:
+							existingTrackSetsByPlaylist.get(matchedPlaylistId) ?? new Set(),
+					});
+					if (updated) {
+						stats.playlists++;
+						stats.tracksOrganized += trackRows.length;
+						stats.updatedPlaylistIds.push(matchedPlaylistId);
+						await onProgress?.(stats);
+					}
+					return;
 				}
 
-				try {
-					const generated = await pRetry(
-						async () => {
-							const clusterInfo: Record<string, string | number> = {
-								mood: meta
-									? meta.dominantMood
-									: [...new Set(moods)].slice(0, 5).join(", "),
-								topThemes:
-									[...new Set(themes)].slice(0, 5).join(", ") || "various",
-								topVibes:
-									[...new Set(vibes)].slice(0, 5).join(", ") || "various",
-								trackCount: trackRows.length,
-								sampleTracks: sampleTracks.join("; "),
-							};
-							if (meta?.themeSummary) clusterInfo.theme = meta.themeSummary;
-							if (meta?.dominantEnergy)
-								clusterInfo.energy = meta.dominantEnergy;
-							if (meta?.suggestedArchetype)
-								clusterInfo.archetype = meta.suggestedArchetype;
-
-							const groq = createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY });
-							const { output } = await generateText({
-								model: groq("openai/gpt-oss-120b"),
-								output: Output.object({ schema: playlistMetadataSchema }),
-								temperature: 0,
-								prompt: llml({
-									role: "You are a creative music curator generating a playlist from a cluster of similar tracks.",
-									clusterInfo,
-									generate: [
-										"name: a creative, evocative playlist name (2-4 words, no generic names like 'My Playlist')",
-										"description: one short sentence (10-15 words max) capturing the vibe — no filler phrases",
-										"taxonomy: mood | situation | genre | hybrid",
-										"coverColor: a hex color code that matches the playlist vibe (e.g. #1a1a2e for dark moody, #ff6b6b for energetic)",
-									],
-								}),
-							});
-							return output;
-						},
-						{
-							retries: 2,
-							minTimeout: 2000,
-							onFailedAttempt: (error) => {
-								logger.warn(
-									{ clusterId: c.id, attempt: error.attemptNumber },
-									"Playlist metadata generation failed, retrying",
-								);
-							},
-						},
-					);
-
-					const tags = [
-						...new Set(meta?.topVibes?.length ? meta.topVibes : vibes),
-					]
-						.slice(0, 3)
-						.map((t) => t.toLowerCase());
-
-					const [inserted] = await db
-						.insert(playlist)
-						.values({
-							userId,
-							name: generated.name,
-							aiGeneratedName: generated.name,
-							description: generated.description,
-							theme: meta?.themeSummary ?? null,
-							taxonomy: generated.taxonomy,
-							genreDomainId: c.genreDomainId,
-							coverColor: generated.coverColor,
-							tags: tags.length > 0 ? tags : null,
-							trackCount: trackRows.length,
-							isGenerated: true,
-							updatedAt: new Date(),
-						})
-						.returning({ id: playlist.id });
-
-					if (!inserted) return;
-
-					await db.insert(playlistClusters).values({
-						playlistId: inserted.id,
-						clusterId: c.id,
-						position: 0,
-						weight: 1.0,
-					});
-
-					const orderedTracks = orderTracksByEnergy(trackRows);
-
-					const trackValues = orderedTracks.map((t, position) => ({
-						playlistId: inserted.id,
-						trackId: t.id,
-						position,
-					}));
-
-					if (trackValues.length > 0) {
-						const batchSize = 100;
-						for (let i = 0; i < trackValues.length; i += batchSize) {
-							await db
-								.insert(playlistTracks)
-								.values(trackValues.slice(i, i + batchSize));
-						}
-					}
-
+				const created = await createNewPlaylist({
+					userId,
+					clusterId: c.id,
+					genreDomainId: c.genreDomainId,
+					meta: c.metadata as ClusterMeta | null,
+					trackRows,
+				});
+				if (created) {
 					stats.playlists++;
-					stats.tracksOrganized += trackValues.length;
+					stats.tracksOrganized += trackRows.length;
 					await onProgress?.(stats);
-				} catch (err) {
-					logger.error(
-						{
-							clusterId: c.id,
-							error: err instanceof Error ? err.message : String(err),
-						},
-						"Failed to generate playlist for cluster",
-					);
 				}
 			}),
 		),
 	);
 
 	logger.info(
-		{ userId, playlists: stats.playlists },
+		{
+			userId,
+			playlists: stats.playlists,
+			updated: stats.updatedPlaylistIds.length,
+			created: stats.playlists - stats.updatedPlaylistIds.length,
+		},
 		"Completed playlist generation",
 	);
 
 	return stats;
 }
 
-function orderTracksByEnergy(
-	tracks: Array<{
-		id: string;
-		llmTags: unknown;
-	}>,
-): typeof tracks {
+async function updateExistingPlaylist(args: {
+	playlistId: number;
+	clusterId: number;
+	meta: ClusterMeta | null;
+	trackRows: TrackRow[];
+	oldTrackIds: Set<string>;
+}): Promise<boolean> {
+	const { playlistId, clusterId, meta, trackRows, oldTrackIds } = args;
+
+	const newTrackIds = new Set(trackRows.map((t) => t.id));
+	const similarity = jaccardSimilarity(oldTrackIds, newTrackIds);
+
+	// Identical membership (order-only differences aside) — nothing changed,
+	// skip the write entirely so an unchanged playlist doesn't get touched
+	// (and doesn't trigger a needless Spotify re-export downstream).
+	if (similarity === 1) return false;
+
+	const shouldRegenerateMetadata =
+		similarity < PLAYLIST_METADATA_REGEN_THRESHOLD;
+
+	let generatedMetadata: {
+		name: string;
+		description: string;
+		taxonomy: string;
+		coverColor: string;
+	} | null = null;
+
+	if (shouldRegenerateMetadata) {
+		try {
+			generatedMetadata = await generatePlaylistMetadata(meta, trackRows);
+		} catch (err) {
+			logger.error(
+				{
+					playlistId,
+					clusterId,
+					error: err instanceof Error ? err.message : String(err),
+				},
+				"Failed to regenerate playlist metadata during update; keeping existing name",
+			);
+		}
+	}
+
+	const orderedTracks = orderTracksByEnergy(trackRows);
+	const tags = deriveTags(meta, trackRows);
+
+	try {
+		await db.transaction(async (tx) => {
+			await tx
+				.update(playlist)
+				.set({
+					trackCount: orderedTracks.length,
+					...(generatedMetadata && {
+						name: generatedMetadata.name,
+						aiGeneratedName: generatedMetadata.name,
+						description: generatedMetadata.description,
+						theme: meta?.themeSummary ?? null,
+						taxonomy: generatedMetadata.taxonomy,
+						coverColor: generatedMetadata.coverColor,
+						tags: tags.length > 0 ? tags : null,
+					}),
+				})
+				.where(eq(playlist.id, playlistId));
+
+			// The cluster this playlist maps to is always this run's fresh
+			// cluster row — last run's playlistClusters row already cascade-
+			// deleted when runClustering() wiped last run's cluster table.
+			await tx.insert(playlistClusters).values({
+				playlistId,
+				clusterId,
+				position: 0,
+				weight: 1.0,
+			});
+
+			// No positional diff: nothing in the app lets a user reorder tracks
+			// within a Harmonia playlist (ordering is always algorithmic, via
+			// orderTracksByEnergy), so a full replace is equivalent to a diff
+			// here and considerably simpler.
+			await tx
+				.delete(playlistTracks)
+				.where(eq(playlistTracks.playlistId, playlistId));
+
+			if (orderedTracks.length > 0) {
+				const batchSize = 100;
+				for (let i = 0; i < orderedTracks.length; i += batchSize) {
+					await tx.insert(playlistTracks).values(
+						orderedTracks.slice(i, i + batchSize).map((t, position) => ({
+							playlistId,
+							trackId: t.id,
+							position: i + position,
+						})),
+					);
+				}
+			}
+		});
+	} catch (err) {
+		logger.error(
+			{
+				playlistId,
+				clusterId,
+				error: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to update existing playlist for cluster",
+		);
+		return false;
+	}
+
+	return true;
+}
+
+async function createNewPlaylist(args: {
+	userId: string;
+	clusterId: number;
+	genreDomainId: number;
+	meta: ClusterMeta | null;
+	trackRows: TrackRow[];
+}): Promise<boolean> {
+	const { userId, clusterId, genreDomainId, meta, trackRows } = args;
+
+	try {
+		const generated = await generatePlaylistMetadata(meta, trackRows);
+		const tags = deriveTags(meta, trackRows);
+		const orderedTracks = orderTracksByEnergy(trackRows);
+
+		const [inserted] = await db
+			.insert(playlist)
+			.values({
+				userId,
+				name: generated.name,
+				aiGeneratedName: generated.name,
+				description: generated.description,
+				theme: meta?.themeSummary ?? null,
+				taxonomy: generated.taxonomy,
+				genreDomainId,
+				coverColor: generated.coverColor,
+				tags: tags.length > 0 ? tags : null,
+				trackCount: orderedTracks.length,
+				isGenerated: true,
+				updatedAt: new Date(),
+			})
+			.returning({ id: playlist.id });
+
+		if (!inserted) return false;
+
+		await db.insert(playlistClusters).values({
+			playlistId: inserted.id,
+			clusterId,
+			position: 0,
+			weight: 1.0,
+		});
+
+		if (orderedTracks.length > 0) {
+			const batchSize = 100;
+			for (let i = 0; i < orderedTracks.length; i += batchSize) {
+				await db.insert(playlistTracks).values(
+					orderedTracks.slice(i, i + batchSize).map((t, position) => ({
+						playlistId: inserted.id,
+						trackId: t.id,
+						position: i + position,
+					})),
+				);
+			}
+		}
+
+		return true;
+	} catch (err) {
+		logger.error(
+			{
+				clusterId,
+				error: err instanceof Error ? err.message : String(err),
+			},
+			"Failed to generate playlist for cluster",
+		);
+		return false;
+	}
+}
+
+function deriveTags(meta: ClusterMeta | null, trackRows: TrackRow[]): string[] {
+	const vibes: string[] = [];
+	for (const t of trackRows) {
+		const tags = getLlmTags(t.llmTags);
+		if (tags.vibe) vibes.push(...tags.vibe);
+	}
+	return [...new Set(meta?.topVibes?.length ? meta.topVibes : vibes)]
+		.slice(0, 3)
+		.map((t) => t.toLowerCase());
+}
+
+async function generatePlaylistMetadata(
+	meta: ClusterMeta | null,
+	trackRows: TrackRow[],
+): Promise<{
+	name: string;
+	description: string;
+	taxonomy: string;
+	coverColor: string;
+}> {
+	const sampleTracks = trackRows.slice(0, 8).map((t) => {
+		const artists = parseJsonStringArray(t.artistNames);
+		return `${t.name} by ${artists.join(", ")}`;
+	});
+
+	const moods: string[] = [];
+	const themes: string[] = [];
+	const vibes: string[] = [];
+	for (const t of trackRows) {
+		if (t.llmMood) moods.push(t.llmMood);
+		const tags = getLlmTags(t.llmTags);
+		if (tags.themes) themes.push(...tags.themes);
+		if (tags.vibe) vibes.push(...tags.vibe);
+	}
+
+	return pRetry(
+		async () => {
+			const clusterInfo: Record<string, string | number> = {
+				mood: meta
+					? meta.dominantMood
+					: [...new Set(moods)].slice(0, 5).join(", "),
+				topThemes: [...new Set(themes)].slice(0, 5).join(", ") || "various",
+				topVibes: [...new Set(vibes)].slice(0, 5).join(", ") || "various",
+				trackCount: trackRows.length,
+				sampleTracks: sampleTracks.join("; "),
+			};
+			if (meta?.themeSummary) clusterInfo.theme = meta.themeSummary;
+			if (meta?.dominantEnergy) clusterInfo.energy = meta.dominantEnergy;
+			if (meta?.suggestedArchetype)
+				clusterInfo.archetype = meta.suggestedArchetype;
+
+			const groq = createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY });
+			const { output } = await generateText({
+				model: groq("openai/gpt-oss-120b"),
+				output: Output.object({ schema: playlistMetadataSchema }),
+				temperature: 0,
+				prompt: llml({
+					role: "You are a creative music curator generating a playlist from a cluster of similar tracks.",
+					clusterInfo,
+					generate: [
+						"name: a creative, evocative playlist name (2-4 words, no generic names like 'My Playlist')",
+						"description: one short sentence (10-15 words max) capturing the vibe — no filler phrases",
+						"taxonomy: mood | situation | genre | hybrid",
+						"coverColor: a hex color code that matches the playlist vibe (e.g. #1a1a2e for dark moody, #ff6b6b for energetic)",
+					],
+				}),
+			});
+			return output;
+		},
+		{
+			retries: 2,
+			minTimeout: 2000,
+			onFailedAttempt: (error) => {
+				logger.warn(
+					{ attempt: error.attemptNumber },
+					"Playlist metadata generation failed, retrying",
+				);
+			},
+		},
+	);
+}
+
+function orderTracksByEnergy(tracks: TrackRow[]): TrackRow[] {
 	const energyMap: Record<string, number> = {
 		"very low": 1,
 		low: 2,

--- a/packages/common/src/services/brain/playlist-generator.ts
+++ b/packages/common/src/services/brain/playlist-generator.ts
@@ -169,7 +169,7 @@ export async function generatePlaylists(
 					const updated = await updateExistingPlaylist({
 						playlistId: matchedPlaylistId,
 						clusterId: c.id,
-						meta: c.metadata as ClusterMeta | null,
+						meta: c.metadata,
 						trackRows,
 						oldTrackIds:
 							existingTrackSetsByPlaylist.get(matchedPlaylistId) ?? new Set(),
@@ -187,7 +187,7 @@ export async function generatePlaylists(
 					userId,
 					clusterId: c.id,
 					genreDomainId: c.genreDomainId,
-					meta: c.metadata as ClusterMeta | null,
+					meta: c.metadata,
 					trackRows,
 				});
 				if (created) {
@@ -278,12 +278,15 @@ async function updateExistingPlaylist(args: {
 			// The cluster this playlist maps to is always this run's fresh
 			// cluster row — last run's playlistClusters row already cascade-
 			// deleted when runClustering() wiped last run's cluster table.
-			await tx.insert(playlistClusters).values({
-				playlistId,
-				clusterId,
-				position: 0,
-				weight: 1.0,
-			});
+			// Upsert defensively: harmless if the row is already unique, but
+			// keeps this idempotent against any future retry path.
+			await tx
+				.insert(playlistClusters)
+				.values({ playlistId, clusterId, position: 0, weight: 1.0 })
+				.onConflictDoUpdate({
+					target: [playlistClusters.playlistId, playlistClusters.clusterId],
+					set: { position: 0, weight: 1.0 },
+				});
 
 			// No positional diff: nothing in the app lets a user reorder tracks
 			// within a Harmonia playlist (ordering is always algorithmic, via

--- a/packages/common/src/services/brain/playlist-matcher.ts
+++ b/packages/common/src/services/brain/playlist-matcher.ts
@@ -1,0 +1,113 @@
+export type ClusterCandidate = {
+	clusterIndex: number;
+	trackIds: Set<string>;
+};
+
+export type ExistingPlaylist = {
+	playlistId: number;
+	trackIds: Set<string>;
+};
+
+export type PlaylistMatch = {
+	clusterIndex: number;
+	playlistId: number;
+	similarity: number;
+};
+
+/**
+ * Jaccard similarity (|intersection| / |union|) between two track-ID sets.
+ * Chosen over the overlap coefficient (|intersection| / min(|A|,|B|)) because
+ * the coefficient is fooled by size asymmetry: a small cluster that happens to
+ * share most of its (few) tracks with one slice of a much larger playlist
+ * scores misleadingly high, even when that playlist is mostly unrelated
+ * content. Jaccard penalizes that by weighting the union, not just the
+ * smaller set.
+ */
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+	if (a.size === 0 && b.size === 0) return 1;
+	const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a];
+	let intersection = 0;
+	for (const id of smaller) {
+		if (larger.has(id)) intersection++;
+	}
+	const union = a.size + b.size - intersection;
+	return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Matches new clusters to existing playlists by track-overlap similarity,
+ * so a re-cluster updates the same playlist instead of creating a duplicate.
+ * Clustering is non-deterministic run-to-run (DBSCAN + k-means fallback), so
+ * cluster IDs can't be trusted to persist — this compares actual membership.
+ *
+ * Each cluster and each playlist is matched at most once (greedy, by
+ * descending similarity). A cluster with no match at or above `threshold`
+ * gets no entry in the result (caller creates a new playlist for it). An
+ * existing playlist with no match gets no entry either (caller leaves it
+ * untouched — see #158: deleting a playlist the user still has on Spotify
+ * just because this run's clustering moved past it is a worse failure mode
+ * than a temporarily stale one).
+ */
+export function matchClustersToPlaylists(
+	clusters: readonly ClusterCandidate[],
+	playlists: readonly ExistingPlaylist[],
+	threshold: number,
+): PlaylistMatch[] {
+	const candidates: Array<PlaylistMatch & { intersectionSize: number }> = [];
+
+	for (const c of clusters) {
+		for (const p of playlists) {
+			const similarity = jaccardSimilarity(c.trackIds, p.trackIds);
+			if (similarity < threshold) continue;
+			let intersectionSize = 0;
+			const [smaller, larger] =
+				c.trackIds.size <= p.trackIds.size
+					? [c.trackIds, p.trackIds]
+					: [p.trackIds, c.trackIds];
+			for (const id of smaller) {
+				if (larger.has(id)) intersectionSize++;
+			}
+			candidates.push({
+				clusterIndex: c.clusterIndex,
+				playlistId: p.playlistId,
+				similarity,
+				intersectionSize,
+			});
+		}
+	}
+
+	// Deterministic tie-break so re-running identical input gives identical
+	// output: highest similarity first; ties broken by larger absolute overlap
+	// (more shared tracks = more meaningful continuity, e.g. when a cluster
+	// cleanly bisects and both halves score similarity 0.5 against the
+	// original); remaining ties broken by playlist ID then cluster index.
+	candidates.sort((a, b) => {
+		if (b.similarity !== a.similarity) return b.similarity - a.similarity;
+		if (b.intersectionSize !== a.intersectionSize)
+			return b.intersectionSize - a.intersectionSize;
+		if (a.playlistId !== b.playlistId) return a.playlistId - b.playlistId;
+		return a.clusterIndex - b.clusterIndex;
+	});
+
+	const usedClusters = new Set<number>();
+	const usedPlaylists = new Set<number>();
+	const result: PlaylistMatch[] = [];
+
+	for (const cand of candidates) {
+		if (
+			usedClusters.has(cand.clusterIndex) ||
+			usedPlaylists.has(cand.playlistId)
+		) {
+			continue;
+		}
+		usedClusters.add(cand.clusterIndex);
+		usedPlaylists.add(cand.playlistId);
+		result.push({
+			clusterIndex: cand.clusterIndex,
+			playlistId: cand.playlistId,
+			similarity: cand.similarity,
+		});
+	}
+
+	return result;
+}

--- a/packages/common/src/services/brain/track-matcher.ts
+++ b/packages/common/src/services/brain/track-matcher.ts
@@ -11,9 +11,14 @@ import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
 import { TRACK_MATCH_SIMILARITY_THRESHOLD } from "../../constants/brain";
 
+export type TrackMatchResult = {
+	matched: number;
+	touchedPlaylistIds: number[];
+};
+
 export async function matchNewTracksToPlaylists(
 	userId: string,
-): Promise<number> {
+): Promise<TrackMatchResult> {
 	const playlists = await db
 		.select({
 			id: playlist.id,
@@ -30,7 +35,7 @@ export async function matchNewTracksToPlaylists(
 			{ userId },
 			"No playlists with centroids; skipping track matching",
 		);
-		return 0;
+		return { matched: 0, touchedPlaylistIds: [] };
 	}
 
 	const existingAssignments = await db
@@ -60,10 +65,11 @@ export async function matchNewTracksToPlaylists(
 
 	if (tracksToMatch.length === 0) {
 		logger.info({ userId }, "No unassigned tracks to match");
-		return 0;
+		return { matched: 0, touchedPlaylistIds: [] };
 	}
 
 	let matched = 0;
+	const touchedPlaylistIds = new Set<number>();
 
 	for (const t of tracksToMatch) {
 		const embedding = t.embedding as number[];
@@ -104,22 +110,20 @@ export async function matchNewTracksToPlaylists(
 				.onConflictDoNothing();
 
 			matched++;
+			touchedPlaylistIds.add(bestPlaylistId);
 		}
 	}
 
-	if (matched > 0) {
-		const playlistIds = [...new Set(playlists.map((p) => p.id))];
-		for (const pid of playlistIds) {
-			const [countResult] = await db
-				.select({ count: sql<number>`COUNT(*)` })
-				.from(playlistTracks)
-				.where(eq(playlistTracks.playlistId, pid));
+	for (const pid of touchedPlaylistIds) {
+		const [countResult] = await db
+			.select({ count: sql<number>`COUNT(*)` })
+			.from(playlistTracks)
+			.where(eq(playlistTracks.playlistId, pid));
 
-			await db
-				.update(playlist)
-				.set({ trackCount: countResult?.count ?? 0 })
-				.where(eq(playlist.id, pid));
-		}
+		await db
+			.update(playlist)
+			.set({ trackCount: countResult?.count ?? 0 })
+			.where(eq(playlist.id, pid));
 	}
 
 	logger.info(
@@ -127,7 +131,7 @@ export async function matchNewTracksToPlaylists(
 		"Completed track-to-playlist matching",
 	);
 
-	return matched;
+	return { matched, touchedPlaylistIds: [...touchedPlaylistIds] };
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {

--- a/packages/common/src/services/music/index.ts
+++ b/packages/common/src/services/music/index.ts
@@ -2,6 +2,7 @@ export {
 	fetchLyricsForPendingTracks,
 	fetchLyricsForTrackIds,
 } from "./lyrics/fetch-lyrics";
+export { autoExportUpdatedPlaylists } from "./spotify/auto-export";
 export { getUserSpotifyAccessToken } from "./spotify/client";
 export {
 	exportAllPlaylists,

--- a/packages/common/src/services/music/spotify/auto-export.ts
+++ b/packages/common/src/services/music/spotify/auto-export.ts
@@ -1,0 +1,71 @@
+import { db } from "@harmonia/db";
+import { playlist } from "@harmonia/db/schema/playlist";
+import { logger } from "@harmonia/logger";
+import { and, inArray, isNotNull } from "drizzle-orm";
+
+import { exportPlaylistToSpotify } from "./export";
+
+export type AutoExportResult = {
+	exported: number;
+	failed: number;
+};
+
+/**
+ * Pushes this run's playlist changes to Spotify automatically — but ONLY for
+ * playlists the user has already manually exported at least once
+ * (`spotifyPlaylistId` set). A playlist the user has never exported is left
+ * database-only; exporting is what opts a playlist into ongoing automatic
+ * updates, not something this pipeline decides on its own. Never creates a
+ * new Spotify playlist — `exportPlaylistToSpotify` only takes the
+ * update-in-place branch here, by construction (only already-exported
+ * playlists are passed in).
+ */
+export async function autoExportUpdatedPlaylists(
+	userId: string,
+	touchedPlaylistIds: readonly number[],
+): Promise<AutoExportResult> {
+	if (touchedPlaylistIds.length === 0) {
+		return { exported: 0, failed: 0 };
+	}
+
+	const alreadyExported = await db
+		.select({ id: playlist.id })
+		.from(playlist)
+		.where(
+			and(
+				inArray(playlist.id, [...touchedPlaylistIds]),
+				isNotNull(playlist.spotifyPlaylistId),
+			),
+		);
+
+	let exported = 0;
+	let failed = 0;
+
+	for (const { id } of alreadyExported) {
+		try {
+			const result = await exportPlaylistToSpotify(userId, id);
+			if (result) {
+				exported++;
+			} else {
+				failed++;
+			}
+		} catch (err) {
+			logger.error(
+				{
+					userId,
+					playlistId: id,
+					error: err instanceof Error ? err.message : String(err),
+				},
+				"Auto-export to Spotify failed for playlist",
+			);
+			failed++;
+		}
+	}
+
+	logger.info(
+		{ userId, exported, failed, candidates: touchedPlaylistIds.length },
+		"Completed automatic Spotify export for updated playlists",
+	);
+
+	return { exported, failed };
+}

--- a/packages/common/src/trigger/tasks/organize.ts
+++ b/packages/common/src/trigger/tasks/organize.ts
@@ -10,6 +10,7 @@ import { sendOrganizeCompleteEmailTask } from "./emails/send-organize-complete";
 import { classifyStageTask } from "./stages/classify";
 import { clusterStageTask } from "./stages/cluster";
 import { embedStageTask } from "./stages/embed";
+import { exportStageTask } from "./stages/export";
 import { generateStageTask } from "./stages/generate";
 import { lyricsStageTask } from "./stages/lyrics";
 import { matchStageTask } from "./stages/match";
@@ -132,6 +133,22 @@ export const organizePipeline = task({
 				runId,
 			});
 
+			// Only playlists actually touched this run (created/updated by
+			// generate, or appended to by match) are candidates for auto-export —
+			// autoExportUpdatedPlaylists further restricts this to playlists the
+			// user has already manually exported at least once.
+			const touchedPlaylistIds = [
+				...new Set([
+					...(generateRun.ok ? generateRun.output.updatedPlaylistIds : []),
+					...(matchRun.ok ? matchRun.output.touchedPlaylistIds : []),
+				]),
+			];
+			const exportRun = await exportStageTask.triggerAndWait({
+				userId,
+				runId,
+				playlistIds: touchedPlaylistIds,
+			});
+
 			// Any stage that resolved with ok:false (exhausted retries, no
 			// throw) is a hard failure of the run and must not be surfaced as
 			// a clean success.
@@ -143,6 +160,7 @@ export const organizePipeline = task({
 			if (!clusterRun.ok) stageFailures.push("cluster");
 			if (!generateRun.ok) stageFailures.push("generate");
 			if (!matchRun.ok) stageFailures.push("match");
+			if (!exportRun.ok) stageFailures.push("export");
 
 			const outcome = assessRunOutcome({
 				classify: classifyRun.ok ? classifyRun.output : undefined,

--- a/packages/common/src/trigger/tasks/stages/export.ts
+++ b/packages/common/src/trigger/tasks/stages/export.ts
@@ -1,0 +1,21 @@
+import { task } from "@trigger.dev/sdk";
+
+import { autoExportUpdatedPlaylists } from "../../../services/music";
+import { checkCancelled } from "../../../services/organize";
+
+export const exportStageTask = task({
+	id: "organize-stage-export",
+	retry: { maxAttempts: 2 },
+	run: async ({
+		userId,
+		runId,
+		playlistIds,
+	}: {
+		userId: string;
+		runId: number;
+		playlistIds: number[];
+	}) => {
+		await checkCancelled(runId, userId);
+		return await autoExportUpdatedPlaylists(userId, playlistIds);
+	},
+});

--- a/packages/common/src/trigger/tasks/stages/export.ts
+++ b/packages/common/src/trigger/tasks/stages/export.ts
@@ -1,11 +1,15 @@
 import { task } from "@trigger.dev/sdk";
 
 import { autoExportUpdatedPlaylists } from "../../../services/music";
-import { checkCancelled } from "../../../services/organize";
+import {
+	checkCancelled,
+	updateRun,
+	updateStageProgress,
+} from "../../../services/organize";
 
 export const exportStageTask = task({
 	id: "organize-stage-export",
-	retry: { maxAttempts: 2 },
+	retry: { maxAttempts: 2, minTimeoutInMs: 2000, factor: 2 },
 	run: async ({
 		userId,
 		runId,
@@ -16,6 +20,9 @@ export const exportStageTask = task({
 		playlistIds: number[];
 	}) => {
 		await checkCancelled(runId, userId);
-		return await autoExportUpdatedPlaylists(userId, playlistIds);
+		await updateRun(runId, { currentStage: "export" });
+		const result = await autoExportUpdatedPlaylists(userId, playlistIds);
+		await updateStageProgress(runId, "export", result);
+		return result;
 	},
 });

--- a/packages/common/src/types/pipeline.ts
+++ b/packages/common/src/types/pipeline.ts
@@ -41,6 +41,8 @@ export type ClusterProgress = {
 export type GenerateProgress = {
 	playlists: number;
 	tracksOrganized: number;
+	/** Playlist IDs created or updated in place this run (see #158) — export candidates. */
+	updatedPlaylistIds?: number[];
 };
 
 export type PipelineProgress = {

--- a/packages/common/src/types/pipeline.ts
+++ b/packages/common/src/types/pipeline.ts
@@ -41,7 +41,7 @@ export type ClusterProgress = {
 export type GenerateProgress = {
 	playlists: number;
 	tracksOrganized: number;
-	/** Playlist IDs created or updated in place this run (see #158) — export candidates. */
+	/** Existing playlist IDs updated in place this run (see #158) — export candidates. Excludes newly created playlists. */
 	updatedPlaylistIds?: number[];
 };
 

--- a/packages/db/src/migrations/0021_tearful_kabuki.sql
+++ b/packages/db/src/migrations/0021_tearful_kabuki.sql
@@ -1,0 +1,18 @@
+-- Clean up any pre-existing concurrent "running" rows before enforcing the
+-- index below — the race this migration fixes could already have left
+-- duplicates in place, which would make the CREATE UNIQUE INDEX fail.
+-- Keep only the most recently started "running" row per user; mark the rest
+-- failed rather than deleting them, so run history stays intact.
+UPDATE "pipeline_run"
+SET "status" = 'failed',
+    "error" = 'Superseded by a concurrent run for the same user (cleaned up when adding pipeline_run_one_running_per_user)',
+    "completed_at" = now()
+WHERE "status" = 'running'
+  AND "id" NOT IN (
+    SELECT DISTINCT ON ("user_id") "id"
+    FROM "pipeline_run"
+    WHERE "status" = 'running'
+    ORDER BY "user_id", "started_at" DESC NULLS LAST, "id" DESC
+  );
+--> statement-breakpoint
+CREATE UNIQUE INDEX "pipeline_run_one_running_per_user" ON "pipeline_run" USING btree ("user_id") WHERE "pipeline_run"."status" = 'running';

--- a/packages/db/src/migrations/meta/0021_snapshot.json
+++ b/packages/db/src/migrations/meta/0021_snapshot.json
@@ -1,0 +1,2402 @@
+{
+	"id": "4d61a681-01cf-46fd-830d-e23f262d0d72",
+	"prevId": "5bbb4573-c1d0-463b-9109-cd8620f95d4d",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_impersonated_by_user_id_fk": {
+					"name": "session_impersonated_by_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["impersonated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_completed_onboarding": {
+					"name": "has_completed_onboarding",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_approved": {
+					"name": "is_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character": {
+			"name": "character",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_user_id_user_id_fk": {
+					"name": "character_user_id_user_id_fk",
+					"tableFrom": "character",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_genre_domain_id_genre_domain_id_fk": {
+					"name": "character_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "character",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_clusters": {
+			"name": "character_clusters",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_clusters_character_id_character_id_fk": {
+					"name": "character_clusters_character_id_character_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_clusters_cluster_id_cluster_id_fk": {
+					"name": "character_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_clusters_character_id_cluster_id_pk": {
+					"name": "character_clusters_character_id_cluster_id_pk",
+					"columns": ["character_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_tracks": {
+			"name": "character_tracks",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_tracks_character_id_character_id_fk": {
+					"name": "character_tracks_character_id_character_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_tracks_track_id_track_id_fk": {
+					"name": "character_tracks_track_id_track_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_tracks_character_id_track_id_pk": {
+					"name": "character_tracks_character_id_track_id_pk",
+					"columns": ["character_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster": {
+			"name": "cluster",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"centroid": {
+					"name": "centroid",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_valence": {
+					"name": "avg_valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_energy": {
+					"name": "avg_energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_tempo": {
+					"name": "avg_tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"cluster_user_id_idx": {
+					"name": "cluster_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"cluster_user_id_user_id_fk": {
+					"name": "cluster_user_id_user_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_genre_domain_id_genre_domain_id_fk": {
+					"name": "cluster_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster_tracks": {
+			"name": "cluster_tracks",
+			"schema": "",
+			"columns": {
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cluster_tracks_cluster_id_cluster_id_fk": {
+					"name": "cluster_tracks_cluster_id_cluster_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_tracks_track_id_track_id_fk": {
+					"name": "cluster_tracks_track_id_track_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"cluster_tracks_cluster_id_track_id_pk": {
+					"name": "cluster_tracks_cluster_id_track_id_pk",
+					"columns": ["cluster_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_send_log": {
+			"name": "email_send_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"template_key": {
+					"name": "template_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"skip_reason": {
+					"name": "skip_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_message_id": {
+					"name": "provider_message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"email_send_log_user_id_idx": {
+					"name": "email_send_log_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_status_idx": {
+					"name": "email_send_log_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_template_key_idx": {
+					"name": "email_send_log_template_key_idx",
+					"columns": [
+						{
+							"expression": "template_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_created_at_idx": {
+					"name": "email_send_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_provider_message_id_idx": {
+					"name": "email_send_log_provider_message_id_idx",
+					"columns": [
+						{
+							"expression": "provider_message_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"email_send_log_user_id_user_id_fk": {
+					"name": "email_send_log_user_id_user_id_fk",
+					"tableFrom": "email_send_log",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_send_log_idempotency_key_unique": {
+					"name": "email_send_log_idempotency_key_unique",
+					"nullsNotDistinct": false,
+					"columns": ["idempotency_key"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_suppression": {
+			"name": "email_suppression",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suppressed_at": {
+					"name": "suppressed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"email_suppression_suppressed_at_idx": {
+					"name": "email_suppression_suppressed_at_idx",
+					"columns": [
+						{
+							"expression": "suppressed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_suppression_email_unique": {
+					"name": "email_suppression_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genre_domain": {
+			"name": "genre_domain",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"genre_domain_name_unique": {
+					"name": "genre_domain_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pipeline_run": {
+			"name": "pipeline_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"current_stage": {
+					"name": "current_stage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"progress": {
+					"name": "progress",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"pipeline_run_user_id_idx": {
+					"name": "pipeline_run_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_status_idx": {
+					"name": "pipeline_run_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_one_running_per_user": {
+					"name": "pipeline_run_one_running_per_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"pipeline_run\".\"status\" = 'running'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pipeline_run_user_id_user_id_fk": {
+					"name": "pipeline_run_user_id_user_id_fk",
+					"tableFrom": "pipeline_run",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist": {
+			"name": "playlist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_generated_name": {
+					"name": "ai_generated_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"taxonomy": {
+					"name": "taxonomy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_color": {
+					"name": "cover_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_count": {
+					"name": "track_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"exported_at": {
+					"name": "exported_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"playlist_user_id_idx": {
+					"name": "playlist_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"playlist_taxonomy_idx": {
+					"name": "playlist_taxonomy_idx",
+					"columns": [
+						{
+							"expression": "taxonomy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"playlist_user_id_user_id_fk": {
+					"name": "playlist_user_id_user_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_genre_domain_id_genre_domain_id_fk": {
+					"name": "playlist_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_clusters": {
+			"name": "playlist_clusters",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_clusters_playlist_id_playlist_id_fk": {
+					"name": "playlist_clusters_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_clusters_cluster_id_cluster_id_fk": {
+					"name": "playlist_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_clusters_playlist_id_cluster_id_pk": {
+					"name": "playlist_clusters_playlist_id_cluster_id_pk",
+					"columns": ["playlist_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_tracks": {
+			"name": "playlist_tracks",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_tracks_playlist_id_playlist_id_fk": {
+					"name": "playlist_tracks_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_tracks_track_id_track_id_fk": {
+					"name": "playlist_tracks_track_id_track_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_tracks_playlist_id_track_id_pk": {
+					"name": "playlist_tracks_playlist_id_track_id_pk",
+					"columns": ["playlist_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_item_artists": {
+			"name": "user_playlist_snapshot_item_artists",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_position": {
+					"name": "artist_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_name": {
+					"name": "artist_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_item_artists",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+					"columns": ["user_id", "playlist_id", "position", "artist_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_items": {
+			"name": "user_playlist_snapshot_items",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_name": {
+					"name": "track_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_uri": {
+					"name": "track_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_items_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_items",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+					"columns": ["user_id", "playlist_id", "position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshots": {
+			"name": "user_playlist_snapshots",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshots_user_id_user_id_fk": {
+					"name": "user_playlist_snapshots_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshots",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshots_user_id_playlist_id_pk": {
+					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
+					"columns": ["user_id", "playlist_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_spotify_library_stats": {
+			"name": "user_spotify_library_stats",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"total_tracks": {
+					"name": "total_tracks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_playlists": {
+					"name": "total_playlists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_albums": {
+					"name": "unique_albums",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_artists": {
+					"name": "unique_artists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_spotify_library_stats_user_id_user_id_fk": {
+					"name": "user_spotify_library_stats_user_id_user_id_fk",
+					"tableFrom": "user_spotify_library_stats",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track": {
+			"name": "track",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"spotify_uri": {
+					"name": "spotify_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_names": {
+					"name": "artist_names",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_image_url": {
+					"name": "album_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spotify_genres": {
+					"name": "spotify_genres",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"valence": {
+					"name": "valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy": {
+					"name": "energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"danceability": {
+					"name": "danceability",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tempo": {
+					"name": "tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acousticness": {
+					"name": "acousticness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instrumentalness": {
+					"name": "instrumentalness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"speechiness": {
+					"name": "speechiness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"liveness": {
+					"name": "liveness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics": {
+					"name": "lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_lyrics": {
+					"name": "synced_lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_instrumental": {
+					"name": "lyrics_instrumental",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lrclib_id": {
+					"name": "lrclib_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_fetched_at": {
+					"name": "lyrics_fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_status": {
+					"name": "lyrics_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_mood": {
+					"name": "llm_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_tags": {
+					"name": "llm_tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_classified_at": {
+					"name": "llm_classified_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_generated_at": {
+					"name": "embedding_generated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_input": {
+					"name": "embedding_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_assigned_at": {
+					"name": "domain_assigned_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"analysis_snapshot": {
+					"name": "analysis_snapshot",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"track_genre_domain_id_idx": {
+					"name": "track_genre_domain_id_idx",
+					"columns": [
+						{
+							"expression": "genre_domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_lyrics_status_idx": {
+					"name": "track_lyrics_status_idx",
+					"columns": [
+						{
+							"expression": "lyrics_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_embedding_idx": {
+					"name": "track_embedding_idx",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genre_domain_id_genre_domain_id_fk": {
+					"name": "track_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "track",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_tracks": {
+			"name": "user_tracks",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_tracks_user_id_idx": {
+					"name": "user_tracks_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_tracks_track_id_idx": {
+					"name": "user_tracks_track_id_idx",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_tracks_user_id_user_id_fk": {
+					"name": "user_tracks_user_id_user_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_tracks_track_id_track_id_fk": {
+					"name": "user_tracks_track_id_track_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_tracks_user_id_track_id_pk": {
+					"name": "user_tracks_user_id_track_id_pk",
+					"columns": ["user_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_email_preferences": {
+			"name": "user_email_preferences",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"transactional_enabled": {
+					"name": "transactional_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"product_updates_enabled": {
+					"name": "product_updates_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"marketing_enabled": {
+					"name": "marketing_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"feedback_enabled": {
+					"name": "feedback_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"consent_source": {
+					"name": "consent_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"consent_captured_at": {
+					"name": "consent_captured_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unsubscribed_at": {
+					"name": "unsubscribed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_email_preferences_user_id_user_id_fk": {
+					"name": "user_email_preferences_user_id_user_id_fk",
+					"tableFrom": "user_email_preferences",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.waitlist_signup": {
+			"name": "waitlist_signup",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "waitlist_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confirmation_email_sent_at": {
+					"name": "confirmation_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_email_sent_at": {
+					"name": "approval_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token": {
+					"name": "invite_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_raw": {
+					"name": "invite_token_raw",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_expires_at": {
+					"name": "invite_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_at": {
+					"name": "invite_redeemed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_by_user_id": {
+					"name": "invite_redeemed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"waitlist_signup_status_idx": {
+					"name": "waitlist_signup_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_created_at_idx": {
+					"name": "waitlist_signup_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_invite_token_idx": {
+					"name": "waitlist_signup_invite_token_idx",
+					"columns": [
+						{
+							"expression": "invite_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"waitlist_signup_invite_redeemed_by_user_id_user_id_fk": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_user_id_fk",
+					"tableFrom": "waitlist_signup",
+					"tableTo": "user",
+					"columnsFrom": ["invite_redeemed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"waitlist_signup_email_unique": {
+					"name": "waitlist_signup_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				},
+				"waitlist_signup_invite_token_unique": {
+					"name": "waitlist_signup_invite_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_token"]
+				},
+				"waitlist_signup_invite_redeemed_by_user_id_unique": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_redeemed_by_user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.waitlist_status": {
+			"name": "waitlist_status",
+			"schema": "public",
+			"values": ["pending", "approved", "rejected"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
 			"when": 1782081000000,
 			"tag": "0020_grandfather_user_approval",
 			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1785414495470,
+			"tag": "0021_tearful_kabuki",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/pipeline-run.ts
+++ b/packages/db/src/schema/pipeline-run.ts
@@ -70,9 +70,7 @@ export const pipelineRun = pgTable(
 	(table) => [
 		index("pipeline_run_user_id_idx").on(table.userId),
 		index("pipeline_run_status_idx").on(table.status),
-		// At most one running run per user — enforced at the DB level so two
-		// overlapping triggers (impatient re-click, cron overlapping a manual
-		// run) can't race to mutate the same playlists concurrently.
+		// At most one "running" row per user — prevents overlapping triggers from racing to update the same playlists.
 		uniqueIndex("pipeline_run_one_running_per_user")
 			.on(table.userId)
 			.where(sql`${table.status} = 'running'`),

--- a/packages/db/src/schema/pipeline-run.ts
+++ b/packages/db/src/schema/pipeline-run.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
 	index,
 	jsonb,
@@ -5,6 +6,7 @@ import {
 	serial,
 	text,
 	timestamp,
+	uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 import { user } from "./auth";
@@ -68,5 +70,11 @@ export const pipelineRun = pgTable(
 	(table) => [
 		index("pipeline_run_user_id_idx").on(table.userId),
 		index("pipeline_run_status_idx").on(table.status),
+		// At most one running run per user — enforced at the DB level so two
+		// overlapping triggers (impatient re-click, cron overlapping a manual
+		// run) can't race to mutate the same playlists concurrently.
+		uniqueIndex("pipeline_run_one_running_per_user")
+			.on(table.userId)
+			.where(sql`${table.status} = 'running'`),
 	],
 );

--- a/packages/orpc/src/routers/public/organize.ts
+++ b/packages/orpc/src/routers/public/organize.ts
@@ -14,16 +14,12 @@ import { and, eq } from "drizzle-orm";
 import { cronOrAuthProcedure } from "../../procedures";
 
 const RUNNING_CONSTRAINT_NAME = "pipeline_run_one_running_per_user";
+const MAX_INSERT_ATTEMPTS = 3;
 
 function isAlreadyRunningConflict(err: unknown): boolean {
-	return (
-		typeof err === "object" &&
-		err !== null &&
-		"code" in err &&
-		(err as { code?: unknown }).code === "23505" &&
-		"constraint" in err &&
-		(err as { constraint?: unknown }).constraint === RUNNING_CONSTRAINT_NAME
-	);
+	if (typeof err !== "object" || err === null) return false;
+	if (!("code" in err) || !("constraint" in err)) return false;
+	return err.code === "23505" && err.constraint === RUNNING_CONSTRAINT_NAME;
 }
 
 async function findRunningRunId(userId: string): Promise<number | null> {
@@ -34,6 +30,48 @@ async function findRunningRunId(userId: string): Promise<number | null> {
 			and(eq(pipelineRun.userId, userId), eq(pipelineRun.status, "running")),
 		);
 	return existing?.id ?? null;
+}
+
+type InsertRunResult =
+	| { kind: "created"; runId: number }
+	| { kind: "skipped"; runId: number };
+
+/**
+ * Inserts a new "running" pipeline_run row for the user, or reports the
+ * existing one if the unique-running-per-user constraint blocks it. If the
+ * conflicting run finishes between our insert attempt and the lookup (a
+ * narrow but real race), the constraint has cleared — retry the insert
+ * instead of dropping a valid request as "skipped".
+ */
+async function insertRunOrSkip(userId: string): Promise<InsertRunResult> {
+	for (let attempt = 0; attempt < MAX_INSERT_ATTEMPTS; attempt++) {
+		try {
+			const [inserted] = await db
+				.insert(pipelineRun)
+				.values({
+					userId,
+					status: "running",
+					currentStage: "sync",
+					startedAt: new Date(),
+				})
+				.returning({ id: pipelineRun.id });
+
+			if (!inserted) throw new Error("Failed to create run record");
+			return { kind: "created", runId: inserted.id };
+		} catch (err) {
+			if (!isAlreadyRunningConflict(err)) throw err;
+
+			const existingRunId = await findRunningRunId(userId);
+			if (existingRunId !== null) {
+				return { kind: "skipped", runId: existingRunId };
+			}
+			// Conflicting run finished between our insert and this lookup —
+			// loop around and retry the insert now that it should be clear.
+		}
+	}
+	throw new Error(
+		`Failed to create pipeline run for user ${userId} after ${MAX_INSERT_ATTEMPTS} attempts (repeatedly raced with another run)`,
+	);
 }
 
 /**
@@ -68,53 +106,39 @@ export const organizeRouter = {
 					});
 				}
 				try {
-					let run: { id: number };
-					try {
-						const [inserted] = await db
-							.insert(pipelineRun)
-							.values({
-								userId: context.userId,
-								status: "running",
-								currentStage: "sync",
-								startedAt: new Date(),
-							})
-							.returning({ id: pipelineRun.id });
+					const insertResult = await insertRunOrSkip(context.userId);
 
-						if (!inserted) throw new Error("Failed to create run record");
-						run = inserted;
-					} catch (insertErr) {
-						if (isAlreadyRunningConflict(insertErr)) {
-							const existingRunId = await findRunningRunId(context.userId);
-							logger.info(
-								{ userId: context.userId, existingRunId },
-								"organize.run skipped — a run is already in progress for this user",
-							);
-							return {
-								success: true,
-								results: [
-									{
-										userId: context.userId,
-										runId: existingRunId ?? -1,
-										status: "skipped",
-										error: "A pipeline run is already in progress",
-									},
-								],
-							};
-						}
-						throw insertErr;
+					if (insertResult.kind === "skipped") {
+						logger.info(
+							{ userId: context.userId, existingRunId: insertResult.runId },
+							"organize.run skipped — a run is already in progress for this user",
+						);
+						return {
+							success: true,
+							results: [
+								{
+									userId: context.userId,
+									runId: insertResult.runId,
+									status: "skipped",
+									error: "A pipeline run is already in progress",
+								},
+							],
+						};
 					}
+
+					const runId = insertResult.runId;
 
 					try {
 						await organizePipeline.trigger({
 							userId: context.userId,
-							runId: run.id,
+							runId,
 						});
 					} catch (triggerErr) {
 						const msg =
 							triggerErr instanceof Error
 								? triggerErr.message
 								: String(triggerErr);
-						await updateRun(run.id, {
+						await updateRun(runId, {
 							status: "failed",
 							error: msg,
 							completedAt: new Date(),
@@ -124,9 +148,7 @@ export const organizeRouter = {
 
 					return {
 						success: true,
-						results: [
-							{ userId: context.userId, runId: run.id, status: "completed" },
-						],
+						results: [{ userId: context.userId, runId, status: "completed" }],
 					};
 				} catch (err) {
 					const message =
@@ -147,61 +169,44 @@ export const organizeRouter = {
 
 			for (const { id } of users) {
 				try {
-					let run: { id: number };
-					try {
-						const [inserted] = await db
-							.insert(pipelineRun)
-							.values({
-								userId: id,
-								status: "running",
-								currentStage: "sync",
-								startedAt: new Date(),
-							})
-							.returning({ id: pipelineRun.id });
+					const insertResult = await insertRunOrSkip(id);
 
-						if (!inserted) throw new Error("Failed to create run record");
-						run = inserted;
-					} catch (insertErr) {
-						if (isAlreadyRunningConflict(insertErr)) {
-							const existingRunId = await findRunningRunId(id);
-							logger.info(
-								{ userId: id, existingRunId },
-								"organize.run skipped for user — a run is already in progress",
-							);
-							results.push({
-								userId: id,
-								runId: existingRunId ?? -1,
-								status: "skipped",
-								error: "A pipeline run is already in progress",
-							});
-							continue;
-						}
-						throw insertErr;
+					if (insertResult.kind === "skipped") {
+						logger.info(
+							{ userId: id, existingRunId: insertResult.runId },
+							"organize.run skipped for user — a run is already in progress",
+						);
+						results.push({
+							userId: id,
+							runId: insertResult.runId,
+							status: "skipped",
+							error: "A pipeline run is already in progress",
+						});
+						continue;
 					}
 
+					const runId = insertResult.runId;
+
 					try {
-						await organizePipeline.trigger({
-							userId: id,
-							runId: run.id,
-						});
-						results.push({ userId: id, runId: run.id, status: "completed" });
+						await organizePipeline.trigger({ userId: id, runId });
+						results.push({ userId: id, runId, status: "completed" });
 					} catch (triggerErr) {
 						const error =
 							triggerErr instanceof Error
 								? triggerErr
 								: new Error(String(triggerErr));
-						await updateRun(run.id, {
+						await updateRun(runId, {
 							status: "failed",
 							error: error.message,
 							completedAt: new Date(),
 						});
 						logger.error(
-							{ userId: id, runId: run.id, error: error.message },
+							{ userId: id, runId, error: error.message },
 							"Failed to queue organize for user",
 						);
 						results.push({
 							userId: id,
-							runId: run.id,
+							runId,
 							status: "failed",
 							error: error.message,
 						});

--- a/packages/orpc/src/routers/public/organize.ts
+++ b/packages/orpc/src/routers/public/organize.ts
@@ -9,8 +9,32 @@ import { user } from "@harmonia/db/schema/auth";
 import { pipelineRun } from "@harmonia/db/schema/pipeline-run";
 import { logger } from "@harmonia/logger";
 import { ORPCError } from "@orpc/server";
+import { and, eq } from "drizzle-orm";
 
 import { cronOrAuthProcedure } from "../../procedures";
+
+const RUNNING_CONSTRAINT_NAME = "pipeline_run_one_running_per_user";
+
+function isAlreadyRunningConflict(err: unknown): boolean {
+	return (
+		typeof err === "object" &&
+		err !== null &&
+		"code" in err &&
+		(err as { code?: unknown }).code === "23505" &&
+		"constraint" in err &&
+		(err as { constraint?: unknown }).constraint === RUNNING_CONSTRAINT_NAME
+	);
+}
+
+async function findRunningRunId(userId: string): Promise<number | null> {
+	const [existing] = await db
+		.select({ id: pipelineRun.id })
+		.from(pipelineRun)
+		.where(
+			and(eq(pipelineRun.userId, userId), eq(pipelineRun.status, "running")),
+		);
+	return existing?.id ?? null;
+}
 
 /**
  * Organize pipeline: syncs Spotify, fetches lyrics, classifies, embeds, clusters, generates playlists.
@@ -44,17 +68,41 @@ export const organizeRouter = {
 					});
 				}
 				try {
-					const [run] = await db
-						.insert(pipelineRun)
-						.values({
-							userId: context.userId,
-							status: "running",
-							currentStage: "sync",
-							startedAt: new Date(),
-						})
-						.returning({ id: pipelineRun.id });
+					let run: { id: number };
+					try {
+						const [inserted] = await db
+							.insert(pipelineRun)
+							.values({
+								userId: context.userId,
+								status: "running",
+								currentStage: "sync",
+								startedAt: new Date(),
+							})
+							.returning({ id: pipelineRun.id });
 
-					if (!run) throw new Error("Failed to create run record");
+						if (!inserted) throw new Error("Failed to create run record");
+						run = inserted;
+					} catch (insertErr) {
+						if (isAlreadyRunningConflict(insertErr)) {
+							const existingRunId = await findRunningRunId(context.userId);
+							logger.info(
+								{ userId: context.userId, existingRunId },
+								"organize.run skipped — a run is already in progress for this user",
+							);
+							return {
+								success: true,
+								results: [
+									{
+										userId: context.userId,
+										runId: existingRunId ?? -1,
+										status: "skipped",
+										error: "A pipeline run is already in progress",
+									},
+								],
+							};
+						}
+						throw insertErr;
+					}
 
 					try {
 						await organizePipeline.trigger({
@@ -93,23 +141,43 @@ export const organizeRouter = {
 			const results: Array<{
 				userId: string;
 				runId: number;
-				status: "completed" | "failed";
+				status: "completed" | "failed" | "skipped";
 				error?: string;
 			}> = [];
 
 			for (const { id } of users) {
 				try {
-					const [run] = await db
-						.insert(pipelineRun)
-						.values({
-							userId: id,
-							status: "running",
-							currentStage: "sync",
-							startedAt: new Date(),
-						})
-						.returning({ id: pipelineRun.id });
+					let run: { id: number };
+					try {
+						const [inserted] = await db
+							.insert(pipelineRun)
+							.values({
+								userId: id,
+								status: "running",
+								currentStage: "sync",
+								startedAt: new Date(),
+							})
+							.returning({ id: pipelineRun.id });
 
-					if (!run) throw new Error("Failed to create run record");
+						if (!inserted) throw new Error("Failed to create run record");
+						run = inserted;
+					} catch (insertErr) {
+						if (isAlreadyRunningConflict(insertErr)) {
+							const existingRunId = await findRunningRunId(id);
+							logger.info(
+								{ userId: id, existingRunId },
+								"organize.run skipped for user — a run is already in progress",
+							);
+							results.push({
+								userId: id,
+								runId: existingRunId ?? -1,
+								status: "skipped",
+								error: "A pipeline run is already in progress",
+							});
+							continue;
+						}
+						throw insertErr;
+					}
 
 					try {
 						await organizePipeline.trigger({


### PR DESCRIPTION
Closes #158

## Problem

`generatePlaylists()` deleted every `isGenerated=true` playlist at the start of each run and recreated all of them from scratch, wiping `spotifyPlaylistId`/`exportedAt` every time. `exportPlaylistToSpotify()` already had update-in-place logic (`if (pl.spotifyPlaylistId) return updateExistingPlaylist(...)`), but that branch never fired since the DB row was always brand new by the time export ran — every pipeline run created a new Spotify playlist instead of updating the previous one.

## Matching

New clusters are matched to existing playlists by **Jaccard similarity** of track-ID sets (`packages/common/src/services/brain/playlist-matcher.ts`), not cluster ID — clustering is non-deterministic run to run (DBSCAN + k-means fallback, #145), so cluster identity can't be trusted to persist, but actual track membership can be compared directly.

Chose Jaccard over the overlap coefficient (`|intersection|/min(|A|,|B|)`) after testing both against an adversarial scenario: a 10-track cluster sharing 8 tracks with an unrelated 75-track playlist scores 0.8 under the coefficient (looks like a strong match) but only 0.104 under Jaccard (correctly weak, since 67 of the playlist's tracks are unrelated). Overlap coefficient only normalizes by the smaller set and is fooled by size asymmetry; Jaccard accounts for the union.

Matching is greedy: score every (cluster, playlist) pair ≥ 0.5, sort by similarity descending (deterministic tie-break: larger absolute overlap, then playlist ID, then cluster index), assign so each side is claimed at most once. A cluster with no match gets a new playlist. **An existing playlist with no match this run is left completely untouched** — deleting a playlist the user still has on Spotify because this run's clustering moved past it is a worse failure mode than a temporarily stale one.

Unit tests (`playlist-matcher.test.ts`, 12 cases) cover: first-run/no-existing-playlists, clean match, clean miss, a clean 50/50 cluster split (deterministic tie-break), an uneven split (higher-similarity cluster wins), the asymmetric-size false-positive scenario above, greedy-assignment conflicts, and orphan handling.

## Two things that made this unsafe/incomplete on its own

**1. No concurrency guard existed.** `organize.run` always inserted a new `pipeline_run` row and triggered a new execution regardless of whether one was already running for that user — the "Analyze My Music" button only disables while the HTTP call is pending, not while the multi-minute background pipeline runs. Harmless under delete-and-recreate; a real corruption risk once two runs can race to update the same playlist row in place.

Added a partial unique index (`pipeline_run_one_running_per_user`, `WHERE status = 'running'`) and conflict handling in `organize.ts` (new `"skipped"` result status, returns the existing run's ID). Verified end-to-end against a local Postgres instance:
- Reproduced the race with synthetic duplicate `running` rows
- Confirmed the index blocks a second concurrent insert (`23505` on the exact constraint name)
- Confirmed the migration's cleanup step (marks all but the most-recent `running` row per user as `failed` before creating the index) handles any duplicates the pre-existing race may have already left in place — so this doesn't fail to apply on a real, already-affected database

**2. Spotify export was entirely manual.** Nothing in the pipeline ever called `exportPlaylistToSpotify` automatically — only a user-clicked dashboard button did. Added an export stage after generate+match that pushes updates **only for playlists the user has already manually exported at least once** (`spotifyPlaylistId` set). A playlist that's never been exported stays database-only until the user opts in with a manual export — confirmed this exact design with @FindMalek before building it. Never creates a new Spotify playlist on its own; only takes the update branch.

## Also found, filed separately (not fixed here — unrelated scope)

**#162** — the full migration chain fails from scratch (`drizzle-kit migrate` against an empty DB errors on a duplicate `ADD COLUMN` in an early migration referencing a since-dropped scaffold `todo` table). This turned out to be the actual root cause of the prod `drizzle-migrate.yml` failure from earlier — the CLI's spinner was swallowing the real error text, which is why it looked like a silent hang.

## Deliberately not done here

Tracked as their own issues, both explicitly out of scope for this PR:
- **#159** — reconciling with manual edits made directly on Spotify (user-edits-win). The existing `userPlaylistSnapshot*` tables already have the data this needs; just not wired in yet.
- **#160** — deduping same-song-twice within a playlist.

## Test plan

- [x] `pnpm build` — 17/17 tasks pass
- [x] `pnpm test` — all tests pass, including the 12 new matcher unit tests
- [x] `pnpm exec biome ci .` — clean
- [x] Migration tested against a real local Postgres: cleanup + index creation verified with synthetic duplicate-running-row data; confirmed the `pg` driver throws the exact `23505`/constraint-name shape the guard checks for
- [x] Full schema verified via `drizzle-kit push` against a fresh database (includes the new index)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organize runs now include an export stage that exports updated playlists and reports export outcomes.
  * Updated playlists can be automatically exported to Spotify.
* **Bug Fixes**
  * Prevented multiple organize runs from running concurrently for the same account; duplicate requests are skipped safely.
  * Improved playlist matching and track-count updates, with deterministic matching and safer greedy assignment.
* **Other**
  * Generated playlists are now updated incrementally instead of deleted/recreated.
  * Run status reporting now supports a `skipped` outcome. 
  * Added tests covering playlist matching thresholds, tie-breaking, and unmatched/orphaned playlists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->