### PR TITLE
fix(brain): handle empty-body Spotify responses and deleted playlists during export

### DIFF
--- a/packages/common/src/services/music/spotify/__tests__/client.test.ts
+++ b/packages/common/src/services/music/spotify/__tests__/client.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@harmonia/db", () => ({ db: {} }));
+
+import { SpotifyApiError, spotifyRequest } from "../client";
+
+function mockFetchOnce(response: {
+	status: number;
+	body?: string;
+	headers?: Record<string, string>;
+}): void {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue(
+			new Response(response.body ?? null, {
+				status: response.status,
+				headers: response.headers,
+			}),
+		),
+	);
+}
+
+describe("spotifyRequest", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("returns undefined for a 204 No Content response instead of throwing", async () => {
+		mockFetchOnce({ status: 204 });
+		await expect(
+			spotifyRequest("/playlists/abc", "token", { method: "PUT" }),
+		).resolves.toBeUndefined();
+	});
+
+	it("returns undefined for a 200 response with an empty body", async () => {
+		mockFetchOnce({ status: 200, body: "" });
+		await expect(
+			spotifyRequest("/playlists/abc", "token", { method: "PUT" }),
+		).resolves.toBeUndefined();
+	});
+
+	it("parses a normal JSON body", async () => {
+		mockFetchOnce({
+			status: 200,
+			body: JSON.stringify({ snapshot_id: "xyz" }),
+		});
+		await expect(
+			spotifyRequest("/playlists/abc/tracks", "token", { method: "PUT" }),
+		).resolves.toEqual({ snapshot_id: "xyz" });
+	});
+
+	it("throws a SpotifyApiError carrying the status on a 404", async () => {
+		mockFetchOnce({
+			status: 404,
+			body: JSON.stringify({ error: { message: "Not found" } }),
+		});
+		const result = spotifyRequest("/playlists/deleted", "token");
+		await expect(result).rejects.toThrow(SpotifyApiError);
+		await expect(result).rejects.toMatchObject({ status: 404 });
+	});
+});

--- a/packages/common/src/services/music/spotify/__tests__/export.test.ts
+++ b/packages/common/src/services/music/spotify/__tests__/export.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => {
+	function chain(result: unknown) {
+		const c: Record<string, unknown> = {};
+		c.from = vi.fn(() => c);
+		c.innerJoin = vi.fn(() => c);
+		c.where = vi.fn(() => c);
+		c.orderBy = vi.fn(() => c);
+		// biome-ignore lint/suspicious/noThenProperty: intentional thenable, faking drizzle's awaitable chained query builder
+		c.then = (
+			resolve: (v: unknown) => unknown,
+			reject?: (e: unknown) => unknown,
+		) => Promise.resolve(result).then(resolve, reject);
+		return c;
+	}
+
+	const selectMock = vi.fn();
+	const updateSetMock = vi.fn(() => ({
+		where: vi.fn(() => Promise.resolve()),
+	}));
+	const updateMock = vi.fn(() => ({ set: updateSetMock }));
+
+	return { chain, selectMock, updateMock, updateSetMock };
+});
+
+vi.mock("@harmonia/db", () => ({
+	db: {
+		select: dbMock.selectMock,
+		update: dbMock.updateMock,
+	},
+}));
+
+vi.mock("../client", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../client")>();
+	return {
+		...actual,
+		getUserSpotifyAccessToken: vi.fn(async () => "test-token"),
+		spotifyRequest: vi.fn(),
+	};
+});
+
+import { SpotifyApiError, spotifyRequest } from "../client";
+import { exportPlaylistToSpotify } from "../export";
+
+describe("exportPlaylistToSpotify", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("recreates the playlist when the existing Spotify playlist was deleted (404), without retrying the dead playlist", async () => {
+		const playlistRow = {
+			id: 1,
+			userId: "user-1",
+			name: "Test Playlist",
+			description: "desc",
+			spotifyPlaylistId: "old-spotify-id",
+		};
+		const trackRows = [{ spotifyUri: "spotify:track:abc" }];
+
+		dbMock.selectMock
+			.mockReturnValueOnce(dbMock.chain([playlistRow]))
+			.mockReturnValueOnce(dbMock.chain(trackRows));
+
+		const mockedSpotifyRequest = vi.mocked(spotifyRequest);
+		mockedSpotifyRequest.mockImplementation(async (path: string) => {
+			if (path === "/playlists/old-spotify-id") {
+				throw new SpotifyApiError(
+					404,
+					"Spotify API error 404 for /playlists/old-spotify-id: Not found",
+				);
+			}
+			if (path === "/me/playlists") {
+				return {
+					id: "new-spotify-id",
+					external_urls: {
+						spotify: "https://open.spotify.com/playlist/new-spotify-id",
+					},
+				};
+			}
+			return undefined;
+		});
+
+		const result = await exportPlaylistToSpotify("user-1", 1);
+
+		expect(result).toEqual({
+			spotifyPlaylistId: "new-spotify-id",
+			spotifyUrl: "https://open.spotify.com/playlist/new-spotify-id",
+		});
+
+		// The failing request against the deleted playlist must not have been
+		// retried — exactly 1 call for that path proves the 404 aborted p-retry
+		// immediately instead of burning retries on a non-transient error.
+		const deletedPlaylistCalls = mockedSpotifyRequest.mock.calls.filter(
+			([path]) => path === "/playlists/old-spotify-id",
+		);
+		expect(deletedPlaylistCalls).toHaveLength(1);
+
+		// The new playlist ID is what gets persisted, not the stale one.
+		expect(dbMock.updateSetMock).toHaveBeenCalledWith(
+			expect.objectContaining({ spotifyPlaylistId: "new-spotify-id" }),
+		);
+	});
+});

