### PR TITLE
fix(brain): close escape hatches allowing under/oversized clusters

### DIFF
--- a/packages/common/src/services/brain/__tests__/clustering.test.ts
+++ b/packages/common/src/services/brain/__tests__/clustering.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@harmonia/db", () => ({ db: {} }));
+
+import { mergeSmallClusters, splitLargeClusters } from "../clustering";
+
+function totalIndices(clusters: number[][]): number[] {
+	return clusters.flat().sort((a, b) => a - b);
+}
+
+describe("mergeSmallClusters", () => {
+	it("merges a small cluster into the nearest large cluster by centroid", () => {
+		const embeddings: number[][] = [];
+		embeddings[0] = [0];
+		embeddings[1] = [0.1];
+		embeddings[2] = [0.2];
+		embeddings[5] = [100];
+		embeddings[6] = [100.1];
+		embeddings[7] = [100.2];
+		embeddings[8] = [99];
+
+		const result = mergeSmallClusters(
+			[[0, 1, 2], [5, 6, 7], [8]],
+			embeddings,
+			3,
+		);
+
+		expect(result).toHaveLength(2);
+		expect(result).toContainEqual([0, 1, 2]);
+		expect(result).toContainEqual([5, 6, 7, 8]);
+	});
+
+	it("merges clusters together when none reaches minSize on its own (issue #204)", () => {
+		const embeddings: number[][] = Array.from({ length: 12 }, (_, i) => [i]);
+
+		const result = mergeSmallClusters(
+			[
+				[0, 1, 2],
+				[3, 4, 5],
+				[6, 7, 8],
+				[9, 10, 11],
+			],
+			embeddings,
+			8,
+		);
+
+		// Every original index must still be present exactly once, and no
+		// output cluster count exceeds the input's — nothing was dropped or
+		// duplicated by the recursive merge.
+		expect(totalIndices(result)).toEqual(
+			Array.from({ length: 12 }, (_, i) => i),
+		);
+		expect(result.length).toBeLessThan(4);
+	});
+
+	it("bottoms out at a single cluster when the whole library is below minSize", () => {
+		const embeddings: number[][] = Array.from({ length: 5 }, (_, i) => [i]);
+
+		const result = mergeSmallClusters([[0, 1], [2, 3], [4]], embeddings, 20);
+
+		expect(result).toHaveLength(1);
+		expect(totalIndices(result)).toEqual([0, 1, 2, 3, 4]);
+	});
+
+	it("is a no-op for a single input cluster", () => {
+		const embeddings: number[][] = [[0], [1]];
+		expect(mergeSmallClusters([[0, 1]], embeddings, 10)).toEqual([[0, 1]]);
+	});
+});
+
+describe("splitLargeClusters", () => {
+	it("leaves clusters at or under maxSize untouched", () => {
+		const embeddings: number[][] = Array.from({ length: 10 }, (_, i) => [i]);
+		const cluster = Array.from({ length: 10 }, (_, i) => i);
+		expect(splitLargeClusters([cluster], embeddings, 80, 5)).toEqual([cluster]);
+	});
+
+	it("guarantees no output bucket exceeds maxSize even in a worst-case split (issue #204)", () => {
+		// All embeddings identical: DBSCAN/k-means can't meaningfully separate
+		// them, forcing the max-recursion-depth fallback path.
+		const size = 200;
+		const maxSize = 80;
+		const embeddings: number[][] = Array.from({ length: size }, () => [0]);
+		const cluster = Array.from({ length: size }, (_, i) => i);
+
+		const result = splitLargeClusters([cluster], embeddings, maxSize, 5);
+
+		for (const bucket of result) {
+			expect(bucket.length).toBeLessThanOrEqual(maxSize);
+		}
+		expect(totalIndices(result)).toEqual(
+			Array.from({ length: size }, (_, i) => i),
+		);
+	});
+});

--- a/packages/common/src/services/brain/clustering.ts
+++ b/packages/common/src/services/brain/clustering.ts
@@ -167,11 +167,14 @@ export async function runClustering(
 	return stats;
 }
 
