### PR TITLE
fix(brain): replace deprecated Groq classification model

### DIFF
--- a/packages/common/src/constants/brain.ts
+++ b/packages/common/src/constants/brain.ts
@@ -2,8 +2,7 @@ export const EMBEDDING_MODEL = "text-embedding-3-small";
 export const EMBEDDING_BATCH_SIZE = 256;
 export const EMBEDDING_CONCURRENCY = 3;
 
-export const CLASSIFICATION_LLM_MODEL =
-	"meta-llama/llama-4-scout-17b-16e-instruct";
+export const CLASSIFICATION_LLM_MODEL = "llama-3.3-70b-versatile";
 export const CLASSIFICATION_BATCH_SIZE = 6;
 export const CLASSIFICATION_CONCURRENCY = 1;
 export const CLASSIFICATION_MAX_OUTPUT_TOKENS = 8192;


### PR DESCRIPTION
## Summary
- `CLASSIFICATION_LLM_MODEL` was `meta-llama/llama-4-scout-17b-16e-instruct`, deprecated by Groq on 2025-04-14 — every classify batch was failing with "model does not exist or you do not have access to it."
- Switched to `llama-3.3-70b-versatile`, which the README already documented as the intended model (code and docs had drifted apart).
- Verified live: a direct request to Groq's `/chat/completions` with this model returns 200.

## Test plan
- [x] `pnpm --filter @harmonia/common build`
- [x] `pnpm --filter @harmonia/common test`
- [x] `biome check`
- [x] Live smoke test against Groq's API with the new model — 200 OK

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the AI model used for classification to improve classification performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->