### PR TITLE
feat(brain): reconcile manual Spotify edits into playlist regeneration

### DIFF
--- a/packages/common/src/services/brain/__tests__/spotify-reconcile.test.ts
+++ b/packages/common/src/services/brain/__tests__/spotify-reconcile.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { diffManualSpotifyEdits } from "../spotify-reconcile";
+
+describe("diffManualSpotifyEdits", () => {
+	it("returns no changes when both sets match", () => {
+		const ids = new Set(["a", "b", "c"]);
+		expect(diffManualSpotifyEdits(ids, ids)).toEqual({
+			added: [],
+			removed: [],
+		});
+	});
+
+	it("detects a manually removed track", () => {
+		const harmonia = new Set(["a", "b", "c"]);
+		const live = new Set(["a", "c"]);
+		expect(diffManualSpotifyEdits(harmonia, live)).toEqual({
+			added: [],
+			removed: ["b"],
+		});
+	});
+
+	it("detects a manually added track", () => {
+		const harmonia = new Set(["a", "b"]);
+		const live = new Set(["a", "b", "d"]);
+		expect(diffManualSpotifyEdits(harmonia, live)).toEqual({
+			added: ["d"],
+			removed: [],
+		});
+	});
+
+	it("detects both an addition and a removal at once", () => {
+		const harmonia = new Set(["a", "b"]);
+		const live = new Set(["a", "d"]);
+		expect(diffManualSpotifyEdits(harmonia, live)).toEqual({
+			added: ["d"],
+			removed: ["b"],
+		});
+	});
+
+	it("treats an empty live playlist as removing every Harmonia track", () => {
+		const harmonia = new Set(["a", "b"]);
+		const live = new Set<string>();
+		expect(diffManualSpotifyEdits(harmonia, live)).toEqual({
+			added: [],
+			removed: ["a", "b"],
+		});
+	});
+});

--- a/packages/common/src/services/brain/playlist-generator.ts
+++ b/packages/common/src/services/brain/playlist-generator.ts
@@ -26,11 +26,13 @@ import { and, eq, inArray } from "drizzle-orm";
 import pLimit from "p-limit";
 import pRetry from "p-retry";
 import { parseJsonStringArray } from "../../utils/parse-json-string-array";
+import { getLatestPlaylistTrackIds } from "../music/spotify/playlist-cache";
 import {
 	jaccardSimilarity,
 	matchClustersToPlaylists,
 } from "./playlist-matcher";
 import { normalizePlaylistName } from "./playlist-naming";
+import { diffManualSpotifyEdits } from "./spotify-reconcile";
 
 // Below this track-overlap similarity, a cluster is treated as unrelated to
 // any existing playlist and gets a brand new one instead of an update.
