### PR TITLE
fix(dashboard): stack scrolled tracklist header instead of cramming one row

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-header.tsx
@@ -42,12 +42,11 @@ export function DashboardPlaylistDetailHeader({
 				) : null}
 			</div>
 
+			{scrolled ? (
+				<p className="mt-3 truncate font-medium text-sm">{name}</p>
+			) : null}
+
 			<div className="mt-3 flex items-center gap-2">
-				{scrolled ? (
-					<span className="max-w-[40%] shrink-0 truncate font-medium text-sm">
-						{name}
-					</span>
-				) : null}
 				<div className="relative flex-1">
 					<Icons.search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
 					<Input


### PR DESCRIPTION
## Summary
- `/playlists/[id]`'s scrolled header state used to cram the truncated playlist name, the search input, and the sort button into a single flex row. Now the name gets its own row (full width, no longer `max-w-[40%]`), with search + sort on the row below.

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified live — Docker (local DB) still unresponsive. Recommend a quick scroll-check on the Vercel preview.

Closes #219