### PR TITLE
fix(brain): classification model doesn't support structured outputs on Groq

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 | Auth | Better Auth — dual instances (dashboard Spotify + admin email/password) |
 | Database | PostgreSQL + Drizzle ORM (Neon in production) |
 | Background jobs | Trigger.dev v4 |
-| LLM | Groq (`llama-3.3-70b-versatile` classify; `gpt-oss-120b` playlist/cluster) |
+| LLM | Groq (`gpt-oss-20b` classify; `gpt-oss-120b` playlist/cluster) |
 | Embeddings | OpenAI `text-embedding-3-small` |
 | Clustering | DBSCAN (`density-clustering`) |
 | Monorepo | pnpm + Turborepo |

--- a/packages/common/src/constants/brain.ts
+++ b/packages/common/src/constants/brain.ts
@@ -2,7 +2,7 @@ export const EMBEDDING_MODEL = "text-embedding-3-small";
 export const EMBEDDING_BATCH_SIZE = 256;
 export const EMBEDDING_CONCURRENCY = 3;
 
-export const CLASSIFICATION_LLM_MODEL = "llama-3.3-70b-versatile";
+export const CLASSIFICATION_LLM_MODEL = "openai/gpt-oss-20b";
 export const CLASSIFICATION_BATCH_SIZE = 6;
 export const CLASSIFICATION_CONCURRENCY = 1;
 export const CLASSIFICATION_MAX_OUTPUT_TOKENS = 8192;


### PR DESCRIPTION
## Summary
Follow-up to #193/#183. `llama-3.3-70b-versatile` fixed the "model does not exist" error but broke immediately on the next real call with:
```
This model does not support response format `json_schema`. See supported models at https://console.groq.com/docs/structured-outputs#supported-models
```
Confirmed against Groq's docs: only the `openai/gpt-oss-*` family supports `json_schema` structured outputs (strict or best-effort) — `llama-3.3-70b-versatile` only supports loose `json_object` mode, which doesn't enforce a schema.

Switched to `openai/gpt-oss-20b`. Compared side-by-side against `gpt-oss-120b` (already used elsewhere in this codebase) on the actual classification schema — no meaningful quality gap, and 20b was ~1.8x faster, which matters since classification runs sequentially across a whole library.

## Test plan
- [x] `pnpm --filter @harmonia/common build`
- [x] `pnpm --filter @harmonia/common test`
- [x] `biome check`
- [x] Live-verified through the real `generateText`/`Output.object` code path in `llml.ts` (not just a raw chat completion) — clean structured output, no error
- [x] Side-by-side quality/latency comparison against `gpt-oss-120b` on the real classification schema

Closes #183 (reopening the model choice, same underlying issue)