-function mergeSmallClusters(
+// Exported for direct unit testing (issue #204) — pure, deterministic, no I/O.
+export function mergeSmallClusters(
 	clusters: number[][],
 	embeddings: number[][],
 	minSize: number,
 ): number[][] {
+	if (clusters.length <= 1) return clusters;
+
 	const large: number[][] = [];
 	const small: number[][] = [];
 
@@ -183,7 +186,39 @@ function mergeSmallClusters(
 		}
 	}
 
-	if (large.length === 0) return clusters;
+	if (large.length === 0) {
+		// No cluster reached minSize on its own (issue #204) — merge the two
+		// closest-by-centroid small clusters together and retry, so small
+		// clusters combine with whichever is musically nearest instead of
+		// every one of them shipping as an under-sized playlist. Bottoms out
+		// at a single cluster if the whole library is smaller than minSize,
+		// which is an inherent data limit, not a bug.
+		if (small.length <= 1) return clusters;
+
+		const smallCentroids = small.map((indices) =>
+			computeCentroid(indices.map((i) => embeddings[i] as number[])),
+		);
+		let bestI = 0;
+		let bestJ = 1;
+		let bestDist = Number.POSITIVE_INFINITY;
+		for (let i = 0; i < small.length; i++) {
+			for (let j = i + 1; j < small.length; j++) {
+				const dist = euclideanDistance(
+					smallCentroids[i] as number[],
+					smallCentroids[j] as number[],
+				);
+				if (dist < bestDist) {
+					bestDist = dist;
+					bestI = i;
+					bestJ = j;
+				}
+			}
+		}
+
+		const merged = [...(small[bestI] ?? []), ...(small[bestJ] ?? [])];
+		const rest = small.filter((_, idx) => idx !== bestI && idx !== bestJ);
+		return mergeSmallClusters([merged, ...rest], embeddings, minSize);
+	}
 
 	const centroids = large.map((indices) =>
 		computeCentroid(indices.map((i) => embeddings[i] as number[])),
@@ -208,7 +243,8 @@ function mergeSmallClusters(
 	return large;
 }
 
-function splitLargeClusters(
+// Exported for direct unit testing (issue #204) — pure, deterministic, no I/O.
+export function splitLargeClusters(
 	clusters: number[][],
 	embeddings: number[][],
 	maxSize: number,
@@ -249,7 +285,19 @@ function splitLargeClusters(
 
 		// Neither method guarantees every bucket is under maxSize, so re-split recursively.
 		if (depth >= MAX_SPLIT_DEPTH) {
-			result.push(...candidates);
+			// Retries are exhausted — force every remaining oversized bucket under
+			// the cap with a plain positional chunk (issue #204). Not centroid-
+			// aware, but a guaranteed size limit matters more than perfect
+			// grouping in this now-rare fallback path.
+			for (const bucket of candidates) {
+				if (bucket.length <= maxSize) {
+					result.push(bucket);
+					continue;
+				}
+				for (let i = 0; i < bucket.length; i += maxSize) {
+					result.push(bucket.slice(i, i + maxSize));
+				}
+			}
 			continue;
 		}
 		result.push(


### PR DESCRIPTION
## Summary
- `mergeSmallClusters` bypassed `CLUSTER_MIN_SIZE` (20) entirely whenever no raw DBSCAN cluster reached it on its own (`if (large.length === 0) return clusters;`) — shipped every tiny cluster as its own under-sized playlist. It now recursively merges the closest-by-centroid pair of small clusters until one clears the minimum, or bottoms out at a single cluster if the whole library is smaller than the minimum (an inherent data limit, not a bug).
- `splitLargeClusters` gave up after `MAX_SPLIT_DEPTH` (4) and accepted whatever the last DBSCAN/k-means attempt produced, even if still over `CLUSTER_MAX_SIZE` (80) — the comment in the code even said as much. It now force-chunks any still-oversized bucket at that point (positional slicing, not centroid-aware, but guarantees the cap).
- Exported both functions (previously private) so they're directly unit-testable without a DB.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `clustering.test.ts` (6 cases: nearest-large-cluster merge preserved, all-small merge-down preserves every index, bottoms out at 1 cluster for a too-small library, single-cluster no-op, under-max-size no-op, and a worst-case 200-identical-embeddings split that forces the max-depth fallback and asserts every bucket stays ≤ maxSize), full suite green (41/41)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified against a real clustering run with a live library (needs a full pipeline run) — recommend validating cluster size distribution on next real run via the existing "clustering sanity" log line

Closes #204