@@ -92,7 +94,11 @@ export async function generatePlaylists(
 	// everything from scratch (issue #158). Fetched up front, before any
 	// per-cluster LLM/DB work, since matching needs the full picture at once.
 	const existingPlaylistRows = await db
-		.select({ id: playlist.id, name: playlist.name })
+		.select({
+			id: playlist.id,
+			name: playlist.name,
+			spotifyPlaylistId: playlist.spotifyPlaylistId,
+		})
 		.from(playlist)
 		.where(and(eq(playlist.userId, userId), eq(playlist.isGenerated, true)));
 
@@ -102,8 +108,10 @@ export async function generatePlaylists(
 	);
 
 	const existingTrackSetsByPlaylist = new Map<number, Set<string>>();
+	const spotifyPlaylistIdByPlaylistId = new Map<number, string | null>();
 	for (const p of existingPlaylistRows) {
 		existingTrackSetsByPlaylist.set(p.id, new Set());
+		spotifyPlaylistIdByPlaylistId.set(p.id, p.spotifyPlaylistId);
 	}
 	if (existingPlaylistRows.length > 0) {
 		const existingTrackRows = await db
@@ -181,7 +189,10 @@ export async function generatePlaylists(
 
 				if (matchedPlaylistId !== undefined) {
 					const updated = await updateExistingPlaylist({
+						userId,
 						playlistId: matchedPlaylistId,
+						spotifyPlaylistId:
+							spotifyPlaylistIdByPlaylistId.get(matchedPlaylistId) ?? null,
 						clusterId: c.id,
 						meta: c.metadata,
 						trackRows,
@@ -229,8 +240,76 @@ export async function generatePlaylists(
 	return stats;
 }
 
-async function updateExistingPlaylist(args: {
+/**
+ * Adjusts a cluster's track rows so a manual edit the user made directly on
+ * Spotify since the last export survives this run: tracks manually removed
+ * are excluded even if clustering would still place them here, and tracks
+ * manually added are preserved even though clustering doesn't know about
+ * them (#159). No-op if the playlist was never exported or hasn't been
+ * synced yet (getLatestPlaylistTrackIds returns null).
+ */
+async function reconcileManualSpotifyEdits(args: {
+	userId: string;
 	playlistId: number;
+	spotifyPlaylistId: string | null;
+	clusterTrackRows: TrackRow[];
+	oldTrackIds: Set<string>;
+}): Promise<TrackRow[]> {
+	const {
+		userId,
+		playlistId,
+		spotifyPlaylistId,
+		clusterTrackRows,
+		oldTrackIds,
+	} = args;
+
+	if (!spotifyPlaylistId) return clusterTrackRows;
+
+	const liveTrackIds = await getLatestPlaylistTrackIds(
+		userId,
+		spotifyPlaylistId,
+	);
+	if (!liveTrackIds) return clusterTrackRows;
+
+	const { added, removed } = diffManualSpotifyEdits(oldTrackIds, liveTrackIds);
+	if (added.length === 0 && removed.length === 0) return clusterTrackRows;
+
+	const removedSet = new Set(removed);
+	let trackRows = clusterTrackRows.filter((t) => !removedSet.has(t.id));
+
+	const clusterTrackIds = new Set(trackRows.map((t) => t.id));
+	const missingAdded = added.filter((id) => !clusterTrackIds.has(id));
+	if (missingAdded.length > 0) {
+		const addedRows = await db
+			.select({
+				id: track.id,
+				name: track.name,
+				artistNames: track.artistNames,
+				llmMood: track.llmMood,
+				llmTags: track.llmTags,
+			})
+			.from(track)
+			.where(inArray(track.id, missingAdded));
+		trackRows = [...trackRows, ...addedRows];
+	}
+
+	logger.info(
+		{
+			playlistId,
+			spotifyPlaylistId,
+			manuallyAdded: missingAdded.length,
+			manuallyRemoved: removed.length,
+		},
+		"Reconciled manual Spotify edits into playlist regeneration",
+	);
+
+	return trackRows;
+}
+
+async function updateExistingPlaylist(args: {
+	userId: string;
+	playlistId: number;
+	spotifyPlaylistId: string | null;
 	clusterId: number;
 	meta: ClusterMeta | null;
 	trackRows: TrackRow[];
@@ -238,13 +317,22 @@ async function updateExistingPlaylist(args: {
 	usedPlaylistNames: Set<string>;
 }): Promise<boolean> {
 	const {
+		userId,
 		playlistId,
+		spotifyPlaylistId,
 		clusterId,
 		meta,
-		trackRows,
 		oldTrackIds,
 		usedPlaylistNames,
 	} = args;
+
+	const trackRows = await reconcileManualSpotifyEdits({
+		userId,
+		playlistId,
+		spotifyPlaylistId,
+		clusterTrackRows: args.trackRows,
+		oldTrackIds,
+	});
 
 	const newTrackIds = new Set(trackRows.map((t) => t.id));
 	const similarity = jaccardSimilarity(oldTrackIds, newTrackIds);

--- a/packages/common/src/services/brain/spotify-reconcile.ts
+++ b/packages/common/src/services/brain/spotify-reconcile.ts
@@ -1,0 +1,22 @@
+/**
+ * Diffs Harmonia's last-known track set for a playlist against what's
+ * actually on Spotify right now, so a manual edit the user made directly on
+ * Spotify (added or removed a track) survives the next pipeline run instead
+ * of being silently overwritten by clustering output (#159).
+ */
+export function diffManualSpotifyEdits(
+	harmoniaTrackIds: ReadonlySet<string>,
+	liveSpotifyTrackIds: ReadonlySet<string>,
+): { added: string[]; removed: string[] } {
+	const added: string[] = [];
+	for (const id of liveSpotifyTrackIds) {
+		if (!harmoniaTrackIds.has(id)) added.push(id);
+	}
+
+	const removed: string[] = [];
+	for (const id of harmoniaTrackIds) {
+		if (!liveSpotifyTrackIds.has(id)) removed.push(id);
+	}
+
+	return { added, removed };
+}

--- a/packages/common/src/services/music/spotify/playlist-cache.ts
+++ b/packages/common/src/services/music/spotify/playlist-cache.ts
@@ -84,6 +84,46 @@ export async function getCachedPlaylistItems(
 }
 
 /**
+ * Returns the track IDs from the most recently cached snapshot of a playlist,
+ * regardless of what that snapshot's ID is — used to read the *current* live
+ * Spotify state of a playlist (kept fresh by the library-sync stage that runs
+ * before playlist generation each pipeline run). Returns null if the playlist
+ * has never been synced yet.
+ */
+export async function getLatestPlaylistTrackIds(
+	userId: string,
+	playlistId: string,
+): Promise<Set<string> | null> {
+	const [snapshot] = await db
+		.select({ snapshotId: userPlaylistSnapshots.snapshotId })
+		.from(userPlaylistSnapshots)
+		.where(
+			and(
+				eq(userPlaylistSnapshots.userId, userId),
+				eq(userPlaylistSnapshots.playlistId, playlistId),
+			),
+		)
+		.limit(1);
+
+	if (!snapshot) {
+		return null;
+	}
+
+	const items = await db
+		.select({ trackId: userPlaylistSnapshotItems.trackId })
+		.from(userPlaylistSnapshotItems)
+		.where(
+			and(
+				eq(userPlaylistSnapshotItems.userId, userId),
+				eq(userPlaylistSnapshotItems.playlistId, playlistId),
+				eq(userPlaylistSnapshotItems.snapshotId, snapshot.snapshotId),
+			),
+		);
+
+	return new Set(items.map((i) => i.trackId));
+}
+
+/**
  * Stores playlist items in the cache. Deletes existing rows for (userId, playlistId) first.
  */
 export async function setCachedPlaylistItems(


### PR DESCRIPTION
## Summary
- Playlist export was pure last-writer-wins: every pipeline run overwrote a matched playlist's tracklist purely from clustering output, silently re-adding tracks the user had manually removed on Spotify and dropping tracks they'd manually added.
- `getLatestPlaylistTrackIds` (new, in `playlist-cache.ts`) reads a playlist's current live track set from the existing `userPlaylistSnapshots`/`userPlaylistSnapshotItems` cache — the same cache the sync stage already keeps fresh for every owned Spotify playlist, before generate/export run in the same pipeline run. Returns `null` if the playlist has never been synced yet (safe no-op).
- `diffManualSpotifyEdits` (new, pure, `spotify-reconcile.ts`) diffs Harmonia's last-known track set against the live one, returning `added`/`removed` track IDs.
- `reconcileManualSpotifyEdits` (new, in `playlist-generator.ts`) uses that diff to adjust a cluster's track rows before they're written: excludes manually-removed tracks even if clustering still wants them, and re-includes manually-added tracks if Harmonia already has them in its own `track` table.
- Wired into `updateExistingPlaylist` — the reconciled track set is what similarity/metadata-regen decisions and the final DB write are based on, so a manual deletion on Spotify now also gets removed from Harmonia's own `playlistTracks`, not just re-added on next export.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `spotify-reconcile.test.ts` (5 cases: no change, removal only, addition only, both at once, fully emptied playlist), full suite green (39/39)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified against a live pipeline run with real manual Spotify edits (would need a full sync → generate → export cycle against a real account) — recommend validating on next real run

Closes #159