### PR TITLE
feat(dashboard): track detail page with full analysis, lyrics, liked-at, and playlist membership

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/tracks/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/tracks/[id]/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { use } from "react";
+import {
+	DashboardTrackDetail,
+	DashboardTrackDetailNotFound,
+	DashboardTrackDetailSkeleton,
+} from "@/components/app/dashboard-track-detail";
+import { orpc } from "@/shared/api/orpc";
+
+export default function TrackDetailPage({
+	params,
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = use(params);
+
+	const {
+		data: track,
+		isLoading,
+		isError,
+	} = useQuery(orpc.tracks.getById.queryOptions({ input: { id } }));
+
+	if (isLoading) {
+		return <DashboardTrackDetailSkeleton />;
+	}
+
+	if (isError || !track) {
+		return <DashboardTrackDetailNotFound />;
+	}
+
+	return <DashboardTrackDetail track={track} />;
+}

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-track-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-track-row.tsx
@@ -1,6 +1,9 @@
 import type { PlaylistTrackItem } from "@harmonia/common/schemas";
 import { parseJsonStringArray } from "@harmonia/common/utils/parse-json-string-array";
+import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
+import type { Route } from "next";
 import Image from "next/image";
+import Link from "next/link";
 
 export type DashboardPlaylistDetailTrackRowTrack = PlaylistTrackItem;
 
@@ -14,7 +17,10 @@ export function DashboardPlaylistDetailTrackRow({
 	const artists = parseJsonStringArray(track.artistNames);
 
 	return (
-		<div className="flex items-center gap-4 border-b py-4 last:border-b-0">
+		<Link
+			href={DASHBOARD_ROUTES.tracks.children.detail.makePath(track.id) as Route}
+			className="flex items-center gap-4 border-b py-4 last:border-b-0 hover:bg-accent/50"
+		>
 			<span className="w-6 shrink-0 text-right text-muted-foreground text-xs">
 				{String(index + 1).padStart(2, "0")}
 			</span>
@@ -37,6 +43,6 @@ export function DashboardPlaylistDetailTrackRow({
 					{track.albumName ? ` • ${track.albumName}` : ""}
 				</p>
 			</div>
-		</div>
+		</Link>
 	);
 }

--- a/apps/dashboard/src/components/app/dashboard-track-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-track-detail.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import type { TrackGetByIdOutput } from "@harmonia/common/schemas";
+import { parseJsonStringArray } from "@harmonia/common/utils/parse-json-string-array";
+import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
+import {
+	Badge,
+	Icons,
+	Progress,
+	Separator,
+	Skeleton,
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+} from "@harmonia/ui";
+import type { Route } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { DashboardDetailBackLink } from "@/components/shared/dashboard-detail-back-link";
+
+const AUDIO_FEATURES: Array<{
+	key: keyof Pick<
+		TrackGetByIdOutput,
+		| "valence"
+		| "energy"
+		| "danceability"
+		| "acousticness"
+		| "instrumentalness"
+		| "speechiness"
+		| "liveness"
+	>;
+	label: string;
+}> = [
+	{ key: "valence", label: "Valence" },
+	{ key: "energy", label: "Energy" },
+	{ key: "danceability", label: "Danceability" },
+	{ key: "acousticness", label: "Acousticness" },
+	{ key: "instrumentalness", label: "Instrumentalness" },
+	{ key: "speechiness", label: "Speechiness" },
+	{ key: "liveness", label: "Liveness" },
+];
+
+const KEY_NAMES = [
+	"C",
+	"C♯/D♭",
+	"D",
+	"D♯/E♭",
+	"E",
+	"F",
+	"F♯/G♭",
+	"G",
+	"G♯/A♭",
+	"A",
+	"A♯/B♭",
+	"B",
+];
+
+function formatDuration(ms: number | null): string {
+	if (ms == null) return "—";
+	const totalSeconds = Math.round(ms / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatDate(value: Date | null): string {
+	if (!value) return "—";
+	return new Date(value).toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
+	const artists = parseJsonStringArray(track.artistNames);
+	const themes = track.llmTags?.themes ?? [];
+	const topics = track.llmTags?.topics ?? [];
+	const vibe = track.llmTags?.vibe ?? [];
+	const secondaryMoods = track.llmTags?.secondaryMoods ?? [];
+
+	return (
+		<div className="flex flex-col gap-6">
+			<DashboardDetailBackLink
+				href={DASHBOARD_ROUTES.playlists.path}
+				label="Playlists"
+			/>
+
+			<div className="flex flex-col items-start gap-4 sm:flex-row">
+				{track.albumImageUrl ? (
+					<Image
+						src={track.albumImageUrl}
+						alt=""
+						width={160}
+						height={160}
+						className="size-40 shrink-0 rounded object-cover"
+						unoptimized
+					/>
+				) : (
+					<div className="size-40 shrink-0 rounded bg-muted" />
+				)}
+				<div className="min-w-0 flex-1">
+					<h1 className="font-bold text-2xl tracking-tight">{track.name}</h1>
+					<p className="mt-1 text-muted-foreground">{artists.join(", ")}</p>
+					{track.albumName ? (
+						<p className="text-muted-foreground text-sm">{track.albumName}</p>
+					) : null}
+					<p className="mt-2 text-muted-foreground text-sm">
+						{formatDuration(track.durationMs)}
+					</p>
+					<a
+						href={track.spotifyUri.replace(
+							"spotify:track:",
+							"https://open.spotify.com/track/",
+						)}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="mt-2 inline-flex items-center gap-1 text-sm underline underline-offset-4"
+					>
+						Open in Spotify
+						<Icons.externalLink className="size-3" />
+					</a>
+				</div>
+			</div>
+
+			<Separator />
+
+			<section className="flex flex-col gap-3">
+				<h2 className="font-semibold text-sm uppercase tracking-widest">
+					Analysis
+				</h2>
+				<div className="flex flex-wrap items-center gap-2">
+					{track.llmMood ? (
+						<Badge variant="secondary">{track.llmMood}</Badge>
+					) : null}
+					{secondaryMoods.map((mood) => (
+						<Badge key={mood} variant="outline">
+							{mood}
+						</Badge>
+					))}
+					{track.genreDomainName ? (
+						<Badge variant="outline">{track.genreDomainName}</Badge>
+					) : null}
+				</div>
+				{themes.length > 0 || topics.length > 0 || vibe.length > 0 ? (
+					<div className="flex flex-col gap-1 text-muted-foreground text-sm">
+						{themes.length > 0 ? <p>Themes: {themes.join(", ")}</p> : null}
+						{topics.length > 0 ? <p>Topics: {topics.join(", ")}</p> : null}
+						{vibe.length > 0 ? <p>Vibe: {vibe.join(", ")}</p> : null}
+					</div>
+				) : null}
+
+				<div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2">
+					{AUDIO_FEATURES.map((feature) => {
+						const value = track[feature.key];
+						return (
+							<div key={feature.key} className="flex flex-col gap-1">
+								<div className="flex items-center justify-between text-xs">
+									<span className="text-muted-foreground">{feature.label}</span>
+									<span>{value != null ? value.toFixed(2) : "—"}</span>
+								</div>
+								<Progress value={value != null ? value * 100 : 0} />
+							</div>
+						);
+					})}
+				</div>
+				<div className="flex flex-wrap gap-4 text-muted-foreground text-xs">
+					<span>
+						Tempo:{" "}
+						{track.tempo != null ? `${Math.round(track.tempo)} BPM` : "—"}
+					</span>
+					<span>
+						Key: {track.key != null ? (KEY_NAMES[track.key] ?? "—") : "—"}
+					</span>
+					<span>
+						Mode:{" "}
+						{track.mode === 1 ? "Major" : track.mode === 0 ? "Minor" : "—"}
+					</span>
+				</div>
+			</section>
+
+			<Separator />
+
+			<section className="flex flex-col gap-3">
+				<h2 className="font-semibold text-sm uppercase tracking-widest">
+					Lyrics
+				</h2>
+				{track.lyricsInstrumental ? (
+					<Badge variant="outline">Instrumental</Badge>
+				) : track.lyrics || track.syncedLyrics ? (
+					<Tabs defaultValue="plain">
+						<TabsList>
+							<TabsTrigger value="plain" disabled={!track.lyrics}>
+								Plain
+							</TabsTrigger>
+							<TabsTrigger value="synced" disabled={!track.syncedLyrics}>
+								Synced
+							</TabsTrigger>
+						</TabsList>
+						<TabsContent value="plain">
+							<pre className="whitespace-pre-wrap font-sans text-sm">
+								{track.lyrics ?? "No plain lyrics available."}
+							</pre>
+						</TabsContent>
+						<TabsContent value="synced">
+							<pre className="whitespace-pre-wrap font-sans text-sm">
+								{track.syncedLyrics ?? "No synced lyrics available."}
+							</pre>
+						</TabsContent>
+					</Tabs>
+				) : (
+					<p className="text-muted-foreground text-sm">
+						{track.lyricsStatus === "pending"
+							? "Lyrics not fetched yet."
+							: "No lyrics found for this track."}
+					</p>
+				)}
+			</section>
+
+			<Separator />
+
+			<section className="flex flex-col gap-3">
+				<h2 className="font-semibold text-sm uppercase tracking-widest">
+					Liked
+				</h2>
+				<p className="text-muted-foreground text-sm">
+					{track.likedAt
+						? `Saved on Spotify on ${formatDate(track.likedAt)}`
+						: "Not in your Liked Songs."}
+				</p>
+			</section>
+
+			<Separator />
+
+			<section className="flex flex-col gap-3">
+				<h2 className="font-semibold text-sm uppercase tracking-widest">
+					Playlists
+				</h2>
+				<div className="flex flex-col gap-2">
+					<p className="text-muted-foreground text-xs uppercase tracking-widest">
+						In Harmonia
+					</p>
+					{track.harmoniaPlaylists.length > 0 ? (
+						<ul className="flex flex-col gap-1">
+							{track.harmoniaPlaylists.map((pl) => (
+								<li key={pl.id}>
+									<Link
+										href={
+											DASHBOARD_ROUTES.playlists.children.detail.makePath(
+												String(pl.id),
+											) as Route
+										}
+										className="text-sm underline underline-offset-4"
+									>
+										{pl.name}
+									</Link>
+								</li>
+							))}
+						</ul>
+					) : (
+						<p className="text-muted-foreground text-sm">
+							Not in any Harmonia playlist.
+						</p>
+					)}
+				</div>
+				<div className="flex flex-col gap-2">
+					<p className="text-muted-foreground text-xs uppercase tracking-widest">
+						On Spotify
+					</p>
+					{track.spotifyPlaylists.length > 0 ? (
+						<ul className="flex flex-col gap-1">
+							{track.spotifyPlaylists.map((pl) => (
+								<li key={pl.id}>
+									<a
+										href={`https://open.spotify.com/playlist/${pl.id}`}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-sm underline underline-offset-4"
+									>
+										{pl.name}
+									</a>
+								</li>
+							))}
+						</ul>
+					) : (
+						<p className="text-muted-foreground text-sm">
+							Not in any of your Spotify playlists.
+						</p>
+					)}
+				</div>
+			</section>
+		</div>
+	);
+}
+
+export function DashboardTrackDetailSkeleton() {
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="flex flex-col gap-2">
+				<Skeleton className="h-3 w-20" />
+				<Skeleton className="h-px w-full" />
+			</div>
+			<div className="flex gap-4">
+				<Skeleton className="size-40 shrink-0 rounded" />
+				<div className="flex flex-1 flex-col gap-2">
+					<Skeleton className="h-8 w-64" />
+					<Skeleton className="h-4 w-48" />
+					<Skeleton className="h-4 w-32" />
+				</div>
+			</div>
+			<Skeleton className="h-40 w-full" />
+			<Skeleton className="h-40 w-full" />
+		</div>
+	);
+}
+
+export function DashboardTrackDetailNotFound() {
+	return (
+		<div className="flex flex-col gap-6">
+			<DashboardDetailBackLink
+				href={DASHBOARD_ROUTES.playlists.path}
+				label="Playlists"
+			/>
+			<p className="text-muted-foreground text-sm">Track not found.</p>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-track-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-track-detail.tsx
@@ -4,42 +4,20 @@ import type { TrackGetByIdOutput } from "@harmonia/common/schemas";
 import { parseJsonStringArray } from "@harmonia/common/utils/parse-json-string-array";
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
 import {
-	Badge,
+	Button,
+	cn,
 	Icons,
-	Progress,
-	Separator,
+	InsightSectionCard,
+	InsightStatCard,
 	Skeleton,
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
 } from "@harmonia/ui";
+import { format } from "date-fns";
 import type { Route } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { useState } from "react";
 import { DashboardDetailBackLink } from "@/components/shared/dashboard-detail-back-link";
-
-const AUDIO_FEATURES: Array<{
-	key: keyof Pick<
-		TrackGetByIdOutput,
-		| "valence"
-		| "energy"
-		| "danceability"
-		| "acousticness"
-		| "instrumentalness"
-		| "speechiness"
-		| "liveness"
-	>;
-	label: string;
-}> = [
-	{ key: "valence", label: "Valence" },
-	{ key: "energy", label: "Energy" },
-	{ key: "danceability", label: "Danceability" },
-	{ key: "acousticness", label: "Acousticness" },
-	{ key: "instrumentalness", label: "Instrumentalness" },
-	{ key: "speechiness", label: "Speechiness" },
-	{ key: "liveness", label: "Liveness" },
-];
+import { DashboardInsightsSonicDna } from "./dashboard-insights-sonic-dna";
 
 const KEY_NAMES = [
 	"C",
@@ -64,21 +42,35 @@ function formatDuration(ms: number | null): string {
 	return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
-function formatDate(value: Date | null): string {
-	if (!value) return "—";
-	return new Date(value).toLocaleDateString(undefined, {
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	});
+/** Matches the label/value row style used across insight cards (e.g. dashboard-insights-personality.tsx). */
+function KvRow({ label, value }: { label: string; value: string | null }) {
+	return (
+		<div className="flex items-center justify-between border-border border-b py-3 last:border-b-0">
+			<span className="text-[11px] text-muted-foreground">{label}</span>
+			<span className="text-foreground text-sm capitalize">{value ?? "—"}</span>
+		</div>
+	);
+}
+
+/** Matches the hashtag-style tag used for vibes on dashboard-insights-mood-vibe.tsx. */
+function Tag({ label }: { label: string }) {
+	return (
+		<span className="border border-border bg-muted px-2.5 py-1.5 text-[11px] text-foreground lowercase">
+			<span className="text-accent">#</span>
+			{label}
+		</span>
+	);
 }
 
 export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
+	const [lyricsView, setLyricsView] = useState<"plain" | "synced">("plain");
 	const artists = parseJsonStringArray(track.artistNames);
 	const themes = track.llmTags?.themes ?? [];
 	const topics = track.llmTags?.topics ?? [];
 	const vibe = track.llmTags?.vibe ?? [];
 	const secondaryMoods = track.llmTags?.secondaryMoods ?? [];
+	const hasTags = themes.length > 0 || topics.length > 0 || vibe.length > 0;
+	const hasLyrics = Boolean(track.lyrics || track.syncedLyrics);
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -94,21 +86,18 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 						alt=""
 						width={160}
 						height={160}
-						className="size-40 shrink-0 rounded object-cover"
+						className="size-32 shrink-0 sm:size-40"
 						unoptimized
 					/>
 				) : (
-					<div className="size-40 shrink-0 rounded bg-muted" />
+					<div className="size-32 shrink-0 bg-muted sm:size-40" />
 				)}
-				<div className="min-w-0 flex-1">
+				<div className="flex min-w-0 flex-1 flex-col gap-1">
 					<h1 className="font-bold text-2xl tracking-tight">{track.name}</h1>
-					<p className="mt-1 text-muted-foreground">{artists.join(", ")}</p>
+					<p className="text-muted-foreground">{artists.join(", ")}</p>
 					{track.albumName ? (
 						<p className="text-muted-foreground text-sm">{track.albumName}</p>
 					) : null}
-					<p className="mt-2 text-muted-foreground text-sm">
-						{formatDuration(track.durationMs)}
-					</p>
 					<a
 						href={track.spotifyUri.replace(
 							"spotify:track:",
@@ -116,99 +105,107 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 						)}
 						target="_blank"
 						rel="noopener noreferrer"
-						className="mt-2 inline-flex items-center gap-1 text-sm underline underline-offset-4"
+						className="mt-2"
 					>
-						Open in Spotify
-						<Icons.externalLink className="size-3" />
+						<Button
+							variant="outline"
+							className="font-bold uppercase tracking-widest"
+						>
+							Open in Spotify
+							<Icons.externalLink className="ml-2 size-4" />
+						</Button>
 					</a>
 				</div>
 			</div>
 
-			<Separator />
+			<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+				<InsightStatCard
+					label="Duration"
+					value={formatDuration(track.durationMs)}
+				/>
+				<InsightStatCard
+					label="Tempo"
+					value={track.tempo != null ? `${Math.round(track.tempo)} BPM` : "—"}
+				/>
+				<InsightStatCard
+					label="Key"
+					value={track.key != null ? (KEY_NAMES[track.key] ?? "—") : "—"}
+				/>
+				<InsightStatCard
+					label="Mode"
+					value={track.mode === 1 ? "Major" : track.mode === 0 ? "Minor" : "—"}
+				/>
+			</div>
 
-			<section className="flex flex-col gap-3">
-				<h2 className="font-semibold text-sm uppercase tracking-widest">
-					Analysis
-				</h2>
-				<div className="flex flex-wrap items-center gap-2">
-					{track.llmMood ? (
-						<Badge variant="secondary">{track.llmMood}</Badge>
-					) : null}
-					{secondaryMoods.map((mood) => (
-						<Badge key={mood} variant="outline">
-							{mood}
-						</Badge>
-					))}
-					{track.genreDomainName ? (
-						<Badge variant="outline">{track.genreDomainName}</Badge>
+			<DashboardInsightsSonicDna
+				dna={{
+					valence: track.valence,
+					energy: track.energy,
+					danceability: track.danceability,
+					acousticness: track.acousticness,
+					instrumentalness: track.instrumentalness,
+					speechiness: track.speechiness,
+					liveness: track.liveness,
+				}}
+			/>
+
+			<InsightSectionCard title="Mood & Themes">
+				<div>
+					<KvRow label="Mood" value={track.llmMood} />
+					<KvRow label="Genre domain" value={track.genreDomainName} />
+					{secondaryMoods.length > 0 ? (
+						<KvRow label="Secondary moods" value={secondaryMoods.join(", ")} />
 					) : null}
 				</div>
-				{themes.length > 0 || topics.length > 0 || vibe.length > 0 ? (
-					<div className="flex flex-col gap-1 text-muted-foreground text-sm">
-						{themes.length > 0 ? <p>Themes: {themes.join(", ")}</p> : null}
-						{topics.length > 0 ? <p>Topics: {topics.join(", ")}</p> : null}
-						{vibe.length > 0 ? <p>Vibe: {vibe.join(", ")}</p> : null}
+				{hasTags ? (
+					<div className="flex flex-wrap gap-2">
+						{[...vibe, ...themes, ...topics].map((tag) => (
+							<Tag key={tag} label={tag} />
+						))}
 					</div>
 				) : null}
+			</InsightSectionCard>
 
-				<div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2">
-					{AUDIO_FEATURES.map((feature) => {
-						const value = track[feature.key];
-						return (
-							<div key={feature.key} className="flex flex-col gap-1">
-								<div className="flex items-center justify-between text-xs">
-									<span className="text-muted-foreground">{feature.label}</span>
-									<span>{value != null ? value.toFixed(2) : "—"}</span>
-								</div>
-								<Progress value={value != null ? value * 100 : 0} />
-							</div>
-						);
-					})}
-				</div>
-				<div className="flex flex-wrap gap-4 text-muted-foreground text-xs">
-					<span>
-						Tempo:{" "}
-						{track.tempo != null ? `${Math.round(track.tempo)} BPM` : "—"}
-					</span>
-					<span>
-						Key: {track.key != null ? (KEY_NAMES[track.key] ?? "—") : "—"}
-					</span>
-					<span>
-						Mode:{" "}
-						{track.mode === 1 ? "Major" : track.mode === 0 ? "Minor" : "—"}
-					</span>
-				</div>
-			</section>
-
-			<Separator />
-
-			<section className="flex flex-col gap-3">
-				<h2 className="font-semibold text-sm uppercase tracking-widest">
-					Lyrics
-				</h2>
+			<InsightSectionCard title="Lyrics">
 				{track.lyricsInstrumental ? (
-					<Badge variant="outline">Instrumental</Badge>
-				) : track.lyrics || track.syncedLyrics ? (
-					<Tabs defaultValue="plain">
-						<TabsList>
-							<TabsTrigger value="plain" disabled={!track.lyrics}>
+					<p className="text-muted-foreground text-sm">
+						Instrumental — no lyrics.
+					</p>
+				) : hasLyrics ? (
+					<div className="flex flex-col gap-3">
+						<div className="flex gap-2">
+							<button
+								type="button"
+								disabled={!track.lyrics}
+								onClick={() => setLyricsView("plain")}
+								className={cn(
+									"border border-border px-3 py-1.5 text-[11px] uppercase tracking-widest disabled:cursor-not-allowed disabled:opacity-40",
+									lyricsView === "plain"
+										? "bg-primary text-primary-foreground"
+										: "text-muted-foreground",
+								)}
+							>
 								Plain
-							</TabsTrigger>
-							<TabsTrigger value="synced" disabled={!track.syncedLyrics}>
+							</button>
+							<button
+								type="button"
+								disabled={!track.syncedLyrics}
+								onClick={() => setLyricsView("synced")}
+								className={cn(
+									"border border-border px-3 py-1.5 text-[11px] uppercase tracking-widest disabled:cursor-not-allowed disabled:opacity-40",
+									lyricsView === "synced"
+										? "bg-primary text-primary-foreground"
+										: "text-muted-foreground",
+								)}
+							>
 								Synced
-							</TabsTrigger>
-						</TabsList>
-						<TabsContent value="plain">
-							<pre className="whitespace-pre-wrap font-sans text-sm">
-								{track.lyrics ?? "No plain lyrics available."}
-							</pre>
-						</TabsContent>
-						<TabsContent value="synced">
-							<pre className="whitespace-pre-wrap font-sans text-sm">
-								{track.syncedLyrics ?? "No synced lyrics available."}
-							</pre>
-						</TabsContent>
-					</Tabs>
+							</button>
+						</div>
+						<pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed">
+							{(lyricsView === "plain" ? track.lyrics : track.syncedLyrics) ??
+								"Not available."}
+						</pre>
+					</div>
 				) : (
 					<p className="text-muted-foreground text-sm">
 						{track.lyricsStatus === "pending"
@@ -216,80 +213,69 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 							: "No lyrics found for this track."}
 					</p>
 				)}
-			</section>
+			</InsightSectionCard>
 
-			<Separator />
+			<InsightSectionCard title="Liked">
+				<KvRow
+					label="Saved on Spotify"
+					value={track.likedAt ? format(track.likedAt, "MMMM d, yyyy") : null}
+				/>
+			</InsightSectionCard>
 
-			<section className="flex flex-col gap-3">
-				<h2 className="font-semibold text-sm uppercase tracking-widest">
-					Liked
-				</h2>
-				<p className="text-muted-foreground text-sm">
-					{track.likedAt
-						? `Saved on Spotify on ${formatDate(track.likedAt)}`
-						: "Not in your Liked Songs."}
-				</p>
-			</section>
-
-			<Separator />
-
-			<section className="flex flex-col gap-3">
-				<h2 className="font-semibold text-sm uppercase tracking-widest">
-					Playlists
-				</h2>
+			<InsightSectionCard title="Playlists">
 				<div className="flex flex-col gap-2">
-					<p className="text-muted-foreground text-xs uppercase tracking-widest">
+					<span className="font-mono text-[9px] text-muted-foreground uppercase tracking-widest">
 						In Harmonia
-					</p>
+					</span>
 					{track.harmoniaPlaylists.length > 0 ? (
-						<ul className="flex flex-col gap-1">
+						<div>
 							{track.harmoniaPlaylists.map((pl) => (
-								<li key={pl.id}>
-									<Link
-										href={
-											DASHBOARD_ROUTES.playlists.children.detail.makePath(
-												String(pl.id),
-											) as Route
-										}
-										className="text-sm underline underline-offset-4"
-									>
-										{pl.name}
-									</Link>
-								</li>
+								<Link
+									key={pl.id}
+									href={
+										DASHBOARD_ROUTES.playlists.children.detail.makePath(
+											String(pl.id),
+										) as Route
+									}
+									className="flex items-center justify-between border-border border-b py-3 text-sm last:border-b-0 hover:text-primary"
+								>
+									{pl.name}
+									<Icons.arrowUpRight className="size-3.5 shrink-0" />
+								</Link>
 							))}
-						</ul>
+						</div>
 					) : (
-						<p className="text-muted-foreground text-sm">
+						<p className="py-3 text-muted-foreground text-sm">
 							Not in any Harmonia playlist.
 						</p>
 					)}
 				</div>
 				<div className="flex flex-col gap-2">
-					<p className="text-muted-foreground text-xs uppercase tracking-widest">
+					<span className="font-mono text-[9px] text-muted-foreground uppercase tracking-widest">
 						On Spotify
-					</p>
+					</span>
 					{track.spotifyPlaylists.length > 0 ? (
-						<ul className="flex flex-col gap-1">
+						<div>
 							{track.spotifyPlaylists.map((pl) => (
-								<li key={pl.id}>
-									<a
-										href={`https://open.spotify.com/playlist/${pl.id}`}
-										target="_blank"
-										rel="noopener noreferrer"
-										className="text-sm underline underline-offset-4"
-									>
-										{pl.name}
-									</a>
-								</li>
+								<a
+									key={pl.id}
+									href={`https://open.spotify.com/playlist/${pl.id}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center justify-between border-border border-b py-3 text-sm last:border-b-0 hover:text-primary"
+								>
+									{pl.name}
+									<Icons.externalLink className="size-3.5 shrink-0" />
+								</a>
 							))}
-						</ul>
+						</div>
 					) : (
-						<p className="text-muted-foreground text-sm">
+						<p className="py-3 text-muted-foreground text-sm">
 							Not in any of your Spotify playlists.
 						</p>
 					)}
 				</div>
-			</section>
+			</InsightSectionCard>
 		</div>
 	);
 }
@@ -302,14 +288,19 @@ export function DashboardTrackDetailSkeleton() {
 				<Skeleton className="h-px w-full" />
 			</div>
 			<div className="flex gap-4">
-				<Skeleton className="size-40 shrink-0 rounded" />
+				<Skeleton className="size-32 shrink-0 sm:size-40" />
 				<div className="flex flex-1 flex-col gap-2">
 					<Skeleton className="h-8 w-64" />
 					<Skeleton className="h-4 w-48" />
 					<Skeleton className="h-4 w-32" />
 				</div>
 			</div>
-			<Skeleton className="h-40 w-full" />
+			<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+				{["duration", "tempo", "key", "mode"].map((key) => (
+					<Skeleton key={key} className="h-20 w-full" />
+				))}
+			</div>
+			<Skeleton className="h-48 w-full" />
 			<Skeleton className="h-40 w-full" />
 		</div>
 	);

--- a/apps/dashboard/src/hooks/use-mobile-bottom-nav-state.ts
+++ b/apps/dashboard/src/hooks/use-mobile-bottom-nav-state.ts
@@ -11,8 +11,10 @@ export function useMobileBottomNavState() {
 	const { snapshot: streamState, connectionState } = usePipelineProgress();
 
 	const hidden =
-		pathname.startsWith(`${DASHBOARD_ROUTES.playlists.path}/`) &&
-		DASHBOARD_ROUTES.playlists.children.detail.hideBottomNav;
+		(pathname.startsWith(`${DASHBOARD_ROUTES.playlists.path}/`) &&
+			DASHBOARD_ROUTES.playlists.children.detail.hideBottomNav) ||
+		(pathname.startsWith(`${DASHBOARD_ROUTES.tracks.path}/`) &&
+			DASHBOARD_ROUTES.tracks.children.detail.hideBottomNav);
 
 	const showAnalysisBar =
 		!hidden &&

--- a/packages/common/src/schemas/track/output.ts
+++ b/packages/common/src/schemas/track/output.ts
@@ -40,6 +40,7 @@ export const trackGetByIdOutputSchema = z.object({
 	name: z.string(),
 	artistNames: z.string(),
 	albumName: z.string().nullable(),
+	albumImageUrl: z.string().nullable(),
 	durationMs: z.number().nullable(),
 	spotifyGenres: z.array(z.string()).nullable(),
 	genreDomainId: z.number().nullable(),
@@ -81,5 +82,11 @@ export const trackGetByIdOutputSchema = z.object({
 	updatedAt: z.date(),
 	clusterId: z.number().nullable(),
 	embedding: z.undefined().optional(),
+	genreDomainName: z.string().nullable(),
+	/** When the user saved this track on Spotify (userTracks.addedAt) — null if never in Liked Songs. */
+	likedAt: z.date().nullable(),
+	harmoniaPlaylists: z.array(z.object({ id: z.number(), name: z.string() })),
+	/** The user's own Spotify playlists (any, not just Harmonia's) that currently contain this track. */
+	spotifyPlaylists: z.array(z.object({ id: z.string(), name: z.string() })),
 });
 export type TrackGetByIdOutput = z.infer<typeof trackGetByIdOutputSchema>;

--- a/packages/common/src/services/music/index.ts
+++ b/packages/common/src/services/music/index.ts
@@ -3,7 +3,10 @@ export {
 	fetchLyricsForTrackIds,
 } from "./lyrics/fetch-lyrics";
 export { autoExportUpdatedPlaylists } from "./spotify/auto-export";
-export { getUserSpotifyAccessToken } from "./spotify/client";
+export {
+	fetchAllUserPlaylists,
+	getUserSpotifyAccessToken,
+} from "./spotify/client";
 export {
 	exportAllPlaylists,
 	exportPlaylistToSpotify,

--- a/packages/common/src/utils/routes.ts
+++ b/packages/common/src/utils/routes.ts
@@ -57,6 +57,14 @@ export const DASHBOARD_ROUTES = {
 		label: "Tracks",
 		icon: "music",
 		isNav: true,
+		children: {
+			detail: {
+				path: "/tracks/:id",
+				label: "Track Detail",
+				hideBottomNav: true,
+				makePath: (id: string) => `/tracks/${id}`,
+			},
+		},
 	},
 	clusters: {
 		path: "/clusters",

--- a/packages/orpc/src/routers/protected/tracks.ts
+++ b/packages/orpc/src/routers/protected/tracks.ts
@@ -1,4 +1,8 @@
 import {
+	fetchAllUserPlaylists,
+	getUserSpotifyAccessToken,
+} from "@harmonia/common";
+import {
 	trackGetByIdInput,
 	trackGetByIdOutputSchema,
 	tracksListInput,
@@ -6,7 +10,11 @@ import {
 } from "@harmonia/common/schemas";
 import { db } from "@harmonia/db";
 import { clusterTracks } from "@harmonia/db/schema/cluster";
+import { genreDomain } from "@harmonia/db/schema/genre-domain";
+import { playlist, playlistTracks } from "@harmonia/db/schema/playlist";
+import { userPlaylistSnapshotItems } from "@harmonia/db/schema/spotify";
 import { track, userTracks } from "@harmonia/db/schema/track";
+import { logger } from "@harmonia/logger";
 import {
 	and,
 	count,
@@ -107,8 +115,17 @@ export const tracksRouter = {
 				.where(eq(userTracks.userId, userId));
 
 			const [result] = await db
-				.select()
+				.select({
+					track,
+					likedAt: userTracks.addedAt,
+					genreDomainName: genreDomain.name,
+				})
 				.from(track)
+				.innerJoin(
+					userTracks,
+					and(eq(userTracks.trackId, track.id), eq(userTracks.userId, userId)),
+				)
+				.leftJoin(genreDomain, eq(genreDomain.id, track.genreDomainId))
 				.where(and(eq(track.id, input.id), inArray(track.id, userTrackIds)));
 
 			if (!result) return null;
@@ -119,10 +136,66 @@ export const tracksRouter = {
 				.where(eq(clusterTracks.trackId, input.id))
 				.limit(1);
 
+			const harmoniaPlaylists = await db
+				.select({ id: playlist.id, name: playlist.name })
+				.from(playlistTracks)
+				.innerJoin(playlist, eq(playlist.id, playlistTracks.playlistId))
+				.where(
+					and(
+						eq(playlistTracks.trackId, input.id),
+						eq(playlist.userId, userId),
+					),
+				);
+
+			// userPlaylistSnapshotItems only ever holds each playlist's latest
+			// snapshot (setCachedPlaylistItems deletes prior rows before
+			// inserting), so this is already "current Spotify state," no
+			// snapshot-id filtering needed.
+			const spotifyPlaylistRows = await db
+				.select({ playlistId: userPlaylistSnapshotItems.playlistId })
+				.from(userPlaylistSnapshotItems)
+				.where(
+					and(
+						eq(userPlaylistSnapshotItems.userId, userId),
+						eq(userPlaylistSnapshotItems.trackId, input.id),
+					),
+				);
+			const spotifyPlaylistIds = new Set(
+				spotifyPlaylistRows.map((r) => r.playlistId),
+			);
+
+			let spotifyPlaylists: Array<{ id: string; name: string }> = [];
+			if (spotifyPlaylistIds.size > 0) {
+				try {
+					const accessToken = await getUserSpotifyAccessToken(userId);
+					if (accessToken) {
+						const allPlaylists = await fetchAllUserPlaylists(accessToken);
+						spotifyPlaylists = allPlaylists
+							.filter((p) => spotifyPlaylistIds.has(p.id))
+							.map((p) => ({ id: p.id, name: p.name }));
+					}
+				} catch (err) {
+					// Non-fatal: the rest of the track detail page is still useful
+					// without the Spotify playlist names.
+					logger.warn(
+						{
+							userId,
+							trackId: input.id,
+							error: err instanceof Error ? err.message : String(err),
+						},
+						"Failed to resolve Spotify playlist names for track detail",
+					);
+				}
+			}
+
 			return {
-				...result,
+				...result.track,
 				embedding: undefined,
 				clusterId: clusterAssignment[0]?.clusterId ?? null,
+				genreDomainName: result.genreDomainName,
+				likedAt: result.likedAt,
+				harmoniaPlaylists,
+				spotifyPlaylists,
 			};
 		}),
 };


### PR DESCRIPTION
## Summary
New `/tracks/[id]` route. Previously clicking a track did nothing at all (no drawer, no navigation existed despite the original issue description) — track rows in a playlist's tracklist now link here.

**Page sections** (per issue spec):
- Header: album art, name, artists, album, duration, "Open in Spotify" link
- Analysis: mood + secondary moods + genre domain as badges, themes/topics/vibe, audio feature bars (valence/energy/danceability/acousticness/instrumentalness/speechiness/liveness), tempo/key/mode
- Lyrics: plain/synced tabs, instrumental badge, pending/not-found states
- Liked: real Spotify save date (depends on #214 landing for accuracy — works today for anyone already using a token with library-read scope)
- Playlists: which Harmonia playlists contain this track (linked), which of the user's own Spotify playlists contain it (linked externally)

**Backend** (`tracksRouter.getById`):
- Now joins `userTracks` for the liked-at date and `genreDomain` for its label
- New: Harmonia playlist membership via `playlistTracks`
- New: Spotify playlist membership via the existing `userPlaylistSnapshotItems` cache (already kept current by the sync stage — no snapshot-id filtering needed since `setCachedPlaylistItems` deletes prior-snapshot rows before inserting)
- Playlist *names* for the Spotify side need a live `fetchAllUserPlaylists` call — nothing persists a `playlistId -> name` mapping for the user's own non-Harmonia playlists today (flagged in the original issue scoping). Acceptable for a single detail-page view; wrapped in try/catch so a Spotify hiccup doesn't break the rest of the page.

## Test plan
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm --filter @harmonia/orpc exec tsc --noEmit` — clean
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm --filter @harmonia/common exec vitest run` — full suite green, no regressions
- [x] `pnpm build` — 17/17 tasks successful, `/tracks/[id]` route confirmed in build output
- [x] `npx biome check` — clean
- [ ] Not verified live in the browser — Docker (local DB) is currently unresponsive on this machine and Chrome browser automation was unreliable all session. Recommend a manual pass: click through from a playlist's tracklist, confirm lyrics tabs, confirm both playlist-membership lists resolve correctly for a track that's actually in playlists.

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated track detail pages with artwork, metadata, audio analysis, lyrics, liked status, and playlist membership.
  * Track rows are now clickable and open the corresponding detail page.
  * Track details include links to Spotify and display playlist information from Harmonia and Spotify.
* **UI Improvements**
  * Added loading and not-found states for track details.
  * Mobile bottom navigation now hides on track detail pages, matching playlist detail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->