### PR TITLE
feat(brain): prune orphaned playlists that no longer match any cluster

### DIFF
--- a/packages/common/src/services/brain/__tests__/playlist-generator.test.ts
+++ b/packages/common/src/services/brain/__tests__/playlist-generator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@harmonia/db", () => ({ db: {} }));
+
+import { findPrunableOrphanedPlaylists } from "../playlist-generator";
+
+describe("findPrunableOrphanedPlaylists", () => {
+	it("returns no prunable playlists when every playlist is matched", () => {
+		const result = findPrunableOrphanedPlaylists(
+			[
+				{ id: 1, spotifyPlaylistId: null },
+				{ id: 2, spotifyPlaylistId: "spotify-2" },
+			],
+			new Set([1, 2]),
+		);
+		expect(result).toEqual({ prunable: [], exportedOrphanCount: 0 });
+	});
+
+	it("prunes an orphaned playlist that was never exported", () => {
+		const result = findPrunableOrphanedPlaylists(
+			[
+				{ id: 1, spotifyPlaylistId: null },
+				{ id: 2, spotifyPlaylistId: "spotify-2" },
+			],
+			new Set([2]),
+		);
+		expect(result).toEqual({ prunable: [1], exportedOrphanCount: 0 });
+	});
+
+	it("leaves an orphaned but already-exported playlist alone, counted separately", () => {
+		const result = findPrunableOrphanedPlaylists(
+			[
+				{ id: 1, spotifyPlaylistId: "spotify-1" },
+				{ id: 2, spotifyPlaylistId: null },
+			],
+			new Set([]),
+		);
+		expect(result).toEqual({ prunable: [2], exportedOrphanCount: 1 });
+	});
+
+	it("prunes multiple never-exported orphans at once", () => {
+		const result = findPrunableOrphanedPlaylists(
+			[
+				{ id: 1, spotifyPlaylistId: null },
+				{ id: 2, spotifyPlaylistId: null },
+				{ id: 3, spotifyPlaylistId: null },
+			],
+			new Set([]),
+		);
+		expect(result.prunable.sort()).toEqual([1, 2, 3]);
+		expect(result.exportedOrphanCount).toBe(0);
+	});
+});

--- a/packages/common/src/services/brain/playlist-generator.ts
+++ b/packages/common/src/services/brain/playlist-generator.ts
@@ -92,7 +92,11 @@ export async function generatePlaylists(
 	// everything from scratch (issue #158). Fetched up front, before any
 	// per-cluster LLM/DB work, since matching needs the full picture at once.
 	const existingPlaylistRows = await db
-		.select({ id: playlist.id, name: playlist.name })
+		.select({
+			id: playlist.id,
+			name: playlist.name,
+			spotifyPlaylistId: playlist.spotifyPlaylistId,
+		})
 		.from(playlist)
 		.where(and(eq(playlist.userId, userId), eq(playlist.isGenerated, true)));
 
@@ -167,6 +171,32 @@ export async function generatePlaylists(
 	const matchedPlaylistIdByClusterIndex = new Map(
 		matches.map((m) => [m.clusterIndex, m.playlistId]),
 	);
+
+	// A playlist that no longer matches any current cluster is an orphan (#206)
+	// — clustering has moved on but nothing ever cleaned it up. Only prune ones
+	// never exported to Spotify; an already-exported orphan is left alone until
+	// there's a deliberate staleness UX, since deleting the Harmonia row
+	// wouldn't touch the real Spotify playlist the user may still be using.
+	const { prunable: prunablePlaylistIds, exportedOrphanCount } =
+		findPrunableOrphanedPlaylists(
+			existingPlaylistRows,
+			new Set(matches.map((m) => m.playlistId)),
+		);
+
+	if (prunablePlaylistIds.length > 0) {
+		await db.delete(playlist).where(inArray(playlist.id, prunablePlaylistIds));
+		logger.info(
+			{ userId, prunedCount: prunablePlaylistIds.length },
+			"Pruned orphaned playlists that no longer match any cluster and were never exported",
+		);
+	}
+
+	if (exportedOrphanCount > 0) {
+		logger.warn(
+			{ userId, exportedOrphanCount },
+			"Some exported playlists no longer match any current cluster; left untouched pending a staleness UX decision (#206)",
+		);
+	}
 
 	const genLimit = pLimit(5);
 
@@ -425,6 +455,25 @@ async function createNewPlaylist(args: {
 		);
 		return null;
 	}
+}
+
+/**
+ * Splits existing playlists into ones prunable now (no current cluster match
+ * and never exported to Spotify) vs. exported orphans, which are left alone
+ * pending a staleness UX decision (#206). Pure, no I/O.
+ */
+export function findPrunableOrphanedPlaylists(
+	existingPlaylists: Array<{ id: number; spotifyPlaylistId: string | null }>,
+	matchedPlaylistIds: ReadonlySet<number>,
+): { prunable: number[]; exportedOrphanCount: number } {
+	const orphaned = existingPlaylists.filter(
+		(p) => !matchedPlaylistIds.has(p.id),
+	);
+	const prunable = orphaned
+		.filter((p) => !p.spotifyPlaylistId)
+		.map((p) => p.id);
+	const exportedOrphanCount = orphaned.length - prunable.length;
+	return { prunable, exportedOrphanCount };
 }
 
 function deriveTags(meta: ClusterMeta | null, trackRows: TrackRow[]): string[] {


### PR DESCRIPTION
## Summary
- Confirmed against the local dev DB: **37 of 50** generated playlists have no current cluster link at all (`playlist_clusters` row missing or pointing at a cluster that no longer exists). Every one is a leftover from a previous run whose cluster stopped matching — clustering drifted, nothing ever cleaned up the playlist it left behind. All 37 were never exported to Spotify.
- This directly explains two of the original bug reports in the same investigation: the "5-track"/"4-track" playlists and the giant 545/332-track ones are mostly these orphans, not necessarily a live clustering-quality issue (see #204, #210 for the separate real clustering bugs also found and fixed).
- It also explains the "some playlists show only track count, no mood/energy/themes" report (#205): an orphaned playlist has no `playlist_clusters` row, so the dashboard's join to `cluster.metadata` returns nothing — not a Groq/metadata-generation bug as originally hypothesized, just orphans with no cluster to join against.
- `generatePlaylists()` now deletes orphaned playlists that were **never exported** to Spotify (safe — nothing user-facing depends on them, and in this dev DB none of the 37 were exported anyway). An orphan that **was** exported is left alone and logged instead, since auto-deleting it wouldn't touch the real Spotify playlist and could surprise a user who's still using it there — that case needs a deliberate staleness UX decision, tracked as a follow-up in #206 itself.
- Extracted the selection logic into `findPrunableOrphanedPlaylists`, a pure function, for direct unit test coverage.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `playlist-generator.test.ts` (4 cases: no orphans, prunes a never-exported orphan, leaves an exported orphan alone while still counting it, prunes multiple at once), full suite green (34/34 on this branch)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [x] Verified the underlying orphan count directly against the local dev DB (37/50, 0 exported) before writing this fix
- [ ] Not verified against a real pipeline run pruning real data — recommend spot-checking playlist count before/after the next real run

Closes #206