### PR TITLE
fix(dashboard): make /playlists list header sticky

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-playlists-page-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-page-header.tsx
@@ -27,7 +27,7 @@ export function DashboardPlaylistsPageHeader({
 	const isBusy = exportMutation.isPending || organizeMutation.isPending;
 
 	return (
-		<div className="flex items-start justify-between gap-4">
+		<div className="sticky -top-5 z-10 -mx-4 -mt-4 flex items-start justify-between gap-4 bg-background px-4 pt-4 pb-3">
 			<PageHeader
 				title="AI Playlists"
 				description="Generated from your taste."


### PR DESCRIPTION
## Summary
- `DashboardPlaylistsPageHeader` (title + sort button + "+" actions) now uses the same `sticky -top-5 z-10 bg-background` treatment `/playlists/[id]`'s header already has, so the sort and actions buttons stay reachable while scrolling a long playlist list.

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified live — Docker (local DB) still unresponsive on this machine. Recommend a quick scroll-check on the Vercel preview.

Closes #218