### PR TITLE
fix(db): remove duplicate todo.user_id column/FK from 0002 migration

### DIFF
--- a/packages/db/src/migrations/0002_cloudy_medusa.sql
+++ b/packages/db/src/migrations/0002_cloudy_medusa.sql
@@ -10,8 +10,6 @@ CREATE TABLE "pipeline_run" (
 	"created_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "todo" ADD COLUMN "user_id" text NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_run" ADD CONSTRAINT "pipeline_run_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "pipeline_run_user_id_idx" ON "pipeline_run" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "pipeline_run_status_idx" ON "pipeline_run" USING btree ("status");--> statement-breakpoint
-ALTER TABLE "todo" ADD CONSTRAINT "todo_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+CREATE INDEX "pipeline_run_status_idx" ON "pipeline_run" USING btree ("status");


### PR DESCRIPTION
## ⚠️ Merging this triggers an automatic production migration run

`.github/workflows/drizzle-migrate.yml` runs `pnpm db:migrate` against **`PRODUCTION_DATABASE_URL`** automatically on every push to `main` that touches `packages/db/src/migrations/**` — no manual approval gate. Merging this PR *will* kick that off. Please don't merge until you're comfortable with that, ideally after verifying the reproduction below yourself.

## Summary
`0002_cloudy_medusa.sql` duplicated two statements `0001_add_todo_user_id.sql` already ran:
```sql
ALTER TABLE "todo" ADD COLUMN "user_id" text NOT NULL;
ALTER TABLE "todo" ADD CONSTRAINT "todo_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
```
Both are exact repeats of what 0001 already did (0001 does the column add as nullable → backfill → `NOT NULL` → the same FK). A `drizzle-kit migrate` run against a genuinely fresh/empty database fails outright on the duplicate `ADD COLUMN` since the column already exists by the time 0002 runs.

This is very likely the same failure the prod `drizzle-migrate.yml` workflow hit on its first real run once `PRODUCTION_DATABASE_URL` was configured (per #162) — local dev only ever uses `pnpm db:push` (which diffs instead of replaying the migration chain), so this was never exercised until CI actually ran `migrate`.

**Why editing an already-shipped migration file is safe here**: every attempt to run this exact statement has failed (including prod's first CI run), and drizzle only marks a migration as applied in `__drizzle_migrations` if it completes successfully. Since it never completed anywhere, no environment should have 0002 recorded as applied — editing it isn't rewriting accepted history, it's fixing something that's never actually succeeded.

Removed both duplicate lines from 0002, keeping the parts that are genuinely new there: the `pipeline_run` table, its own FK, and its two indexes. The cumulative schema state after 0002 is unchanged, so the snapshot JSON files don't need updates.

## Test plan
- [x] `pnpm --filter @harmonia/db exec tsc --noEmit` — clean
- [ ] **Not verified against a real fresh-database migration run** — Docker is unresponsive on this machine, blocking the exact reproduction from #162:
  ```bash
  docker exec harmonia-postgres psql -U postgres -c "CREATE DATABASE repro;"
  docker exec harmonia-postgres psql -U postgres -d repro -c "CREATE EXTENSION IF NOT EXISTS vector;"
  HARMONIA_DATABASE_URL="postgres://postgres:password@localhost:5433/repro" pnpm db:migrate:direct
  ```
  Strongly recommend running this yourself before merging, given the auto-migrate-on-merge behavior above.

Closes #162