### PR TITLE
fix(dashboard): exported/synced indicator on playlists list row was icon-only

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
@@ -8,6 +8,7 @@ import {
 	Icons,
 	Skeleton,
 } from "@harmonia/ui";
+import { formatDistanceToNow } from "date-fns";
 import Link from "next/link";
 import { Fragment } from "react";
 import type { z } from "zod";
@@ -36,18 +37,21 @@ export function DashboardPlaylistsListRow({
 			)}
 		>
 			<div className="flex items-center justify-between gap-3">
-				<div className="flex items-center gap-2">
+				<div className="flex flex-wrap items-center gap-2">
 					<p className="text-muted-foreground text-xs uppercase tracking-wide">
 						{playlist.trackCount} tracks
 					</p>
 					{playlist.spotifyPlaylistId ? (
-						<Badge
-							variant="outline"
-							className="border-primary/40 text-primary"
-							aria-label="Exported to Spotify"
-						>
+						<Badge variant="outline" className="border-primary/40 text-primary">
 							<Icons.circleCheck className="size-3" />
+							Exported
 						</Badge>
+					) : null}
+					{playlist.spotifyPlaylistId && playlist.exportedAt ? (
+						<span className="text-muted-foreground text-xs">
+							Synced{" "}
+							{formatDistanceToNow(playlist.exportedAt, { addSuffix: true })}
+						</span>
 					) : null}
 				</div>
 				<span


### PR DESCRIPTION
## Summary
The list row's exported indicator was just a bare checkmark icon with no label — no way to tell at a glance which playlists were exported vs. not, or how recently, unlike the detail page's "Exported" text badge + "Synced X ago" caption.

Brought to parity: badge now has visible "Exported" text, plus a "Synced X ago" caption next to it when `exportedAt` is set. `flex-wrap` on the row header so it wraps gracefully on narrow viewports instead of overflowing.

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit`
- [x] `pnpm build`
- [x] `biome check`
- [ ] Live browser verification — Chrome automation unresponsive in this session (same known issue), not visually verified

Closes #187