### PR TITLE
fix(dashboard): correct export button label, add exported-to-Spotify indicator

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-actions.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-actions.tsx
@@ -12,16 +12,13 @@ export function DashboardPlaylistDetailActions({
 	exportPending: boolean;
 	onExport: () => void;
 }) {
-	const isExported = spotifyPlaylistId !== null;
+	const isExported = Boolean(spotifyPlaylistId);
 
 	return (
 		<div className="flex flex-col gap-2">
 			{isExported ? (
 				<div className="flex items-center justify-between gap-2">
-					<Badge
-						variant="outline"
-						className="border-[#1DB954]/40 text-[#1DB954]"
-					>
+					<Badge variant="outline" className="border-primary/40 text-primary">
 						<Icons.circleCheck className="size-3" />
 						Exported
 					</Badge>
@@ -38,7 +35,7 @@ export function DashboardPlaylistDetailActions({
 					target="_blank"
 					rel="noreferrer"
 				>
-					<Button className="w-full bg-[#1DB954] font-bold text-black uppercase tracking-widest hover:bg-[#1ed760]">
+					<Button className="w-full bg-primary font-bold text-primary-foreground uppercase tracking-widest hover:bg-primary/90">
 						Open in Spotify
 						<Icons.externalLink className="ml-2 size-4" />
 					</Button>

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-actions.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-actions.tsx
@@ -1,16 +1,37 @@
-import { Button, Icons } from "@harmonia/ui";
+import { Badge, Button, Icons } from "@harmonia/ui";
+import { formatDistanceToNow } from "date-fns";
 
 export function DashboardPlaylistDetailActions({
 	spotifyPlaylistId,
+	exportedAt,
 	exportPending,
 	onExport,
 }: {
 	spotifyPlaylistId: string | null;
+	exportedAt: Date | null;
 	exportPending: boolean;
 	onExport: () => void;
 }) {
+	const isExported = spotifyPlaylistId !== null;
+
 	return (
 		<div className="flex flex-col gap-2">
+			{isExported ? (
+				<div className="flex items-center justify-between gap-2">
+					<Badge
+						variant="outline"
+						className="border-[#1DB954]/40 text-[#1DB954]"
+					>
+						<Icons.circleCheck className="size-3" />
+						Exported
+					</Badge>
+					{exportedAt ? (
+						<span className="text-muted-foreground text-xs">
+							Synced {formatDistanceToNow(exportedAt, { addSuffix: true })}
+						</span>
+					) : null}
+				</div>
+			) : null}
 			{spotifyPlaylistId ? (
 				<a
 					href={`https://open.spotify.com/playlist/${spotifyPlaylistId}`}
@@ -32,10 +53,12 @@ export function DashboardPlaylistDetailActions({
 				{exportPending ? (
 					<>
 						<Icons.spinner className="mr-2 size-4 animate-spin" />
-						Creating...
+						{isExported ? "Updating..." : "Exporting..."}
 					</>
+				) : isExported ? (
+					"Update in Spotify"
 				) : (
-					"Create Spotify Playlist"
+					"Export to Spotify"
 				)}
 			</Button>
 		</div>

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
@@ -44,6 +44,7 @@ export function DashboardPlaylistDetail({
 
 			<DashboardPlaylistDetailActions
 				spotifyPlaylistId={playlist.spotifyPlaylistId}
+				exportedAt={playlist.exportedAt}
 				exportPending={exportPending}
 				onExport={onExport}
 			/>

--- a/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
@@ -1,5 +1,6 @@
 import type { playlistListItemSchema } from "@harmonia/common/schemas";
 import {
+	Badge,
 	Breadcrumb,
 	BreadcrumbItem,
 	BreadcrumbList,
@@ -35,9 +36,20 @@ export function DashboardPlaylistsListRow({
 			)}
 		>
 			<div className="flex items-center justify-between gap-3">
-				<p className="text-muted-foreground text-xs uppercase tracking-wide">
-					{playlist.trackCount} tracks
-				</p>
+				<div className="flex items-center gap-2">
+					<p className="text-muted-foreground text-xs uppercase tracking-wide">
+						{playlist.trackCount} tracks
+					</p>
+					{playlist.spotifyPlaylistId ? (
+						<Badge
+							variant="outline"
+							className="border-[#1DB954]/40 text-[#1DB954]"
+							aria-label="Exported to Spotify"
+						>
+							<Icons.circleCheck className="size-3" />
+						</Badge>
+					) : null}
+				</div>
 				<span
 					className="flex size-11 shrink-0 items-center justify-end text-muted-foreground"
 					aria-hidden

--- a/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
@@ -43,7 +43,7 @@ export function DashboardPlaylistsListRow({
 					{playlist.spotifyPlaylistId ? (
 						<Badge
 							variant="outline"
-							className="border-[#1DB954]/40 text-[#1DB954]"
+							className="border-primary/40 text-primary"
 							aria-label="Exported to Spotify"
 						>
 							<Icons.circleCheck className="size-3" />


### PR DESCRIPTION
Closes #164

## Problem

`DashboardPlaylistDetailActions` always rendered "Create Spotify Playlist" / "Creating...", regardless of whether the playlist was already exported. `onExport` already calls `exportPlaylistToSpotify`, which branches internally on `spotifyPlaylistId` to update rather than create — the mechanism was correct, the label lied about what clicking it would do.

There was also no exported-to-Spotify indicator anywhere — not in the list view, not on the detail page (only an implicit conditional "Open in Spotify" button).

## Solution

- Button now reads "Export to Spotify" (never exported) or "Update in Spotify" (already has `spotifyPlaylistId`), same for the pending state.
- Compact indicator (icon-only `Badge` in Spotify green, no text — mobile list-row space is tight) added to `DashboardPlaylistsListRow`, and a labeled version + "Synced {relative time}" caption added to the detail page's actions component.
- No backend work — `spotifyPlaylistId`/`exportedAt` were already in `playlistListItemSchema` and already being fetched, just never surfaced in the UI.

## Test plan

- [x] `pnpm --filter dashboard build` — clean, no type errors
- [x] `biome ci .` — clean
- [ ] Not visually verified in a running browser — doing so needs a seeded session with a Spotify-authenticated user and at least one playlist with `spotifyPlaylistId` set, which isn't available in this environment. The change is a straightforward conditional-render based on existing, already-typed data, verified via typecheck, but flagging this gap rather than claiming a browser check that didn't happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playlist details now show when a playlist has been exported and when it was last synced.
  * Export actions now support updating previously exported playlists, with clearer progress and button states.
  * Playlist rows display track counts and an “Exported to Spotify” indicator for exported playlists.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->