### PR TITLE
fix(brain): cap incremental track matching at CLUSTER_MAX_SIZE

### DIFF
--- a/packages/common/src/services/brain/__tests__/track-matcher.test.ts
+++ b/packages/common/src/services/brain/__tests__/track-matcher.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@harmonia/db", () => ({ db: {} }));
+
+import { pickBestPlaylistForTrack } from "../track-matcher";
+
+describe("pickBestPlaylistForTrack", () => {
+	it("picks the most similar playlist above the threshold", () => {
+		const result = pickBestPlaylistForTrack(
+			[1, 0],
+			[
+				{ id: 1, centroid: [0, 1], trackCount: 0 },
+				{ id: 2, centroid: [1, 0], trackCount: 0 },
+			],
+			80,
+			0.5,
+		);
+		expect(result).toBe(2);
+	});
+
+	it("returns null when nothing clears the similarity threshold", () => {
+		const result = pickBestPlaylistForTrack(
+			[1, 0],
+			[{ id: 1, centroid: [0, 1], trackCount: 0 }],
+			80,
+			0.5,
+		);
+		expect(result).toBeNull();
+	});
+
+	it("excludes a playlist already at maxSize even if it's the best match (issue #210)", () => {
+		const result = pickBestPlaylistForTrack(
+			[1, 0],
+			[
+				{ id: 1, centroid: [1, 0], trackCount: 80 },
+				{ id: 2, centroid: [0.9, 0.1], trackCount: 10 },
+			],
+			80,
+			0.5,
+		);
+		expect(result).toBe(2);
+	});
+
+	it("returns null when every candidate is at or over maxSize", () => {
+		const result = pickBestPlaylistForTrack(
+			[1, 0],
+			[{ id: 1, centroid: [1, 0], trackCount: 80 }],
+			80,
+			0.5,
+		);
+		expect(result).toBeNull();
+	});
+
+	it("ignores candidates without a centroid", () => {
+		const result = pickBestPlaylistForTrack(
+			[1, 0],
+			[
+				{ id: 1, centroid: null, trackCount: 0 },
+				{ id: 2, centroid: [1, 0], trackCount: 0 },
+			],
+			80,
+			0.5,
+		);
+		expect(result).toBe(2);
+	});
+});

--- a/packages/common/src/services/brain/track-matcher.ts
+++ b/packages/common/src/services/brain/track-matcher.ts
@@ -9,7 +9,10 @@ import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 
-import { TRACK_MATCH_SIMILARITY_THRESHOLD } from "../../constants/brain";
+import {
+	CLUSTER_MAX_SIZE,
+	TRACK_MATCH_SIMILARITY_THRESHOLD,
+} from "../../constants/brain";
 
 export type TrackMatchResult = {
 	matched: number;
@@ -68,29 +71,35 @@ export async function matchNewTracksToPlaylists(
 		return { matched: 0, touchedPlaylistIds: [] };
 	}
 
+	// Tracked and updated as we go so a run that matches several tracks to the
+	// same playlist can't push it past CLUSTER_MAX_SIZE (#210) — this stage
+	// runs every pipeline run with no other size gate on incremental growth.
+	const trackCounts = new Map<number, number>();
+	for (const p of playlists) {
+		const [countResult] = await db
+			.select({ count: sql<number>`COUNT(*)` })
+			.from(playlistTracks)
+			.where(eq(playlistTracks.playlistId, p.id));
+		trackCounts.set(p.id, countResult?.count ?? 0);
+	}
+
 	let matched = 0;
 	const touchedPlaylistIds = new Set<number>();
 
 	for (const t of tracksToMatch) {
 		const embedding = t.embedding as number[];
-		let bestPlaylistId: number | null = null;
-		let bestSimilarity = -1;
+		const bestPlaylistId = pickBestPlaylistForTrack(
+			embedding,
+			playlists.map((p) => ({
+				id: p.id,
+				centroid: p.centroid as number[] | null,
+				trackCount: trackCounts.get(p.id) ?? 0,
+			})),
+			CLUSTER_MAX_SIZE,
+			TRACK_MATCH_SIMILARITY_THRESHOLD,
+		);
 
-		for (const p of playlists) {
-			const centroid = p.centroid as number[];
-			if (!centroid || centroid.length === 0) continue;
-
-			const similarity = cosineSimilarity(embedding, centroid);
-			if (similarity > bestSimilarity) {
-				bestSimilarity = similarity;
-				bestPlaylistId = p.id;
-			}
-		}
-
-		if (
-			bestPlaylistId !== null &&
-			bestSimilarity >= TRACK_MATCH_SIMILARITY_THRESHOLD
-		) {
+		if (bestPlaylistId !== null) {
 			const [maxPos] = await db
 				.select({
 					max: sql<number>`COALESCE(MAX(${playlistTracks.position}), -1)`,
@@ -111,6 +120,10 @@ export async function matchNewTracksToPlaylists(
 
 			matched++;
 			touchedPlaylistIds.add(bestPlaylistId);
+			trackCounts.set(
+				bestPlaylistId,
+				(trackCounts.get(bestPlaylistId) ?? 0) + 1,
+			);
 		}
 	}
 
@@ -132,6 +145,38 @@ export async function matchNewTracksToPlaylists(
 	);
 
 	return { matched, touchedPlaylistIds: [...touchedPlaylistIds] };
+}
+
+/**
+ * Picks the most similar playlist for a track's embedding, excluding any
+ * playlist already at maxSize (#210) and requiring the best similarity to
+ * clear similarityThreshold. Pure and DB-free so it's directly unit-testable.
+ */
+export function pickBestPlaylistForTrack(
+	embedding: number[],
+	candidates: Array<{
+		id: number;
+		centroid: number[] | null;
+		trackCount: number;
+	}>,
+	maxSize: number,
+	similarityThreshold: number,
+): number | null {
+	let bestPlaylistId: number | null = null;
+	let bestSimilarity = -1;
+
+	for (const candidate of candidates) {
+		if (!candidate.centroid || candidate.centroid.length === 0) continue;
+		if (candidate.trackCount >= maxSize) continue;
+
+		const similarity = cosineSimilarity(embedding, candidate.centroid);
+		if (similarity > bestSimilarity) {
+			bestSimilarity = similarity;
+			bestPlaylistId = candidate.id;
+		}
+	}
+
+	return bestSimilarity >= similarityThreshold ? bestPlaylistId : null;
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {


### PR DESCRIPTION
## Summary
- `matchNewTracksToPlaylists()` (the "match" pipeline stage) assigns each newly-classified/embedded track to whichever existing playlist's centroid it's most similar to, every run, with **no size cap at all** — confirmed against the local dev DB as the likely cause of a playlist that reached 545 tracks (another reached 332), both several times over `CLUSTER_MAX_SIZE` (80), incrementally over many runs.
- Now tracks each candidate playlist's current size while matching (updated as tracks are assigned within the same run) and skips any playlist already at or over the cap — a track that would have landed there is left unassigned instead, for the next full clustering run to place into a proper-sized cluster.
- Extracted the best-playlist selection logic into `pickBestPlaylistForTrack`, a pure function, so it's directly unit-testable without mocking the DB.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `track-matcher.test.ts` (5 cases: picks most similar above threshold, returns null below threshold, excludes an at-cap playlist even if it's the best match, returns null when every candidate is at cap, ignores centroid-less candidates), full suite green (35/35 on this branch)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified against a real pipeline run (would need several match-stage runs against a live library to see growth actually stop at the cap) — recommend spot-checking playlist sizes after the next real run

Closes #210