### PR TITLE
feat(dashboard): move sticky search/header to playlist/[id], paginate its tracklist

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/playlists/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/playlists/[id]/page.tsx
@@ -42,7 +42,13 @@ export default function PlaylistDetailPage({
 		backToTopAt: 400,
 	});
 
-	const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = tracks;
+	const {
+		data,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+		isLoading: tracksLoading,
+	} = tracks;
 	const tracksSentinelRef = useInfiniteScrollSentinel({
 		rootRef: scrollContainerRef,
 		hasNextPage,
@@ -72,6 +78,7 @@ export default function PlaylistDetailPage({
 					updateMutation.mutate({ id: playlist.id, autoSyncEnabled: checked })
 				}
 				tracks={trackItems}
+				tracksLoading={tracksLoading}
 				hasNextTracksPage={hasNextPage}
 				tracksSentinelRef={tracksSentinelRef}
 				scrolled={scrolled}

--- a/apps/dashboard/src/app/(dashboard)/playlists/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/playlists/[id]/page.tsx
@@ -6,7 +6,14 @@ import {
 	DashboardPlaylistDetailNotFound,
 	DashboardPlaylistDetailSkeleton,
 } from "@/components/app/dashboard-playlist-detail";
-import { usePlaylistsController } from "@/shared/lib/playlists/controller.hook";
+import { ScrollToTopButton } from "@/components/shared/scroll-to-top-button";
+import { useDashboardScrollContainer } from "@/hooks/use-dashboard-scroll-container";
+import { useInfiniteScrollSentinel } from "@/hooks/use-infinite-scroll-sentinel";
+import { useScrollFlags } from "@/hooks/use-scroll-flags";
+import {
+	usePlaylistsController,
+	usePlaylistTracksController,
+} from "@/shared/lib/playlists/controller.hook";
 
 export default function PlaylistDetailPage({
 	params,
@@ -18,11 +25,31 @@ export default function PlaylistDetailPage({
 
 	const { setSelectedPlaylist, detail, exportMutation, updateMutation } =
 		usePlaylistsController();
+	const { tracks, trackSearch, setTrackSearch } =
+		usePlaylistTracksController(playlistId);
 
 	useEffect(() => {
 		setSelectedPlaylist(playlistId);
-		return () => setSelectedPlaylist(null);
-	}, [playlistId, setSelectedPlaylist]);
+		return () => {
+			setSelectedPlaylist(null);
+			setTrackSearch("");
+		};
+	}, [playlistId, setSelectedPlaylist, setTrackSearch]);
+
+	const scrollContainerRef = useDashboardScrollContainer();
+	const { scrolled, showBackToTop } = useScrollFlags(scrollContainerRef, {
+		collapseAt: 24,
+		backToTopAt: 400,
+	});
+
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = tracks;
+	const tracksSentinelRef = useInfiniteScrollSentinel({
+		rootRef: scrollContainerRef,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	});
+	const trackItems = data?.pages.flatMap((page) => page.items) ?? [];
 
 	const { data: playlist, isLoading, isError } = detail;
 
@@ -35,14 +62,26 @@ export default function PlaylistDetailPage({
 	}
 
 	return (
-		<DashboardPlaylistDetail
-			playlist={playlist}
-			exportPending={exportMutation.isPending}
-			onExport={() => exportMutation.mutate({ id: playlist.id })}
-			autoSyncPending={updateMutation.isPending}
-			onToggleAutoSync={(checked) =>
-				updateMutation.mutate({ id: playlist.id, autoSyncEnabled: checked })
-			}
-		/>
+		<>
+			<DashboardPlaylistDetail
+				playlist={playlist}
+				exportPending={exportMutation.isPending}
+				onExport={() => exportMutation.mutate({ id: playlist.id })}
+				autoSyncPending={updateMutation.isPending}
+				onToggleAutoSync={(checked) =>
+					updateMutation.mutate({ id: playlist.id, autoSyncEnabled: checked })
+				}
+				tracks={trackItems}
+				hasNextTracksPage={hasNextPage}
+				tracksSentinelRef={tracksSentinelRef}
+				scrolled={scrolled}
+				trackSearch={trackSearch}
+				onTrackSearchChange={setTrackSearch}
+			/>
+			<ScrollToTopButton
+				visible={showBackToTop}
+				containerRef={scrollContainerRef}
+			/>
+		</>
 	);
 }

--- a/apps/dashboard/src/app/(dashboard)/playlists/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/playlists/page.tsx
@@ -16,7 +16,7 @@ import { useScrollFlags } from "@/hooks/use-scroll-flags";
 import { usePlaylistsController } from "@/shared/lib/playlists/controller.hook";
 
 export default function PlaylistsPage() {
-	const { list, search } = usePlaylistsController();
+	const { list } = usePlaylistsController();
 	const {
 		data,
 		isLoading,
@@ -29,7 +29,7 @@ export default function PlaylistsPage() {
 	} = list;
 
 	const scrollContainerRef = useDashboardScrollContainer();
-	const { scrolled, showBackToTop } = useScrollFlags(scrollContainerRef, {
+	const { showBackToTop } = useScrollFlags(scrollContainerRef, {
 		collapseAt: 24,
 		backToTopAt: 400,
 	});
@@ -46,10 +46,7 @@ export default function PlaylistsPage() {
 	if (isError) {
 		return (
 			<div className="space-y-8">
-				<DashboardPlaylistsPageHeader
-					hasPlaylists={false}
-					scrolled={scrolled}
-				/>
+				<DashboardPlaylistsPageHeader hasPlaylists={false} />
 				<ErrorState
 					message={
 						error instanceof Error ? error.message : "Failed to load playlists"
@@ -63,46 +60,29 @@ export default function PlaylistsPage() {
 	if (isLoading) {
 		return (
 			<div className="space-y-8">
-				<DashboardPlaylistsPageHeader
-					hasPlaylists={false}
-					scrolled={scrolled}
-				/>
+				<DashboardPlaylistsPageHeader hasPlaylists={false} />
 				<DashboardPlaylistsListSkeleton />
 			</div>
 		);
 	}
 
-	const hasAnyPlaylists = playlists.length > 0 || search.length > 0;
-
 	return (
 		<div className="space-y-8">
-			<DashboardPlaylistsPageHeader
-				hasPlaylists={hasAnyPlaylists}
-				scrolled={scrolled}
-			/>
+			<DashboardPlaylistsPageHeader hasPlaylists={Boolean(playlists.length)} />
 
 			{playlists.length === 0 ? (
-				search ? (
-					<EmptyState
-						icon={Icons.search}
-						title="No matching playlists"
-						description="Try a different search."
-						variant="card"
-					/>
-				) : (
-					<EmptyState
-						icon={Icons.disc}
-						title="No playlists yet"
-						description="Run the pipeline to generate playlists from your library."
-						action={{
-							label: "Run Pipeline",
-							onClick: () => {
-								window.location.href = DASHBOARD_ROUTES.overview.path;
-							},
-						}}
-						variant="card"
-					/>
-				)
+				<EmptyState
+					icon={Icons.disc}
+					title="No playlists yet"
+					description="Run the pipeline to generate playlists from your library."
+					action={{
+						label: "Run Pipeline",
+						onClick: () => {
+							window.location.href = DASHBOARD_ROUTES.overview.path;
+						},
+					}}
+					variant="card"
+				/>
 			) : (
 				<div className="divide-y divide-border">
 					{playlists.map((pl) => (

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-header.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
+import { cn, Icons, Input } from "@harmonia/ui";
+import { DashboardDetailBackLink } from "@/components/shared/dashboard-detail-back-link";
+
+export function DashboardPlaylistDetailHeader({
+	name,
+	description,
+	scrolled,
+	trackSearch,
+	onTrackSearchChange,
+}: {
+	name: string;
+	description: string | null;
+	scrolled: boolean;
+	trackSearch: string;
+	onTrackSearchChange: (value: string) => void;
+}) {
+	return (
+		<div className="sticky top-0 z-10 -mx-4 -mt-4 bg-background px-4 pt-4 pb-3">
+			<DashboardDetailBackLink
+				href={DASHBOARD_ROUTES.playlists.path}
+				label="Playlists"
+			/>
+
+			{/* ponytail: discrete collapse on a scrolled threshold, not a continuous
+			scroll-linked interpolation — add spring/transform interpolation if the
+			step transition ever feels abrupt. */}
+			<div
+				className={cn(
+					"overflow-hidden transition-all duration-200 ease-out",
+					scrolled ? "mt-0 max-h-0 opacity-0" : "mt-3 max-h-24 opacity-100",
+				)}
+			>
+				<h1 className="font-bold text-2xl tracking-tight">{name}</h1>
+				{description ? (
+					<p className="mt-1 text-muted-foreground text-sm">{description}</p>
+				) : null}
+			</div>
+
+			<div className="mt-3 flex items-center gap-2">
+				{scrolled ? (
+					<span className="max-w-[40%] shrink-0 truncate font-medium text-sm">
+						{name}
+					</span>
+				) : null}
+				<div className="relative flex-1">
+					<Icons.search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						value={trackSearch}
+						onChange={(e) => onTrackSearchChange(e.target.value)}
+						placeholder="Search tracks"
+						aria-label="Search tracks"
+						className="pl-9"
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-track-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-track-row.tsx
@@ -1,9 +1,8 @@
-import type { PlaylistGetByIdOutput } from "@harmonia/common/schemas";
+import type { PlaylistTrackItem } from "@harmonia/common/schemas";
 import { parseJsonStringArray } from "@harmonia/common/utils/parse-json-string-array";
 import Image from "next/image";
 
-export type DashboardPlaylistDetailTrackRowTrack =
-	PlaylistGetByIdOutput["tracks"][number];
+export type DashboardPlaylistDetailTrackRowTrack = PlaylistTrackItem;
 
 export function DashboardPlaylistDetailTrackRow({
 	track,

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-tracklist.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-tracklist.tsx
@@ -1,11 +1,16 @@
+import type { RefObject } from "react";
 import { DashboardPlaylistDetailSectionLabel } from "./dashboard-playlist-detail-section-label";
 import type { DashboardPlaylistDetailTrackRowTrack } from "./dashboard-playlist-detail-track-row";
 import { DashboardPlaylistDetailTrackRow } from "./dashboard-playlist-detail-track-row";
 
 export function DashboardPlaylistDetailTracklist({
 	tracks,
+	hasNextPage,
+	sentinelRef,
 }: {
 	tracks: DashboardPlaylistDetailTrackRowTrack[];
+	hasNextPage: boolean;
+	sentinelRef: RefObject<HTMLDivElement | null>;
 }) {
 	return (
 		<section className="flex flex-col">
@@ -20,6 +25,7 @@ export function DashboardPlaylistDetailTracklist({
 			{tracks.length === 0 ? (
 				<p className="py-4 text-muted-foreground text-sm">No tracks yet.</p>
 			) : null}
+			{hasNextPage ? <div ref={sentinelRef} className="h-1" /> : null}
 		</section>
 	);
 }

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-tracklist.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-tracklist.tsx
@@ -1,30 +1,50 @@
+import { Skeleton } from "@harmonia/ui";
 import type { RefObject } from "react";
 import { DashboardPlaylistDetailSectionLabel } from "./dashboard-playlist-detail-section-label";
 import type { DashboardPlaylistDetailTrackRowTrack } from "./dashboard-playlist-detail-track-row";
 import { DashboardPlaylistDetailTrackRow } from "./dashboard-playlist-detail-track-row";
 
+const TRACKLIST_SKELETON_KEYS = [
+	"tl-sk-1",
+	"tl-sk-2",
+	"tl-sk-3",
+	"tl-sk-4",
+	"tl-sk-5",
+	"tl-sk-6",
+] as const;
+
 export function DashboardPlaylistDetailTracklist({
 	tracks,
+	isLoading,
 	hasNextPage,
 	sentinelRef,
 }: {
 	tracks: DashboardPlaylistDetailTrackRowTrack[];
+	isLoading: boolean;
 	hasNextPage: boolean;
 	sentinelRef: RefObject<HTMLDivElement | null>;
 }) {
 	return (
 		<section className="flex flex-col">
 			<DashboardPlaylistDetailSectionLabel label="TRACKLIST" />
-			{tracks.map((track, index) => (
-				<DashboardPlaylistDetailTrackRow
-					key={track.id}
-					track={track}
-					index={index}
-				/>
-			))}
-			{tracks.length === 0 ? (
-				<p className="py-4 text-muted-foreground text-sm">No tracks yet.</p>
-			) : null}
+			{isLoading ? (
+				TRACKLIST_SKELETON_KEYS.map((key) => (
+					<Skeleton key={key} className="my-2 h-16 w-full" />
+				))
+			) : (
+				<>
+					{tracks.map((track, index) => (
+						<DashboardPlaylistDetailTrackRow
+							key={track.id}
+							track={track}
+							index={index}
+						/>
+					))}
+					{tracks.length === 0 ? (
+						<p className="py-4 text-muted-foreground text-sm">No tracks yet.</p>
+					) : null}
+				</>
+			)}
 			{hasNextPage ? <div ref={sentinelRef} className="h-1" /> : null}
 		</section>
 	);

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import type { PlaylistGetByIdOutput } from "@harmonia/common/schemas";
+import type {
+	PlaylistGetByIdOutput,
+	PlaylistTrackItem,
+} from "@harmonia/common/schemas";
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
 import { Skeleton } from "@harmonia/ui";
+import type { RefObject } from "react";
 import { DashboardDetailBackLink } from "@/components/shared/dashboard-detail-back-link";
 import { DashboardPlaylistDetailActions } from "./dashboard-playlist-detail-actions";
+import { DashboardPlaylistDetailHeader } from "./dashboard-playlist-detail-header";
 import { DashboardPlaylistDetailMetadata } from "./dashboard-playlist-detail-metadata";
 import { DashboardPlaylistDetailTracklist } from "./dashboard-playlist-detail-tracklist";
 
@@ -14,30 +19,36 @@ export function DashboardPlaylistDetail({
 	onExport,
 	autoSyncPending,
 	onToggleAutoSync,
+	tracks,
+	hasNextTracksPage,
+	tracksSentinelRef,
+	scrolled,
+	trackSearch,
+	onTrackSearchChange,
 }: {
 	playlist: PlaylistGetByIdOutput;
 	exportPending: boolean;
 	onExport: () => void;
 	autoSyncPending: boolean;
 	onToggleAutoSync: (checked: boolean) => void;
+	tracks: PlaylistTrackItem[];
+	hasNextTracksPage: boolean;
+	tracksSentinelRef: RefObject<HTMLDivElement | null>;
+	scrolled: boolean;
+	trackSearch: string;
+	onTrackSearchChange: (value: string) => void;
 }) {
 	const themesLine = playlist.themes?.join(", ") ?? null;
 
 	return (
 		<div className="flex flex-col gap-6">
-			<DashboardDetailBackLink
-				href={DASHBOARD_ROUTES.playlists.path}
-				label="Playlists"
+			<DashboardPlaylistDetailHeader
+				name={playlist.name}
+				description={playlist.description}
+				scrolled={scrolled}
+				trackSearch={trackSearch}
+				onTrackSearchChange={onTrackSearchChange}
 			/>
-
-			<div className="flex flex-col gap-1">
-				<h1 className="font-bold text-2xl tracking-tight">{playlist.name}</h1>
-				{playlist.description ? (
-					<p className="text-muted-foreground text-sm">
-						{playlist.description}
-					</p>
-				) : null}
-			</div>
 
 			<DashboardPlaylistDetailMetadata
 				trackCount={playlist.trackCount}
@@ -56,7 +67,11 @@ export function DashboardPlaylistDetail({
 				onExport={onExport}
 			/>
 
-			<DashboardPlaylistDetailTracklist tracks={playlist.tracks} />
+			<DashboardPlaylistDetailTracklist
+				tracks={tracks}
+				hasNextPage={hasNextTracksPage}
+				sentinelRef={tracksSentinelRef}
+			/>
 		</div>
 	);
 }

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail.tsx
@@ -20,6 +20,7 @@ export function DashboardPlaylistDetail({
 	autoSyncPending,
 	onToggleAutoSync,
 	tracks,
+	tracksLoading,
 	hasNextTracksPage,
 	tracksSentinelRef,
 	scrolled,
@@ -32,6 +33,7 @@ export function DashboardPlaylistDetail({
 	autoSyncPending: boolean;
 	onToggleAutoSync: (checked: boolean) => void;
 	tracks: PlaylistTrackItem[];
+	tracksLoading: boolean;
 	hasNextTracksPage: boolean;
 	tracksSentinelRef: RefObject<HTMLDivElement | null>;
 	scrolled: boolean;
@@ -69,6 +71,7 @@ export function DashboardPlaylistDetail({
 
 			<DashboardPlaylistDetailTracklist
 				tracks={tracks}
+				isLoading={tracksLoading}
 				hasNextPage={hasNextTracksPage}
 				sentinelRef={tracksSentinelRef}
 			/>

--- a/apps/dashboard/src/components/app/dashboard-playlists-page-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-page-header.tsx
@@ -2,13 +2,11 @@
 
 import {
 	Button,
-	cn,
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 	Icons,
-	Input,
 } from "@harmonia/ui";
 import { useOrganizeController } from "@/shared/lib/organize/controller.hook";
 import { usePlaylistsController } from "@/shared/lib/playlists/controller.hook";
@@ -16,93 +14,56 @@ import { PageHeader } from "../shared/page-header";
 
 export function DashboardPlaylistsPageHeader({
 	hasPlaylists,
-	scrolled,
 }: {
 	hasPlaylists: boolean;
-	scrolled: boolean;
 }) {
 	const { organizeMutation } = useOrganizeController();
-	const {
-		exportAllMutation: exportMutation,
-		search,
-		setSearch,
-	} = usePlaylistsController();
+	const { exportAllMutation: exportMutation } = usePlaylistsController();
 	const isBusy = exportMutation.isPending || organizeMutation.isPending;
 
-	const actions = hasPlaylists ? (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button
-					type="button"
-					variant="default"
-					className="size-11 shrink-0 rounded-none"
-					disabled={isBusy}
-					aria-label="Playlist actions"
-				>
-					{isBusy ? (
-						<Icons.spinner className="size-5 shrink-0 animate-spin" />
-					) : (
-						<Icons.plus className="size-5 shrink-0" />
-					)}
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end" className="min-w-48">
-				<DropdownMenuItem
-					disabled={exportMutation.isPending}
-					onSelect={() => {
-						exportMutation.mutate({});
-					}}
-				>
-					Send all to Spotify
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					disabled={organizeMutation.isPending}
-					onSelect={() => {
-						organizeMutation.mutate({});
-					}}
-				>
-					Run analysis again
-				</DropdownMenuItem>
-			</DropdownMenuContent>
-		</DropdownMenu>
-	) : null;
-
 	return (
-		<div className="sticky top-0 z-10 -mx-4 -mt-4 bg-background px-4 pt-4 pb-3">
-			{/* ponytail: discrete collapse on a scrolled threshold, not a continuous
-			scroll-linked interpolation — add spring/transform interpolation if the
-			step transition ever feels abrupt. */}
-			<div
-				className={cn(
-					"flex items-start justify-between gap-4 overflow-hidden transition-all duration-200 ease-out",
-					scrolled ? "mb-0 max-h-0 opacity-0" : "mb-3 max-h-20 opacity-100",
-				)}
-			>
-				<PageHeader
-					title="AI Playlists"
-					description="Generated from your taste."
-				/>
-				{actions}
-			</div>
-
-			<div className="flex items-center gap-2">
-				{scrolled ? (
-					<span className="shrink-0 font-medium text-foreground text-sm">
-						AI Playlists
-					</span>
-				) : null}
-				<div className="relative flex-1">
-					<Icons.search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-					<Input
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						placeholder="Search playlists"
-						aria-label="Search playlists"
-						className="pl-9"
-					/>
-				</div>
-				{scrolled ? actions : null}
-			</div>
+		<div className="flex items-start justify-between gap-4">
+			<PageHeader
+				title="AI Playlists"
+				description="Generated from your taste."
+			/>
+			{hasPlaylists ? (
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							type="button"
+							variant="default"
+							className="size-11 shrink-0 rounded-none"
+							disabled={isBusy}
+							aria-label="Playlist actions"
+						>
+							{isBusy ? (
+								<Icons.spinner className="size-5 shrink-0 animate-spin" />
+							) : (
+								<Icons.plus className="size-5 shrink-0" />
+							)}
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="min-w-48">
+						<DropdownMenuItem
+							disabled={exportMutation.isPending}
+							onSelect={() => {
+								exportMutation.mutate({});
+							}}
+						>
+							Send all to Spotify
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							disabled={organizeMutation.isPending}
+							onSelect={() => {
+								organizeMutation.mutate({});
+							}}
+						>
+							Run analysis again
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			) : null}
 		</div>
 	);
 }

--- a/apps/dashboard/src/shared/lib/playlists/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/playlists/controller.hook.ts
@@ -14,18 +14,17 @@ import { queryKeys } from "@/shared/api/query-keys";
 import { usePlaylistsStore } from "./store";
 
 const PLAYLISTS_PAGE_SIZE = 20;
+const PLAYLIST_TRACKS_PAGE_SIZE = 50;
 
 export function usePlaylistsController(updateOnSuccess?: () => void) {
 	const store = usePlaylistsStore();
 	const queryClient = useQueryClient();
-	const deferredSearch = useDeferredValue(store.search.trim());
 
 	const list = useInfiniteQuery(
 		orpc.playlists.list.infiniteOptions({
 			input: (cursor: number | null) => ({
 				cursor,
 				limit: PLAYLISTS_PAGE_SIZE,
-				search: deferredSearch || undefined,
 			}),
 			initialPageParam: null,
 			getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -89,5 +88,30 @@ export function usePlaylistsController(updateOnSuccess?: () => void) {
 		exportMutation,
 		exportAllMutation,
 		updateMutation,
+	};
+}
+
+export function usePlaylistTracksController(playlistId: number) {
+	const store = usePlaylistsStore();
+	const deferredSearch = useDeferredValue(store.trackSearch.trim());
+
+	const tracks = useInfiniteQuery({
+		...orpc.playlists.getTracks.infiniteOptions({
+			input: (cursor: number | null) => ({
+				playlistId,
+				cursor,
+				limit: PLAYLIST_TRACKS_PAGE_SIZE,
+				search: deferredSearch || undefined,
+			}),
+			initialPageParam: null,
+			getNextPageParam: (lastPage) => lastPage.nextCursor,
+		}),
+		enabled: playlistId > 0,
+	});
+
+	return {
+		tracks,
+		trackSearch: store.trackSearch,
+		setTrackSearch: store.setTrackSearch,
 	};
 }

--- a/apps/dashboard/src/shared/lib/playlists/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/playlists/controller.hook.ts
@@ -6,7 +6,7 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useDeferredValue } from "react";
+import { useDeferredValue, useRef } from "react";
 import { toast } from "sonner";
 import { toastError } from "@/shared/api/error-handler";
 import { orpc } from "@/shared/api/orpc";
@@ -93,7 +93,17 @@ export function usePlaylistsController(updateOnSuccess?: () => void) {
 
 export function usePlaylistTracksController(playlistId: number) {
 	const store = usePlaylistsStore();
-	const deferredSearch = useDeferredValue(store.trackSearch.trim());
+
+	// The store's trackSearch only actually resets in the page's effect
+	// cleanup, which fires *after* this hook re-renders with the new
+	// playlistId — without this, the first render/query for a newly-viewed
+	// playlist would briefly use the previous playlist's search term.
+	const prevPlaylistIdRef = useRef(playlistId);
+	const isNewPlaylist = prevPlaylistIdRef.current !== playlistId;
+	prevPlaylistIdRef.current = playlistId;
+	const trackSearch = isNewPlaylist ? "" : store.trackSearch;
+
+	const deferredSearch = useDeferredValue(trackSearch.trim());
 
 	const tracks = useInfiniteQuery({
 		...orpc.playlists.getTracks.infiniteOptions({
@@ -111,7 +121,7 @@ export function usePlaylistTracksController(playlistId: number) {
 
 	return {
 		tracks,
-		trackSearch: store.trackSearch,
+		trackSearch,
 		setTrackSearch: store.setTrackSearch,
 	};
 }

--- a/apps/dashboard/src/shared/lib/playlists/store.ts
+++ b/apps/dashboard/src/shared/lib/playlists/store.ts
@@ -3,13 +3,14 @@ import { create } from "zustand";
 interface PlaylistsStore {
 	selectedPlaylistId: number | null;
 	setSelectedPlaylist: (id: number | null) => void;
-	search: string;
-	setSearch: (value: string) => void;
+	/** Search within the currently-viewed playlist's own tracklist (playlist/[id]), not the playlists list. */
+	trackSearch: string;
+	setTrackSearch: (value: string) => void;
 }
 
 export const usePlaylistsStore = create<PlaylistsStore>((set) => ({
 	selectedPlaylistId: null,
 	setSelectedPlaylist: (id) => set({ selectedPlaylistId: id }),
-	search: "",
-	setSearch: (value) => set({ search: value }),
+	trackSearch: "",
+	setTrackSearch: (value) => set({ trackSearch: value }),
 }));

--- a/packages/common/src/schemas/playlist/input.ts
+++ b/packages/common/src/schemas/playlist/input.ts
@@ -5,6 +5,14 @@ export const playlistGetByIdInput = z.object({
 });
 export type PlaylistGetByIdInput = z.infer<typeof playlistGetByIdInput>;
 
+export const playlistTracksInput = z.object({
+	playlistId: z.number(),
+	cursor: z.number().nullish(),
+	limit: z.number().int().min(1).max(100).default(50),
+	search: z.string().optional(),
+});
+export type PlaylistTracksInput = z.infer<typeof playlistTracksInput>;
+
 export const playlistListInput = z.object({
 	cursor: z.number().nullish(),
 	limit: z.number().int().min(1).max(50).default(20),

--- a/packages/common/src/schemas/playlist/output.ts
+++ b/packages/common/src/schemas/playlist/output.ts
@@ -44,7 +44,7 @@ export const playlistListOutputSchema = z.object({
 });
 export type PlaylistListOutput = z.infer<typeof playlistListOutputSchema>;
 
-const playlistTrackItemSchema = z.object({
+export const playlistTrackItemSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	artistNames: z.string(),
@@ -55,9 +55,15 @@ const playlistTrackItemSchema = z.object({
 	llmTags: llmTagsSchema.nullable(),
 	position: z.number(),
 });
+export type PlaylistTrackItem = z.infer<typeof playlistTrackItemSchema>;
+
+export const playlistTracksOutputSchema = z.object({
+	items: z.array(playlistTrackItemSchema),
+	nextCursor: z.number().nullable(),
+});
+export type PlaylistTracksOutput = z.infer<typeof playlistTracksOutputSchema>;
 
 export const playlistGetByIdOutputSchema = playlistListItemSchema.extend({
-	tracks: z.array(playlistTrackItemSchema),
 	mood: z.string().nullable(),
 	energy: z.string().nullable(),
 	themes: z.array(z.string()).nullable(),

--- a/packages/orpc/src/routers/protected/playlists.ts
+++ b/packages/orpc/src/routers/protected/playlists.ts
@@ -8,6 +8,8 @@ import {
 	playlistGetByIdOutputSchema,
 	playlistListInput,
 	playlistListOutputSchema,
+	playlistTracksInput,
+	playlistTracksOutputSchema,
 	playlistUpdateInput,
 	playlistUpdateOutputSchema,
 } from "@harmonia/common/schemas";
@@ -20,7 +22,8 @@ import {
 	playlistTracks,
 } from "@harmonia/db/schema/playlist";
 import { track } from "@harmonia/db/schema/track";
-import { and, desc, eq, ilike, lt } from "drizzle-orm";
+import { ORPCError } from "@orpc/server";
+import { and, desc, eq, gt, ilike, lt, or } from "drizzle-orm";
 import { z } from "zod";
 import { approvedProcedure } from "../../procedures";
 
@@ -48,7 +51,7 @@ export const playlistsRouter = {
 
 			const hasMore = items.length > input.limit;
 			const page = hasMore ? items.slice(0, input.limit) : items;
-			const nextCursor = hasMore ? (page.at(-1)?.id ?? null) : null;
+			const nextCursor = hasMore ? (page[page.length - 1]?.id ?? null) : null;
 
 			return { items: page, nextCursor };
 		}),
@@ -66,7 +69,40 @@ export const playlistsRouter = {
 
 			if (!result) return null;
 
-			const tracks = await db
+			const [clusterRow] = await db
+				.select({ metadata: cluster.metadata })
+				.from(playlistClusters)
+				.innerJoin(cluster, eq(cluster.id, playlistClusters.clusterId))
+				.where(eq(playlistClusters.playlistId, input.id))
+				.limit(1);
+
+			const meta = clusterRow?.metadata as ClusterMeta | null;
+
+			return {
+				...result,
+				mood: meta?.dominantMood ?? null,
+				energy: meta?.dominantEnergy ?? null,
+				themes: meta?.topThemes ?? null,
+			};
+		}),
+
+	getTracks: approvedProcedure
+		.input(playlistTracksInput)
+		.output(playlistTracksOutputSchema)
+		.handler(async ({ input, context }) => {
+			const userId = context.session.user.id;
+
+			const [owned] = await db
+				.select({ id: playlist.id })
+				.from(playlist)
+				.where(
+					and(eq(playlist.id, input.playlistId), eq(playlist.userId, userId)),
+				);
+			if (!owned) {
+				throw new ORPCError("NOT_FOUND", { message: "Playlist not found" });
+			}
+
+			const rows = await db
 				.select({
 					id: track.id,
 					name: track.name,
@@ -80,25 +116,30 @@ export const playlistsRouter = {
 				})
 				.from(playlistTracks)
 				.innerJoin(track, eq(track.id, playlistTracks.trackId))
-				.where(eq(playlistTracks.playlistId, input.id))
-				.orderBy(playlistTracks.position);
+				.where(
+					and(
+						eq(playlistTracks.playlistId, input.playlistId),
+						input.cursor != null
+							? gt(playlistTracks.position, input.cursor)
+							: undefined,
+						input.search
+							? or(
+									ilike(track.name, `%${input.search}%`),
+									ilike(track.artistNames, `%${input.search}%`),
+								)
+							: undefined,
+					),
+				)
+				.orderBy(playlistTracks.position)
+				.limit(input.limit + 1);
 
-			const [clusterRow] = await db
-				.select({ metadata: cluster.metadata })
-				.from(playlistClusters)
-				.innerJoin(cluster, eq(cluster.id, playlistClusters.clusterId))
-				.where(eq(playlistClusters.playlistId, input.id))
-				.limit(1);
+			const hasMore = rows.length > input.limit;
+			const page = hasMore ? rows.slice(0, input.limit) : rows;
+			const nextCursor = hasMore
+				? (page[page.length - 1]?.position ?? null)
+				: null;
 
-			const meta = clusterRow?.metadata as ClusterMeta | null;
-
-			return {
-				...result,
-				tracks,
-				mood: meta?.dominantMood ?? null,
-				energy: meta?.dominantEnergy ?? null,
-				themes: meta?.topThemes ?? null,
-			};
+			return { items: page, nextCursor };
 		}),
 
 	update: approvedProcedure


### PR DESCRIPTION
## Summary

**Reverts #165's misdirected work**: the playlists list page (\`/playlists\`) goes back to plain — no search, no sticky collapsing header.

**Builds it correctly on \`playlist/[id]\`** instead:
- Sticky header: title + search box, pinned flush against the top of the scroll container. Uses the same \`-mx-4 -mt-4\` bleed trick as the list page's (now-reverted) header so there's genuinely no gap above it once stuck — not just \`sticky top-0\` sitting inside the container's own padding.
- Description collapses away on scroll; a compact title takes its place next to the search input, same "iOS large title" pattern.
- Search filters the **tracklist** (by track name/artist), not the playlist list — different data entirely, backed by a new \`playlists.getTracks\` procedure.

**Tracklist pagination**: \`playlists.getById\` no longer returns the full \`tracks\` array — it's paginated separately now via \`getTracks\`, cursor-based on \`playlistTracks.position\` (stable, unique within a playlist), reusing \`useInfiniteScrollSentinel\` from #192/#195.

**Also**: added the scroll-to-top button to this page (previously only on the list page), and fixed a \`.at(-1)\` call in \`playlists.list\` while touching this file — the repo's own indexed-access convention explicitly bans it (\`array[array.length - 1]\` instead).

## Scope note
Chrome browser automation was unresponsive again this session (same known issue). This is the largest visual change of the batch — pixel-level details like "genuinely no gap above the sticky header" are exactly the kind of thing that benefits from live verification, which wasn't possible here. Flagging explicitly.

## Test plan
- [x] \`pnpm --filter dashboard exec tsc --noEmit\`, \`pnpm --filter @harmonia/orpc build\`
- [x] \`pnpm build\` (full monorepo)
- [x] \`pnpm test\`
- [x] \`biome ci .\`
- [ ] Live browser verification — not done, see note above

Closes #185
Closes #186