--- a/packages/common/src/services/music/spotify/client.ts
+++ b/packages/common/src/services/music/spotify/client.ts
@@ -122,6 +122,17 @@ export type SpotifyRequestOptions = {
 	body?: unknown;
 };
 
+/** Thrown by spotifyRequest for non-ok responses; carries the HTTP status so callers can special-case e.g. 404 (deleted resource) without string-matching the message. */
+export class SpotifyApiError extends Error {
+	readonly status: number;
+
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = "SpotifyApiError";
+		this.status = status;
+	}
+}
+
 /**
  * Unified Spotify API request helper. Handles auth, 429 retries, and error formatting.
  */
@@ -196,12 +207,20 @@ export async function spotifyRequest<T>(
 			bodyJson.error_description ?? bodyJson.error ?? response.statusText;
 		const summary =
 			typeof rawSummary === "string" ? rawSummary : JSON.stringify(rawSummary);
-		throw new Error(
+		throw new SpotifyApiError(
+			response.status,
 			`Spotify API error ${response.status} for ${path}: ${summary}`,
 		);
 	}
 
-	return (await response.json()) as T;
+	// Several Spotify endpoints (e.g. PUT /playlists/{id}) return 200/204 with
+	// an empty body — response.json() throws "Unexpected end of JSON input" on
+	// those, so read as text first and only parse when there's content.
+	const responseText = await response.text();
+	if (!responseText) {
+		return undefined as T;
+	}
+	return JSON.parse(responseText) as T;
 }
 
 function spotifyGet<T>(path: string, accessToken: string): Promise<T> {

--- a/packages/common/src/services/music/spotify/client.ts
+++ b/packages/common/src/services/music/spotify/client.ts
@@ -141,7 +141,7 @@ export async function spotifyRequest<T>(
 	accessToken: string,
 	options: SpotifyRequestOptions = {},
 	retriesLeft = SPOTIFY_RATE_LIMIT_MAX_RETRIES,
-): Promise<T> {
+): Promise<T | undefined> {
 	const { method = "GET", body } = options;
 	const init: RequestInit = {
 		method,
@@ -218,13 +218,20 @@ export async function spotifyRequest<T>(
 	// those, so read as text first and only parse when there's content.
 	const responseText = await response.text();
 	if (!responseText) {
-		return undefined as T;
+		return undefined;
 	}
 	return JSON.parse(responseText) as T;
 }
 
-function spotifyGet<T>(path: string, accessToken: string): Promise<T> {
-	return spotifyRequest<T>(path, accessToken, { method: "GET" });
+// GET endpoints used in this codebase always return a body (paginated list
+// responses) — fail loudly rather than silently propagating undefined if
+// that assumption is ever wrong, instead of an `as T` cast.
+async function spotifyGet<T>(path: string, accessToken: string): Promise<T> {
+	const result = await spotifyRequest<T>(path, accessToken, { method: "GET" });
+	if (result === undefined) {
+		throw new Error(`Spotify GET ${path} returned an empty body`);
+	}
+	return result;
 }
 
 export function spotifyRelativePathFromNext(nextUrl: string): string {

--- a/packages/common/src/services/music/spotify/export.ts
+++ b/packages/common/src/services/music/spotify/export.ts
@@ -124,6 +124,10 @@ async function createNewPlaylist(
 		),
 	);
 
+	if (!created) {
+		throw new Error("Spotify did not return a playlist after creation");
+	}
+
 	const spotifyPlaylistId = created.id;
 	const spotifyUrl = created.external_urls.spotify;
 

--- a/packages/common/src/services/music/spotify/export.ts
+++ b/packages/common/src/services/music/spotify/export.ts
@@ -4,10 +4,31 @@ import { playlist, playlistTracks } from "@harmonia/db/schema/playlist";
 import { track } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { and, eq } from "drizzle-orm";
-import pRetry from "p-retry";
+import pRetry, { AbortError } from "p-retry";
 
 import { SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST } from "../../../constants/spotify";
-import { getUserSpotifyAccessToken, spotifyRequest } from "./client";
+import {
+	getUserSpotifyAccessToken,
+	SpotifyApiError,
+	spotifyRequest,
+} from "./client";
+
+/** Wraps spotifyRequest with retry, but a 404 (deleted playlist) is never transient — abort immediately instead of burning retries on it. */
+function retryableSpotifyRequest<T>(fn: () => Promise<T>): Promise<T> {
+	return pRetry(
+		async () => {
+			try {
+				return await fn();
+			} catch (err) {
+				if (err instanceof SpotifyApiError && err.status === 404) {
+					throw new AbortError(err);
+				}
+				throw err;
+			}
+		},
+		{ retries: 2, minTimeout: 1000 },
+	);
+}
 
 export async function exportPlaylistToSpotify(
 	userId: string,
@@ -59,13 +80,23 @@ export async function exportPlaylistToSpotify(
 	}
 
 	if (pl.spotifyPlaylistId) {
-		return updateExistingPlaylist(
-			accessToken,
-			pl.spotifyPlaylistId,
-			pl,
-			filteredUris,
-			playlistId,
-		);
+		try {
+			return await updateExistingPlaylist(
+				accessToken,
+				pl.spotifyPlaylistId,
+				pl,
+				filteredUris,
+				playlistId,
+			);
+		} catch (err) {
+			if (!(err instanceof SpotifyApiError) || err.status !== 404) {
+				throw err;
+			}
+			logger.warn(
+				{ playlistId, spotifyPlaylistId: pl.spotifyPlaylistId },
+				"Spotify playlist was deleted; creating a new one",
+			);
+		}
 	}
 
 	return createNewPlaylist(accessToken, userId, pl, filteredUris, playlistId);
@@ -78,21 +109,19 @@ async function createNewPlaylist(
 	trackUris: string[],
 	playlistId: number,
 ): Promise<{ spotifyPlaylistId: string; spotifyUrl: string }> {
-	const created = await pRetry(
-		() =>
-			spotifyRequest<SpotifyCreatePlaylistResponse>(
-				"/me/playlists",
-				accessToken,
-				{
-					method: "POST",
-					body: {
-						name: pl.name,
-						description: pl.description ?? "",
-						public: false,
-					},
+	const created = await retryableSpotifyRequest(() =>
+		spotifyRequest<SpotifyCreatePlaylistResponse>(
+			"/me/playlists",
+			accessToken,
+			{
+				method: "POST",
+				body: {
+					name: pl.name,
+					description: pl.description ?? "",
+					public: false,
 				},
-			),
-		{ retries: 2, minTimeout: 1000 },
+			},
+		),
 	);
 
 	const spotifyPlaylistId = created.id;
@@ -104,13 +133,11 @@ async function createNewPlaylist(
 		i += SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST
 	) {
 		const batch = trackUris.slice(i, i + SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST);
-		await pRetry(
-			() =>
-				spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
-					method: "POST",
-					body: { uris: batch },
-				}),
-			{ retries: 2, minTimeout: 1000 },
+		await retryableSpotifyRequest(() =>
+			spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
+				method: "POST",
+				body: { uris: batch },
+			}),
 		);
 	}
 
@@ -137,27 +164,23 @@ async function updateExistingPlaylist(
 	trackUris: string[],
 	playlistId: number,
 ): Promise<{ spotifyPlaylistId: string; spotifyUrl: string }> {
-	await pRetry(
-		() =>
-			spotifyRequest(`/playlists/${spotifyPlaylistId}`, accessToken, {
-				method: "PUT",
-				body: {
-					name: pl.name,
-					description: pl.description ?? "",
-				},
-			}),
-		{ retries: 2, minTimeout: 1000 },
+	await retryableSpotifyRequest(() =>
+		spotifyRequest(`/playlists/${spotifyPlaylistId}`, accessToken, {
+			method: "PUT",
+			body: {
+				name: pl.name,
+				description: pl.description ?? "",
+			},
+		}),
 	);
 
-	await pRetry(
-		() =>
-			spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
-				method: "PUT",
-				body: {
-					uris: trackUris.slice(0, SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST),
-				},
-			}),
-		{ retries: 2, minTimeout: 1000 },
+	await retryableSpotifyRequest(() =>
+		spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
+			method: "PUT",
+			body: {
+				uris: trackUris.slice(0, SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST),
+			},
+		}),
 	);
 
 	for (
@@ -166,13 +189,11 @@ async function updateExistingPlaylist(
 		i += SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST
 	) {
 		const batch = trackUris.slice(i, i + SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST);
-		await pRetry(
-			() =>
-				spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
-					method: "POST",
-					body: { uris: batch },
-				}),
-			{ retries: 2, minTimeout: 1000 },
+		await retryableSpotifyRequest(() =>
+			spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
+				method: "POST",
+				body: { uris: batch },
+			}),
 		);
 	}
 


### PR DESCRIPTION
## Summary
- `spotifyRequest()` called `response.json()` unconditionally, but Spotify's `PUT /playlists/{id}` (change details) returns an empty body — this crashed with `SyntaxError: Unexpected end of JSON input`, retried twice pointlessly, then surfaced as a 500 on `playlists/export`.
- Added `SpotifyApiError` (carries the HTTP status) so callers can distinguish a 404 (playlist deleted on Spotify) from other failures.
- `updateExistingPlaylist` now catches a 404 and falls back to creating a brand new Spotify playlist instead of failing forever against a dead `spotifyPlaylistId`.
- 404s no longer waste retry attempts — `retryableSpotifyRequest` aborts immediately via `p-retry`'s `AbortError` since a 404 is never transient.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `client.test.ts` covers 204, empty-200, normal JSON body, and 404→`SpotifyApiError` cases (4/4 passing), full suite green (34/34)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [ ] Not verified live end-to-end against the real Spotify API (Chrome browser automation was unresponsive this session) — recommend a manual export test on next deploy

Closes #202
Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spotify integration reliability by retrying temporary request failures.
  * Deleted Spotify playlists are now automatically replaced when exports continue.
  * Empty successful Spotify responses are handled without errors.
  * Spotify request failures now preserve their HTTP status for more accurate error handling.
  * Unexpectedly empty playlist responses are now detected instead of being accepted silently.
* **Tests**
  * Added coverage for successful responses, empty results, retries, and not-found errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->