### PR TITLE
fix(dashboard): infinite scroll observer was recreated on every fetch, cascading through all pages

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/playlists/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/playlists/page.tsx
@@ -2,7 +2,6 @@
 
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
 import { Icons } from "@harmonia/ui";
-import { useEffect, useRef } from "react";
 import {
 	DashboardPlaylistsListRow,
 	DashboardPlaylistsListSkeleton,
@@ -12,6 +11,7 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { ErrorState } from "@/components/shared/error-state";
 import { ScrollToTopButton } from "@/components/shared/scroll-to-top-button";
 import { useDashboardScrollContainer } from "@/hooks/use-dashboard-scroll-container";
+import { useInfiniteScrollSentinel } from "@/hooks/use-infinite-scroll-sentinel";
 import { useScrollFlags } from "@/hooks/use-scroll-flags";
 import { usePlaylistsController } from "@/shared/lib/playlists/controller.hook";
 
@@ -34,24 +34,12 @@ export default function PlaylistsPage() {
 		backToTopAt: 400,
 	});
 
-	const sentinelRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		const sentinel = sentinelRef.current;
-		const root = scrollContainerRef.current;
-		if (!sentinel || !root) return;
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-					fetchNextPage();
-				}
-			},
-			{ root, rootMargin: "200px" },
-		);
-		observer.observe(sentinel);
-		return () => observer.disconnect();
-	}, [scrollContainerRef, hasNextPage, isFetchingNextPage, fetchNextPage]);
+	const sentinelRef = useInfiniteScrollSentinel({
+		rootRef: scrollContainerRef,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	});
 
 	const playlists = data?.pages.flatMap((page) => page.items) ?? [];
 

--- a/apps/dashboard/src/hooks/use-infinite-scroll-sentinel.ts
+++ b/apps/dashboard/src/hooks/use-infinite-scroll-sentinel.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { type RefObject, useEffect, useRef } from "react";
+
+/**
+ * A single, stable IntersectionObserver for the lifetime of the sentinel.
+ * Recreating the observer on every hasNextPage/isFetchingNextPage change
+ * would re-trigger its "report current state" callback on every re-attach,
+ * cascading through every remaining page regardless of actual scroll
+ * position — the observer only needs to exist once; live values are read
+ * from a ref so the callback always sees the latest state.
+ */
+export function useInfiniteScrollSentinel({
+	rootRef,
+	hasNextPage,
+	isFetchingNextPage,
+	fetchNextPage,
+}: {
+	rootRef: RefObject<HTMLElement | null>;
+	hasNextPage: boolean;
+	isFetchingNextPage: boolean;
+	fetchNextPage: () => void;
+}) {
+	const sentinelRef = useRef<HTMLDivElement>(null);
+	const stateRef = useRef({ hasNextPage, isFetchingNextPage, fetchNextPage });
+	stateRef.current = { hasNextPage, isFetchingNextPage, fetchNextPage };
+
+	useEffect(() => {
+		const sentinel = sentinelRef.current;
+		const root = rootRef.current;
+		if (!sentinel || !root) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const current = stateRef.current;
+				if (
+					entries[0]?.isIntersecting &&
+					current.hasNextPage &&
+					!current.isFetchingNextPage
+				) {
+					current.fetchNextPage();
+				}
+			},
+			{ root, rootMargin: "200px" },
+		);
+		observer.observe(sentinel);
+		return () => observer.disconnect();
+	}, [rootRef]);
+
+	return sentinelRef;
+}


### PR DESCRIPTION
## Root cause
\`IntersectionObserver\` always fires its callback once immediately on \`.observe()\` with the sentinel's current intersection state — that's spec behavior, not a bug in the browser. The old effect in the playlists page tore down and recreated the observer every time \`hasNextPage\`/\`isFetchingNextPage\` changed (i.e. after every page finished loading), so each new page's arrival caused an immediate re-check that, if the sentinel was still anywhere near the viewport (very likely right after new rows get appended), fetched the *next* page too — chaining through every remaining page in rapid succession regardless of whether the user had scrolled at all. From the user's side this is indistinguishable from "loads everything at once."

## Fix
Extracted \`useInfiniteScrollSentinel\` (\`apps/dashboard/src/hooks/use-infinite-scroll-sentinel.ts\`): creates **one** observer for the sentinel's lifetime (effect deps just the stable root ref), reading live \`hasNextPage\`/\`isFetchingNextPage\`/\`fetchNextPage\` off a ref instead of recreating the observer to pick up fresh closures. Now it only fires on genuine scroll-driven intersection crossings.

Shared as its own hook since #186 (tracklist pagination on \`playlist/[id]\`) needs the identical pattern — writing it correctly once here.

## Scope note
Chrome browser automation was unresponsive in this session (same issue as earlier — extension connected but not answering), so this wasn't visually verified live. The root cause is well-understood browser API behavior and the fix is a standard mitigation for it, but flagging the lack of live verification explicitly rather than claiming it's confirmed.

## Test plan
- [x] \`pnpm --filter dashboard exec tsc --noEmit\`
- [x] \`pnpm build\` (full monorepo)
- [x] \`biome check\`
- [ ] Live browser verification — not done, see note above

Closes #192