### PR TITLE
feat(brain): per-playlist auto/manual Spotify sync toggle

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/playlists/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/playlists/[id]/page.tsx
@@ -16,7 +16,7 @@ export default function PlaylistDetailPage({
 	const { id } = use(params);
 	const playlistId = Number(id);
 
-	const { setSelectedPlaylist, detail, exportMutation } =
+	const { setSelectedPlaylist, detail, exportMutation, updateMutation } =
 		usePlaylistsController();
 
 	useEffect(() => {
@@ -39,6 +39,10 @@ export default function PlaylistDetailPage({
 			playlist={playlist}
 			exportPending={exportMutation.isPending}
 			onExport={() => exportMutation.mutate({ id: playlist.id })}
+			autoSyncPending={updateMutation.isPending}
+			onToggleAutoSync={(checked) =>
+				updateMutation.mutate({ id: playlist.id, autoSyncEnabled: checked })
+			}
 		/>
 	);
 }

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-actions.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-actions.tsx
@@ -1,11 +1,17 @@
-import { Button, Icons } from "@harmonia/ui";
+import { Button, Icons, Switch } from "@harmonia/ui";
 
 export function DashboardPlaylistDetailActions({
 	spotifyPlaylistId,
+	autoSyncEnabled,
+	autoSyncPending,
+	onToggleAutoSync,
 	exportPending,
 	onExport,
 }: {
 	spotifyPlaylistId: string | null;
+	autoSyncEnabled: boolean;
+	autoSyncPending: boolean;
+	onToggleAutoSync: (checked: boolean) => void;
 	exportPending: boolean;
 	onExport: () => void;
 }) {
@@ -38,6 +44,23 @@ export function DashboardPlaylistDetailActions({
 					"Create Spotify Playlist"
 				)}
 			</Button>
+			{spotifyPlaylistId ? (
+				<div className="flex items-center justify-between gap-3 border-t py-3">
+					<div className="flex flex-col gap-0.5">
+						<span className="font-medium text-sm">Auto-update in Spotify</span>
+						<span className="text-muted-foreground text-xs">
+							{autoSyncEnabled
+								? "Harmonia pushes changes here automatically after each run."
+								: "Off — Harmonia keeps this playlist current, but you push updates yourself."}
+						</span>
+					</div>
+					<Switch
+						checked={autoSyncEnabled}
+						disabled={autoSyncPending}
+						onCheckedChange={onToggleAutoSync}
+					/>
+				</div>
+			) : null}
 		</div>
 	);
 }

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
@@ -12,10 +12,14 @@ export function DashboardPlaylistDetail({
 	playlist,
 	exportPending,
 	onExport,
+	autoSyncPending,
+	onToggleAutoSync,
 }: {
 	playlist: PlaylistGetByIdOutput;
 	exportPending: boolean;
 	onExport: () => void;
+	autoSyncPending: boolean;
+	onToggleAutoSync: (checked: boolean) => void;
 }) {
 	const themesLine = playlist.themes?.join(", ") ?? null;
 
@@ -44,6 +48,9 @@ export function DashboardPlaylistDetail({
 
 			<DashboardPlaylistDetailActions
 				spotifyPlaylistId={playlist.spotifyPlaylistId}
+				autoSyncEnabled={playlist.autoSyncEnabled}
+				autoSyncPending={autoSyncPending}
+				onToggleAutoSync={onToggleAutoSync}
 				exportPending={exportPending}
 				onExport={onExport}
 			/>

--- a/packages/common/src/schemas/playlist/input.ts
+++ b/packages/common/src/schemas/playlist/input.ts
@@ -9,6 +9,7 @@ export const playlistUpdateInput = z.object({
 	id: z.number(),
 	name: z.string().optional(),
 	description: z.string().optional(),
+	autoSyncEnabled: z.boolean().optional(),
 });
 export type PlaylistUpdateInput = z.infer<typeof playlistUpdateInput>;
 

--- a/packages/common/src/schemas/playlist/output.ts
+++ b/packages/common/src/schemas/playlist/output.ts
@@ -26,6 +26,7 @@ export const playlistListItemSchema = z.object({
 	isGenerated: z.boolean(),
 	spotifyPlaylistId: z.string().nullable(),
 	exportedAt: z.date().nullable(),
+	autoSyncEnabled: z.boolean(),
 	createdAt: z.date(),
 	updatedAt: z.date(),
 });

--- a/packages/common/src/services/music/spotify/auto-export.ts
+++ b/packages/common/src/services/music/spotify/auto-export.ts
@@ -10,17 +10,7 @@ export type AutoExportResult = {
 	failed: number;
 };
 
-/**
- * Pushes this run's playlist changes to Spotify automatically — but ONLY for
- * playlists the user has already manually exported at least once
- * (`spotifyPlaylistId` set) AND that haven't been switched to manual sync
- * (`autoSyncEnabled`, #166). A playlist the user has never exported is left
- * database-only; exporting is what opts a playlist into ongoing automatic
- * updates, not something this pipeline decides on its own. Never creates a
- * new Spotify playlist — `exportPlaylistToSpotify` only takes the
- * update-in-place branch here, by construction (only already-exported
- * playlists are passed in).
- */
+/** Auto-syncs only playlists already exported at least once with autoSyncEnabled still on (#166); never creates a new Spotify playlist. */
 export async function autoExportUpdatedPlaylists(
 	userId: string,
 	touchedPlaylistIds: readonly number[],

--- a/packages/common/src/services/music/spotify/auto-export.ts
+++ b/packages/common/src/services/music/spotify/auto-export.ts
@@ -1,7 +1,7 @@
 import { db } from "@harmonia/db";
 import { playlist } from "@harmonia/db/schema/playlist";
 import { logger } from "@harmonia/logger";
-import { and, inArray, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
 
 import { exportPlaylistToSpotify } from "./export";
 
@@ -13,7 +13,8 @@ export type AutoExportResult = {
 /**
  * Pushes this run's playlist changes to Spotify automatically — but ONLY for
  * playlists the user has already manually exported at least once
- * (`spotifyPlaylistId` set). A playlist the user has never exported is left
+ * (`spotifyPlaylistId` set) AND that haven't been switched to manual sync
+ * (`autoSyncEnabled`, #166). A playlist the user has never exported is left
  * database-only; exporting is what opts a playlist into ongoing automatic
  * updates, not something this pipeline decides on its own. Never creates a
  * new Spotify playlist — `exportPlaylistToSpotify` only takes the
@@ -35,6 +36,7 @@ export async function autoExportUpdatedPlaylists(
 			and(
 				inArray(playlist.id, [...touchedPlaylistIds]),
 				isNotNull(playlist.spotifyPlaylistId),
+				eq(playlist.autoSyncEnabled, true),
 			),
 		);
 

--- a/packages/db/src/migrations/0022_lovely_shaman.sql
+++ b/packages/db/src/migrations/0022_lovely_shaman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "playlist" ADD COLUMN "auto_sync_enabled" boolean DEFAULT true NOT NULL;

--- a/packages/db/src/migrations/meta/0022_snapshot.json
+++ b/packages/db/src/migrations/meta/0022_snapshot.json
@@ -1,0 +1,2409 @@
+{
+	"id": "7c695760-0510-44bc-a84d-f42d3f846621",
+	"prevId": "4d61a681-01cf-46fd-830d-e23f262d0d72",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_impersonated_by_user_id_fk": {
+					"name": "session_impersonated_by_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["impersonated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_completed_onboarding": {
+					"name": "has_completed_onboarding",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_approved": {
+					"name": "is_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character": {
+			"name": "character",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_user_id_user_id_fk": {
+					"name": "character_user_id_user_id_fk",
+					"tableFrom": "character",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_genre_domain_id_genre_domain_id_fk": {
+					"name": "character_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "character",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_clusters": {
+			"name": "character_clusters",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_clusters_character_id_character_id_fk": {
+					"name": "character_clusters_character_id_character_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_clusters_cluster_id_cluster_id_fk": {
+					"name": "character_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_clusters_character_id_cluster_id_pk": {
+					"name": "character_clusters_character_id_cluster_id_pk",
+					"columns": ["character_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_tracks": {
+			"name": "character_tracks",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_tracks_character_id_character_id_fk": {
+					"name": "character_tracks_character_id_character_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_tracks_track_id_track_id_fk": {
+					"name": "character_tracks_track_id_track_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_tracks_character_id_track_id_pk": {
+					"name": "character_tracks_character_id_track_id_pk",
+					"columns": ["character_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster": {
+			"name": "cluster",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"centroid": {
+					"name": "centroid",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_valence": {
+					"name": "avg_valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_energy": {
+					"name": "avg_energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_tempo": {
+					"name": "avg_tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"cluster_user_id_idx": {
+					"name": "cluster_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"cluster_user_id_user_id_fk": {
+					"name": "cluster_user_id_user_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_genre_domain_id_genre_domain_id_fk": {
+					"name": "cluster_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster_tracks": {
+			"name": "cluster_tracks",
+			"schema": "",
+			"columns": {
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cluster_tracks_cluster_id_cluster_id_fk": {
+					"name": "cluster_tracks_cluster_id_cluster_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_tracks_track_id_track_id_fk": {
+					"name": "cluster_tracks_track_id_track_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"cluster_tracks_cluster_id_track_id_pk": {
+					"name": "cluster_tracks_cluster_id_track_id_pk",
+					"columns": ["cluster_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_send_log": {
+			"name": "email_send_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"template_key": {
+					"name": "template_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"skip_reason": {
+					"name": "skip_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_message_id": {
+					"name": "provider_message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"email_send_log_user_id_idx": {
+					"name": "email_send_log_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_status_idx": {
+					"name": "email_send_log_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_template_key_idx": {
+					"name": "email_send_log_template_key_idx",
+					"columns": [
+						{
+							"expression": "template_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_created_at_idx": {
+					"name": "email_send_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_provider_message_id_idx": {
+					"name": "email_send_log_provider_message_id_idx",
+					"columns": [
+						{
+							"expression": "provider_message_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"email_send_log_user_id_user_id_fk": {
+					"name": "email_send_log_user_id_user_id_fk",
+					"tableFrom": "email_send_log",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_send_log_idempotency_key_unique": {
+					"name": "email_send_log_idempotency_key_unique",
+					"nullsNotDistinct": false,
+					"columns": ["idempotency_key"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_suppression": {
+			"name": "email_suppression",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suppressed_at": {
+					"name": "suppressed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"email_suppression_suppressed_at_idx": {
+					"name": "email_suppression_suppressed_at_idx",
+					"columns": [
+						{
+							"expression": "suppressed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_suppression_email_unique": {
+					"name": "email_suppression_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genre_domain": {
+			"name": "genre_domain",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"genre_domain_name_unique": {
+					"name": "genre_domain_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pipeline_run": {
+			"name": "pipeline_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"current_stage": {
+					"name": "current_stage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"progress": {
+					"name": "progress",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"pipeline_run_user_id_idx": {
+					"name": "pipeline_run_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_status_idx": {
+					"name": "pipeline_run_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_one_running_per_user": {
+					"name": "pipeline_run_one_running_per_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"pipeline_run\".\"status\" = 'running'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pipeline_run_user_id_user_id_fk": {
+					"name": "pipeline_run_user_id_user_id_fk",
+					"tableFrom": "pipeline_run",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist": {
+			"name": "playlist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_generated_name": {
+					"name": "ai_generated_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"taxonomy": {
+					"name": "taxonomy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_color": {
+					"name": "cover_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_count": {
+					"name": "track_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"exported_at": {
+					"name": "exported_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auto_sync_enabled": {
+					"name": "auto_sync_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"playlist_user_id_idx": {
+					"name": "playlist_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"playlist_taxonomy_idx": {
+					"name": "playlist_taxonomy_idx",
+					"columns": [
+						{
+							"expression": "taxonomy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"playlist_user_id_user_id_fk": {
+					"name": "playlist_user_id_user_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_genre_domain_id_genre_domain_id_fk": {
+					"name": "playlist_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_clusters": {
+			"name": "playlist_clusters",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_clusters_playlist_id_playlist_id_fk": {
+					"name": "playlist_clusters_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_clusters_cluster_id_cluster_id_fk": {
+					"name": "playlist_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_clusters_playlist_id_cluster_id_pk": {
+					"name": "playlist_clusters_playlist_id_cluster_id_pk",
+					"columns": ["playlist_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_tracks": {
+			"name": "playlist_tracks",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_tracks_playlist_id_playlist_id_fk": {
+					"name": "playlist_tracks_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_tracks_track_id_track_id_fk": {
+					"name": "playlist_tracks_track_id_track_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_tracks_playlist_id_track_id_pk": {
+					"name": "playlist_tracks_playlist_id_track_id_pk",
+					"columns": ["playlist_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_item_artists": {
+			"name": "user_playlist_snapshot_item_artists",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_position": {
+					"name": "artist_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_name": {
+					"name": "artist_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_item_artists",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+					"columns": ["user_id", "playlist_id", "position", "artist_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_items": {
+			"name": "user_playlist_snapshot_items",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_name": {
+					"name": "track_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_uri": {
+					"name": "track_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_items_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_items",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+					"columns": ["user_id", "playlist_id", "position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshots": {
+			"name": "user_playlist_snapshots",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshots_user_id_user_id_fk": {
+					"name": "user_playlist_snapshots_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshots",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshots_user_id_playlist_id_pk": {
+					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
+					"columns": ["user_id", "playlist_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_spotify_library_stats": {
+			"name": "user_spotify_library_stats",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"total_tracks": {
+					"name": "total_tracks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_playlists": {
+					"name": "total_playlists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_albums": {
+					"name": "unique_albums",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_artists": {
+					"name": "unique_artists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_spotify_library_stats_user_id_user_id_fk": {
+					"name": "user_spotify_library_stats_user_id_user_id_fk",
+					"tableFrom": "user_spotify_library_stats",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track": {
+			"name": "track",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"spotify_uri": {
+					"name": "spotify_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_names": {
+					"name": "artist_names",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_image_url": {
+					"name": "album_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spotify_genres": {
+					"name": "spotify_genres",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"valence": {
+					"name": "valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy": {
+					"name": "energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"danceability": {
+					"name": "danceability",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tempo": {
+					"name": "tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acousticness": {
+					"name": "acousticness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instrumentalness": {
+					"name": "instrumentalness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"speechiness": {
+					"name": "speechiness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"liveness": {
+					"name": "liveness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics": {
+					"name": "lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_lyrics": {
+					"name": "synced_lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_instrumental": {
+					"name": "lyrics_instrumental",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lrclib_id": {
+					"name": "lrclib_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_fetched_at": {
+					"name": "lyrics_fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_status": {
+					"name": "lyrics_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_mood": {
+					"name": "llm_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_tags": {
+					"name": "llm_tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_classified_at": {
+					"name": "llm_classified_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_generated_at": {
+					"name": "embedding_generated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_input": {
+					"name": "embedding_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_assigned_at": {
+					"name": "domain_assigned_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"analysis_snapshot": {
+					"name": "analysis_snapshot",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"track_genre_domain_id_idx": {
+					"name": "track_genre_domain_id_idx",
+					"columns": [
+						{
+							"expression": "genre_domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_lyrics_status_idx": {
+					"name": "track_lyrics_status_idx",
+					"columns": [
+						{
+							"expression": "lyrics_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_embedding_idx": {
+					"name": "track_embedding_idx",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genre_domain_id_genre_domain_id_fk": {
+					"name": "track_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "track",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_tracks": {
+			"name": "user_tracks",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_tracks_user_id_idx": {
+					"name": "user_tracks_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_tracks_track_id_idx": {
+					"name": "user_tracks_track_id_idx",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_tracks_user_id_user_id_fk": {
+					"name": "user_tracks_user_id_user_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_tracks_track_id_track_id_fk": {
+					"name": "user_tracks_track_id_track_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_tracks_user_id_track_id_pk": {
+					"name": "user_tracks_user_id_track_id_pk",
+					"columns": ["user_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_email_preferences": {
+			"name": "user_email_preferences",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"transactional_enabled": {
+					"name": "transactional_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"product_updates_enabled": {
+					"name": "product_updates_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"marketing_enabled": {
+					"name": "marketing_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"feedback_enabled": {
+					"name": "feedback_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"consent_source": {
+					"name": "consent_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"consent_captured_at": {
+					"name": "consent_captured_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unsubscribed_at": {
+					"name": "unsubscribed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_email_preferences_user_id_user_id_fk": {
+					"name": "user_email_preferences_user_id_user_id_fk",
+					"tableFrom": "user_email_preferences",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.waitlist_signup": {
+			"name": "waitlist_signup",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "waitlist_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confirmation_email_sent_at": {
+					"name": "confirmation_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_email_sent_at": {
+					"name": "approval_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token": {
+					"name": "invite_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_raw": {
+					"name": "invite_token_raw",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_expires_at": {
+					"name": "invite_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_at": {
+					"name": "invite_redeemed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_by_user_id": {
+					"name": "invite_redeemed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"waitlist_signup_status_idx": {
+					"name": "waitlist_signup_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_created_at_idx": {
+					"name": "waitlist_signup_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_invite_token_idx": {
+					"name": "waitlist_signup_invite_token_idx",
+					"columns": [
+						{
+							"expression": "invite_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"waitlist_signup_invite_redeemed_by_user_id_user_id_fk": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_user_id_fk",
+					"tableFrom": "waitlist_signup",
+					"tableTo": "user",
+					"columnsFrom": ["invite_redeemed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"waitlist_signup_email_unique": {
+					"name": "waitlist_signup_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				},
+				"waitlist_signup_invite_token_unique": {
+					"name": "waitlist_signup_invite_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_token"]
+				},
+				"waitlist_signup_invite_redeemed_by_user_id_unique": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_redeemed_by_user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.waitlist_status": {
+			"name": "waitlist_status",
+			"schema": "public",
+			"values": ["pending", "approved", "rejected"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
 			"when": 1785414495470,
 			"tag": "0021_tearful_kabuki",
 			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1785490018642,
+			"tag": "0022_lovely_shaman",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/playlist.ts
+++ b/packages/db/src/schema/playlist.ts
@@ -36,9 +36,7 @@ export const playlist = pgTable(
 		isGenerated: boolean("is_generated").default(false).notNull(),
 		spotifyPlaylistId: text("spotify_playlist_id"),
 		exportedAt: timestamp("exported_at"),
-		// Default true: every already-exported playlist keeps auto-updating on
-		// Spotify exactly as before this column existed (#166) — opt-out, not
-		// opt-in.
+		// Default true: opt-out, not opt-in — existing exported playlists keep auto-updating (#166).
 		autoSyncEnabled: boolean("auto_sync_enabled").default(true).notNull(),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at")

--- a/packages/db/src/schema/playlist.ts
+++ b/packages/db/src/schema/playlist.ts
@@ -36,6 +36,10 @@ export const playlist = pgTable(
 		isGenerated: boolean("is_generated").default(false).notNull(),
 		spotifyPlaylistId: text("spotify_playlist_id"),
 		exportedAt: timestamp("exported_at"),
+		// Default true: every already-exported playlist keeps auto-updating on
+		// Spotify exactly as before this column existed (#166) — opt-out, not
+		// opt-in.
+		autoSyncEnabled: boolean("auto_sync_enabled").default(true).notNull(),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at")
 			.$onUpdate(() => new Date())

--- a/packages/orpc/src/routers/protected/playlists.ts
+++ b/packages/orpc/src/routers/protected/playlists.ts
@@ -93,10 +93,16 @@ export const playlistsRouter = {
 		.handler(async ({ input, context }) => {
 			const userId = context.session.user.id;
 
-			const updates: { name?: string; description?: string } = {};
+			const updates: {
+				name?: string;
+				description?: string;
+				autoSyncEnabled?: boolean;
+			} = {};
 			if (input.name !== undefined) updates.name = input.name;
 			if (input.description !== undefined)
 				updates.description = input.description;
+			if (input.autoSyncEnabled !== undefined)
+				updates.autoSyncEnabled = input.autoSyncEnabled;
 
 			if (Object.keys(updates).length === 0) return null;
 


### PR DESCRIPTION
Closes #166

## Problem

#158 made auto-export to Spotify all-or-nothing: any playlist with `spotifyPlaylistId` set gets auto-updated on every future run, forever, with no way to opt one out. If you've hand-tuned a playlist and don't want the algorithm touching it on Spotify anymore, there was no way to say that short of never running analysis again.

## Solution

New `playlist.autoSyncEnabled` column, default `true` — every currently-exported playlist keeps its exact current behavior, this is opt-out not opt-in. `autoExportUpdatedPlaylists` (#158) now filters on `autoSyncEnabled = true` alongside the existing `spotifyPlaylistId IS NOT NULL` check. Turning it off only stops the automatic Spotify push — Harmonia's own database keeps updating the playlist every run exactly as before, same as any playlist; you just push the update yourself via the existing export button when you want to.

`playlistUpdateInput` already accepted partial updates (`{id, name?, description?}`) — added `autoSyncEnabled` as one more optional field rather than a new endpoint.

## UI

`Switch` on the playlist detail page, next to the export button, only shown once a playlist has been exported (nothing to toggle before that). Mirrors the exact pattern already used on `/settings/notifications` — `Switch` + `onCheckedChange` driving a mutation, disabled while pending.

## Test plan

- [x] Migration tested with `drizzle-kit push` against a fresh throwaway Postgres database before trusting it
- [x] `pnpm build` (full monorepo, 17/17) — clean
- [x] `pnpm test` — clean
- [x] `biome ci .` — clean
- [ ] Not visually verified in a running browser (same limitation as #171 — needs a seeded, Spotify-authenticated session with an exported playlist)