### PR TITLE
fix(dashboard): analysis completion/error UX — scope down global toast, polish inline states, move Toaster to top

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-analysis-drawer.tsx
+++ b/apps/dashboard/src/components/app/dashboard-analysis-drawer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import {
+	Alert,
+	AlertDescription,
 	Button,
 	Drawer,
 	DrawerContent,
@@ -258,7 +260,7 @@ export function DashboardAnalysisDrawer() {
 									)}
 									{isPartial && (
 										<div className="mb-1 text-sm text-yellow-600">
-											Finished with low coverage
+											Low coverage
 										</div>
 									)}
 									{isFailed && (
@@ -275,32 +277,13 @@ export function DashboardAnalysisDrawer() {
 								/>
 
 								{(isPartial || isFailed) && streamState.error && (
-									<div
-										role="alert"
-										className={cn(
-											"flex items-start gap-2 border-l-2 px-3 py-2 text-xs",
-											isPartial
-												? "border-yellow-600 text-yellow-600"
-												: "border-destructive text-destructive",
-										)}
-									>
-										<Icons.alertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-										<div className="space-y-1">
-											<div className="font-medium">
-												{isPartial
-													? "Analysis finished with reduced coverage"
-													: "Analysis failed"}
-											</div>
-											<div className="text-muted-foreground">
-												{streamState.error}
-											</div>
-											{isPartial && (
-												<div className="text-muted-foreground">
-													Re-running the analysis is recommended.
-												</div>
-											)}
-										</div>
-									</div>
+									<Alert variant={isPartial ? "warning" : "destructive"}>
+										<Icons.alertTriangle />
+										<AlertDescription>
+											{streamState.error}
+											{isPartial && " Re-running is recommended."}
+										</AlertDescription>
+									</Alert>
 								)}
 							</div>
 

--- a/apps/dashboard/src/components/layout/app-providers.tsx
+++ b/apps/dashboard/src/components/layout/app-providers.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Providers } from "@harmonia/ui";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { queryClient } from "@/shared/api/orpc";
 
@@ -11,9 +10,8 @@ export default function AppProviders({
 	children: React.ReactNode;
 }) {
 	return (
-		<Providers queryClient={queryClient}>
+		<Providers queryClient={queryClient} toasterPosition="top-center">
 			{children}
-			{/* <ReactQueryDevtools /> */}
 		</Providers>
 	);
 }

--- a/apps/dashboard/src/shared/api/orpc.tsx
+++ b/apps/dashboard/src/shared/api/orpc.tsx
@@ -8,6 +8,11 @@ import { env } from "@/lib/env";
 export const queryClient = new QueryClient({
 	queryCache: new QueryCache({
 		onError: (error, query) => {
+			// Background-polling queries (pipeline run/stats refetchInterval)
+			// retry themselves on their own cadence — a toast per failed poll is
+			// noise, not signal, since the next interval just tries again.
+			if (query.meta?.silent) return;
+
 			const message = error.message;
 			const fullText = `Error: ${message}`;
 			toast.error(fullText, {

--- a/apps/dashboard/src/shared/lib/pipeline/pipeline.util.ts
+++ b/apps/dashboard/src/shared/lib/pipeline/pipeline.util.ts
@@ -13,6 +13,7 @@ export function pipelineGetAllQueryOptions() {
 		staleTime: PIPELINE_HYDRATION_STALE_MS,
 		refetchOnMount: false,
 		refetchOnWindowFocus: false,
+		meta: { silent: true },
 	};
 }
 
@@ -22,6 +23,7 @@ export function pipelineStatsQueryOptions() {
 		staleTime: PIPELINE_HYDRATION_STALE_MS,
 		refetchOnMount: false,
 		refetchOnWindowFocus: false,
+		meta: { silent: true },
 	};
 }
 

--- a/packages/ui/src/components/providers/providers.tsx
+++ b/packages/ui/src/components/providers/providers.tsx
@@ -2,6 +2,7 @@
 
 import type { QueryClient } from "@tanstack/react-query";
 import { QueryClientProvider } from "@tanstack/react-query";
+import type { ToasterProps } from "sonner";
 
 import { Toaster } from "../ui/sonner";
 import { TooltipProvider } from "../ui/tooltip";
@@ -10,9 +11,14 @@ import { ThemeProvider } from "./theme-provider";
 type ProvidersProps = {
 	children: React.ReactNode;
 	queryClient?: QueryClient;
+	toasterPosition?: ToasterProps["position"];
 };
 
-export function Providers({ children, queryClient }: ProvidersProps) {
+export function Providers({
+	children,
+	queryClient,
+	toasterPosition,
+}: ProvidersProps) {
 	const content = queryClient ? (
 		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 	) : (
@@ -27,7 +33,7 @@ export function Providers({ children, queryClient }: ProvidersProps) {
 			disableTransitionOnChange
 		>
 			<TooltipProvider>{content}</TooltipProvider>
-			<Toaster richColors />
+			<Toaster richColors position={toasterPosition} />
 		</ThemeProvider>
 	);
 }

--- a/packages/ui/src/components/ui/alert.tsx
+++ b/packages/ui/src/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
 				default: "bg-card text-card-foreground",
 				destructive:
 					"bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+				warning:
+					"bg-card text-yellow-600 *:data-[slot=alert-description]:text-yellow-600/90 dark:text-yellow-500 dark:*:data-[slot=alert-description]:text-yellow-500/90 *:[svg]:text-current",
 			},
 		},
 		defaultVariants: {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,6 +9,12 @@ export type { Icon } from "./components/shared/icons";
 export { Icons } from "./components/shared/icons";
 export { ModeToggle } from "./components/shared/mode-toggle";
 export { UserMenu } from "./components/shared/user-menu";
+export {
+	Alert,
+	AlertAction,
+	AlertDescription,
+	AlertTitle,
+} from "./components/ui/alert";
 export { Badge, badgeVariants } from "./components/ui/badge";
 export {
 	Breadcrumb,


### PR DESCRIPTION
## Summary

**Toast audit**: went through every \`toast.*\` call site in the dashboard. Every explicit-action toast (export, save, cancel analysis, clear analysis, copy-to-clipboard) is legitimate feedback tied directly to a button click — none of those were actually unnecessary. The genuinely noisy one is the **global** \`QueryCache.onError\` handler (\`apps/dashboard/src/shared/api/orpc.tsx\`), which fires a raw \`Error: ...\` toast with Copy/Retry buttons for *any* failed query anywhere — including the pipeline's own background-polling queries (\`pipeline.getAll\`/\`pipeline.stats\`, driven by \`refetchInterval\`). Those retry themselves on their own cadence regardless of one failed poll, so a toast per miss was pure noise. Tagged them \`meta: { silent: true }\` and skip the toast for those specifically; one-off query failures elsewhere still surface normally.

**Reposition**: \`Providers\` (shared, used by dashboard/admin/web) now takes an optional \`toasterPosition\` prop. Only the dashboard passes \`"top-center"\` — admin/web keep Sonner's default bottom-right, unchanged.

**Inline low-coverage/failed state**: the analysis drawer was repeating the same explanation twice — a one-line colored status tag next to the percentage, then a full hand-rolled alert box below restating it plus the raw error plus a recommendation, as three stacked lines. Consolidated into the existing \`Alert\` component from \`packages/ui\` (previously defined but never exported/used anywhere), added a \`warning\` variant for the partial-coverage case, single concise description instead of three redundant lines.

## Scope note
Chrome browser automation was unresponsive again this session (same known issue), so this wasn't visually verified live — flagging explicitly.

## Test plan
- [x] \`pnpm --filter @harmonia/ui build\`, \`pnpm --filter dashboard exec tsc --noEmit\`
- [x] \`pnpm build\` (full monorepo — admin/web included, to confirm the shared \`Providers\`/\`Alert\` changes don't break them)
- [x] \`pnpm test\`
- [x] \`biome ci .\`
- [ ] Live browser verification — not done, see note above

Closes #184