### PR TITLE
fix(dashboard): bigger cover art and repositioned Open in Spotify on track detail

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-track-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-track-detail.tsx
@@ -79,43 +79,42 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 				label="Playlists"
 			/>
 
-			<div className="flex flex-col items-start gap-4 sm:flex-row">
-				{track.albumImageUrl ? (
-					<Image
-						src={track.albumImageUrl}
-						alt=""
-						width={160}
-						height={160}
-						className="size-32 shrink-0 sm:size-40"
-						unoptimized
-					/>
-				) : (
-					<div className="size-32 shrink-0 bg-muted sm:size-40" />
-				)}
-				<div className="flex min-w-0 flex-1 flex-col gap-1">
-					<h1 className="font-bold text-2xl tracking-tight">{track.name}</h1>
-					<p className="text-muted-foreground">{artists.join(", ")}</p>
-					{track.albumName ? (
-						<p className="text-muted-foreground text-sm">{track.albumName}</p>
-					) : null}
-					<a
-						href={track.spotifyUri.replace(
-							"spotify:track:",
-							"https://open.spotify.com/track/",
-						)}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="mt-2"
-					>
-						<Button
-							variant="outline"
-							className="font-bold uppercase tracking-widest"
-						>
-							Open in Spotify
-							<Icons.externalLink className="ml-2 size-4" />
-						</Button>
-					</a>
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+				<div className="flex flex-col items-start gap-4 sm:flex-row">
+					{track.albumImageUrl ? (
+						<Image
+							src={track.albumImageUrl}
+							alt=""
+							width={224}
+							height={224}
+							className="size-44 shrink-0 sm:size-56"
+							unoptimized
+						/>
+					) : (
+						<div className="size-44 shrink-0 bg-muted sm:size-56" />
+					)}
+					<div className="flex min-w-0 flex-1 flex-col gap-1 sm:pt-2">
+						<h1 className="font-bold text-2xl tracking-tight">{track.name}</h1>
+						<p className="text-muted-foreground">{artists.join(", ")}</p>
+						{track.albumName ? (
+							<p className="text-muted-foreground text-sm">{track.albumName}</p>
+						) : null}
+					</div>
 				</div>
+				<a
+					href={track.spotifyUri.replace(
+						"spotify:track:",
+						"https://open.spotify.com/track/",
+					)}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="shrink-0"
+				>
+					<Button className="w-full bg-primary font-bold text-primary-foreground uppercase tracking-widest hover:bg-primary/90 sm:w-auto">
+						Open in Spotify
+						<Icons.externalLink className="ml-2 size-4" />
+					</Button>
+				</a>
 			</div>
 
 			<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -288,7 +287,7 @@ export function DashboardTrackDetailSkeleton() {
 				<Skeleton className="h-px w-full" />
 			</div>
 			<div className="flex gap-4">
-				<Skeleton className="size-32 shrink-0 sm:size-40" />
+				<Skeleton className="size-44 shrink-0 sm:size-56" />
 				<div className="flex flex-1 flex-col gap-2">
 					<Skeleton className="h-8 w-64" />
 					<Skeleton className="h-4 w-48" />


### PR DESCRIPTION
## Summary
- Album cover bumped from 128-160px (`size-32 sm:size-40`) to 176-224px (`size-44 sm:size-56`) so it reads as a clear visual anchor for the page instead of a small thumbnail.
- "Open in Spotify" moves from a small `variant="outline"` button stacked under the album name (looked like an afterthought) to a primary button (matching the primary-CTA style already used for playlist export in `dashboard-playlist-detail-actions.tsx`) aligned top-right of the header — full width on mobile, inline alongside the title block on larger screens.

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm build` — 17/17 tasks successful
- [x] `npx biome check` — clean
- [ ] Not verified live — Docker (local DB) still unresponsive. Recommend a quick look on the Vercel preview.

Closes #221