### PR TITLE
fix(brain): persist Spotify's real added_at for liked tracks

### DIFF
--- a/packages/common/src/services/music/spotify/__tests__/library-sync.test.ts
+++ b/packages/common/src/services/music/spotify/__tests__/library-sync.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@harmonia/db", () => ({ db: {}, conflictValue: vi.fn() }));
+
+import { partitionTracksByKnownLikedAt } from "../library-sync";
+
+describe("partitionTracksByKnownLikedAt", () => {
+	it("puts every track in withoutLikedAt when nothing is known", () => {
+		const result = partitionTracksByKnownLikedAt(
+			[{ id: "a" }, { id: "b" }],
+			new Map(),
+		);
+		expect(result.withLikedAt).toEqual([]);
+		expect(result.withoutLikedAt).toEqual([{ id: "a" }, { id: "b" }]);
+	});
+
+	it("puts every track in withLikedAt when all are known", () => {
+		const likedAt = new Date("2026-01-01T00:00:00Z");
+		const result = partitionTracksByKnownLikedAt(
+			[{ id: "a" }, { id: "b" }],
+			new Map([
+				["a", likedAt],
+				["b", likedAt],
+			]),
+		);
+		expect(result.withLikedAt).toEqual([
+			{ id: "a", addedAt: likedAt },
+			{ id: "b", addedAt: likedAt },
+		]);
+		expect(result.withoutLikedAt).toEqual([]);
+	});
+
+	it("splits a mix of known and unknown tracks", () => {
+		const likedAt = new Date("2026-02-01T00:00:00Z");
+		const result = partitionTracksByKnownLikedAt(
+			[{ id: "a" }, { id: "b" }, { id: "c" }],
+			new Map([["b", likedAt]]),
+		);
+		expect(result.withLikedAt).toEqual([{ id: "b", addedAt: likedAt }]);
+		expect(result.withoutLikedAt).toEqual([{ id: "a" }, { id: "c" }]);
+	});
+
+	it("preserves extra fields on the input track objects", () => {
+		const likedAt = new Date("2026-03-01T00:00:00Z");
+		const result = partitionTracksByKnownLikedAt(
+			[{ id: "a", name: "Track A" }],
+			new Map([["a", likedAt]]),
+		);
+		expect(result.withLikedAt).toEqual([
+			{ id: "a", name: "Track A", addedAt: likedAt },
+		]);
+	});
+});

--- a/packages/common/src/services/music/spotify/library-sync.ts
+++ b/packages/common/src/services/music/spotify/library-sync.ts
@@ -80,6 +80,33 @@ function normalizeTrack(t: {
 	};
 }
 
+/**
+ * Splits tracks into ones whose real "liked at" date is known (from
+ * Spotify's saved-tracks `added_at`) vs. unknown (track was only ever seen
+ * via a playlist scan, never in Liked Songs) — the two groups need different
+ * upsert conflict handling: known dates can safely overwrite a stale
+ * placeholder, unknown ones must never clobber an already-correct value with
+ * the insert-time default (#214). Pure, no I/O.
+ */
+export function partitionTracksByKnownLikedAt<T extends { id: string }>(
+	tracks: T[],
+	likedAtByTrackId: ReadonlyMap<string, Date>,
+): { withLikedAt: Array<T & { addedAt: Date }>; withoutLikedAt: T[] } {
+	const withLikedAt: Array<T & { addedAt: Date }> = [];
+	const withoutLikedAt: T[] = [];
+
+	for (const t of tracks) {
+		const addedAt = likedAtByTrackId.get(t.id);
+		if (addedAt) {
+			withLikedAt.push({ ...t, addedAt });
+		} else {
+			withoutLikedAt.push(t);
+		}
+	}
+
+	return { withLikedAt, withoutLikedAt };
+}
+
 export function extractTrackInfo(items: SpotifyPlaylistTrackItem[]): {
 	trackIds: Set<string>;
 	albumKeys: Set<string>;
@@ -167,6 +194,9 @@ export async function syncLibraryTracks(
 	const albumNames = new Set<string>();
 	const artistNames = new Set<string>();
 	const tracksMap = new Map<string, TrackForUpsert>();
+	// Real "liked at" date per track, from Spotify's saved-tracks added_at —
+	// only populated for tracks actually in Liked Songs (#214).
+	const likedAtByTrackId = new Map<string, Date>();
 
 	// 1. Saved tracks (progress per Spotify page)
 	let savedTracksTotalFromApi: number | undefined;
@@ -188,7 +218,10 @@ export async function syncLibraryTracks(
 				if (artistKey) artistNames.add(artistKey);
 			}
 			const normalized = normalizeTrack(t);
-			if (normalized) tracksMap.set(normalized.id, normalized);
+			if (normalized) {
+				tracksMap.set(normalized.id, normalized);
+				likedAtByTrackId.set(normalized.id, new Date(item.added_at));
+			}
 		}
 	};
 
@@ -390,8 +423,27 @@ export async function syncLibraryTracks(
 			});
 	}
 
-	for (let i = 0; i < tracks.length; i += TRACK_UPSERT_BATCH_SIZE) {
-		const batch = tracks.slice(i, i + TRACK_UPSERT_BATCH_SIZE);
+	// Tracks with a known real liked-at date self-heal a stale placeholder on
+	// every sync; tracks without one must never touch an existing row's
+	// addedAt with the insert-time default (#214).
+	const { withLikedAt, withoutLikedAt } = partitionTracksByKnownLikedAt(
+		tracks,
+		likedAtByTrackId,
+	);
+
+	for (let i = 0; i < withLikedAt.length; i += TRACK_UPSERT_BATCH_SIZE) {
+		const batch = withLikedAt.slice(i, i + TRACK_UPSERT_BATCH_SIZE);
+		await db
+			.insert(userTracks)
+			.values(batch.map((t) => ({ userId, trackId: t.id, addedAt: t.addedAt })))
+			.onConflictDoUpdate({
+				target: [userTracks.userId, userTracks.trackId],
+				set: { addedAt: conflictValue(userTracks.addedAt) },
+			});
+	}
+
+	for (let i = 0; i < withoutLikedAt.length; i += TRACK_UPSERT_BATCH_SIZE) {
+		const batch = withoutLikedAt.slice(i, i + TRACK_UPSERT_BATCH_SIZE);
 		await db
 			.insert(userTracks)
 			.values(batch.map((t) => ({ userId, trackId: t.id })))


### PR DESCRIPTION
## Summary
- `userTracks.addedAt` never reflected when the user actually saved a track on Spotify — `library-sync.ts`'s upsert only ever inserted `{ userId, trackId }`, so the column always fell back to its insert-time default (`now()`), i.e. whenever Harmonia's sync first happened to see the track.
- Spotify's saved-tracks API already returns a real `added_at` per item — it's typed in `SpotifySavedTracksResponse` but was never read. Now captured during the saved-tracks sync phase into a `likedAtByTrackId` map.
- Split the final upsert into two batches via a new pure `partitionTracksByKnownLikedAt`: tracks with a known liked-at date use `onConflictDoUpdate` (self-heals a stale placeholder on every sync, safe since Spotify's `added_at` never changes for an existing saved track), tracks only ever seen via a playlist scan (never in Liked Songs) keep the original `onConflictDoNothing` so an already-correct value is never overwritten by a guess.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `library-sync.test.ts` (4 cases: none known, all known, mixed split, extra fields preserved), full suite green (59/59)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified against a live sync (would need a real Spotify account re-sync to confirm `addedAt` values land correctly) — recommend spot-checking a few tracks after the next real sync

Closes #214