### PR TITLE
fix(brain): exclude followed playlists from clustering input

### DIFF
--- a/packages/common/src/services/music/spotify/library-sync.ts
+++ b/packages/common/src/services/music/spotify/library-sync.ts
@@ -23,6 +23,7 @@ import {
 	fetchAllSavedTracks,
 	fetchAllUserPlaylists,
 	fetchPlaylistItems,
+	getSpotifyAccount,
 	getUserSpotifyAccessToken,
 } from "./client";
 import {
@@ -159,6 +160,9 @@ export async function syncLibraryTracks(
 
 	logger.info({ userId }, "Starting syncLibraryTracks from Spotify");
 
+	const spotifyAccount = await getSpotifyAccount(userId);
+	const spotifyUserId = spotifyAccount?.accountId ?? null;
+
 	const trackIds = new Set<string>();
 	const albumNames = new Set<string>();
 	const artistNames = new Set<string>();
@@ -288,6 +292,14 @@ export async function syncLibraryTracks(
 						return;
 					}
 				}
+
+				// Followed (non-owned) playlists are cached above for snapshot
+				// purposes but excluded here: clustering should only draw from
+				// Liked Songs + playlists the user actually owns, not playlists
+				// they merely follow (#167).
+				const isOwned =
+					spotifyUserId !== null && playlist.owner?.id === spotifyUserId;
+				if (!isOwned) return;
 
 				const info = extractTrackInfo(items);
 				for (const id of info.trackIds) trackIds.add(id);


### PR DESCRIPTION
## Summary
- `syncLibraryTracks` now only merges tracks from Liked Songs and playlists the user owns into the pool clustering consumes.
- Followed (non-owned) playlists are still fetched/cached for snapshot purposes (avoids wasted API calls next run) but no longer pollute the clustering input.
- Ownership check uses the Spotify account ID already stored on the linked `account` row (`getSpotifyAccount`) — no extra API call needed.

## Scoping decision on existing users
The issue's acceptance criteria raised a retroactive cleanup question: should `userTracks` rows sourced only from followed playlists be purged for users who already synced under the old behavior?

`userTracks` today has no deletion path anywhere in the sync code — it's purely additive. Adding one just for this case would introduce a new kind of deletion to handle one narrow slice of a broader staleness problem (tracks removed from everywhere, unliked tracks, etc. already aren't cleaned up either). Doing it properly would need real track-provenance tracking, which is a bigger schema change than this issue calls for.

Going with the issue's own fallback: accept the staleness and let it fade out naturally as clustering re-runs pull fresh, correctly-scoped data. Flagging this explicitly rather than silently skipping it — happy to file a separate issue for provenance-aware cleanup if that staleness turns out to matter in practice.

## Test plan
- [x] `pnpm --filter @harmonia/common build`
- [x] `pnpm build` (full monorepo)
- [x] `pnpm test`
- [x] `biome ci .`

Closes #167