### PR TITLE
feat(brain): dedupe version variants (Deluxe/Remastered/Radio Edit) at sync time

### DIFF
--- a/packages/common/src/services/music/spotify/library-sync.ts
+++ b/packages/common/src/services/music/spotify/library-sync.ts
@@ -19,6 +19,8 @@ import {
 	PLAYLIST_FETCH_DELAY_MS,
 	TRACK_UPSERT_BATCH_SIZE,
 } from "../../../constants/spotify";
+import { selectCanonicalTracks } from "../../../utils/normalize-track-title";
+import { parseJsonStringArray } from "../../../utils/parse-json-string-array";
 import {
 	fetchAllSavedTracks,
 	fetchAllUserPlaylists,
@@ -423,11 +425,32 @@ export async function syncLibraryTracks(
 			});
 	}
 
+	// Collapse version variants (Deluxe/Remastered/Radio Edit/etc.) of the same
+	// song down to one canonical userTracks entry (#130) — the underlying
+	// `track` table upsert above stays unfiltered since other users may own
+	// the non-canonical version.
+	const canonicalTracks = selectCanonicalTracks(
+		tracks.map((t) => ({
+			id: t.id,
+			name: t.name,
+			primaryArtist: parseJsonStringArray(t.artistNames)[0] ?? "",
+		})),
+	);
+	const canonicalTrackIds = new Set(canonicalTracks.map((t) => t.id));
+	logger.info(
+		{
+			userId,
+			total: tracks.length,
+			deduped: tracks.length - canonicalTrackIds.size,
+		},
+		"Sync dedup removed version variants",
+	);
+
 	// Tracks with a known real liked-at date self-heal a stale placeholder on
 	// every sync; tracks without one must never touch an existing row's
 	// addedAt with the insert-time default (#214).
 	const { withLikedAt, withoutLikedAt } = partitionTracksByKnownLikedAt(
-		tracks,
+		tracks.filter((t) => canonicalTrackIds.has(t.id)),
 		likedAtByTrackId,
 	);
 

--- a/packages/common/src/utils/__tests__/normalize-track-title.test.ts
+++ b/packages/common/src/utils/__tests__/normalize-track-title.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	normalizeTrackTitle,
+	selectCanonicalTracks,
+} from "../normalize-track-title";
+
+describe("normalizeTrackTitle", () => {
+	it("strips a Deluxe Edition suffix", () => {
+		expect(normalizeTrackTitle("The Unforgiven (Deluxe Edition)")).toBe(
+			"The Unforgiven",
+		);
+	});
+
+	it("strips a bare Deluxe suffix", () => {
+		expect(normalizeTrackTitle("Song (Deluxe)")).toBe("Song");
+	});
+
+	it("strips a Remastered suffix with a year", () => {
+		expect(normalizeTrackTitle("Song (Remastered 2009)")).toBe("Song");
+	});
+
+	it("strips a year-prefixed Remaster suffix", () => {
+		expect(normalizeTrackTitle("Song (2009 Remaster)")).toBe("Song");
+	});
+
+	it("strips a Radio Edit suffix in brackets", () => {
+		expect(normalizeTrackTitle("Song [Radio Edit]")).toBe("Song");
+	});
+
+	it("strips an Explicit tag", () => {
+		expect(normalizeTrackTitle("Song (Explicit)")).toBe("Song");
+	});
+
+	it("leaves a title with no parenthetical unchanged", () => {
+		expect(normalizeTrackTitle("Live and Let Die")).toBe("Live and Let Die");
+	});
+
+	it("keeps a Live recording tag (different recording, not a re-release)", () => {
+		expect(normalizeTrackTitle("Hurt (Live at MSG 2007)")).toBe(
+			"Hurt (Live at MSG 2007)",
+		);
+	});
+
+	it("keeps a feat. credit", () => {
+		expect(normalizeTrackTitle("Song (feat. Someone)")).toBe(
+			"Song (feat. Someone)",
+		);
+	});
+
+	it("keeps an Acoustic tag", () => {
+		expect(normalizeTrackTitle("Song (Acoustic)")).toBe("Song (Acoustic)");
+	});
+
+	it("keeps an Instrumental tag", () => {
+		expect(normalizeTrackTitle("Song (Instrumental)")).toBe(
+			"Song (Instrumental)",
+		);
+	});
+});
+
+describe("selectCanonicalTracks", () => {
+	it("keeps the plain version over a Deluxe Edition duplicate", () => {
+		const result = selectCanonicalTracks([
+			{
+				id: "b",
+				name: "The Unforgiven (Deluxe Edition)",
+				primaryArtist: "Metallica",
+			},
+			{ id: "a", name: "The Unforgiven", primaryArtist: "Metallica" },
+		]);
+		expect(result).toEqual([
+			{ id: "a", name: "The Unforgiven", primaryArtist: "Metallica" },
+		]);
+	});
+
+	it("keeps both a Live version and the studio version", () => {
+		const tracks = [
+			{ id: "a", name: "Hurt", primaryArtist: "Johnny Cash" },
+			{
+				id: "b",
+				name: "Hurt (Live at MSG 2007)",
+				primaryArtist: "Johnny Cash",
+			},
+		];
+		const result = selectCanonicalTracks(tracks);
+		expect(result).toHaveLength(2);
+	});
+
+	it("keeps tracks with different primary artists separate even with the same title", () => {
+		const tracks = [
+			{ id: "a", name: "Home", primaryArtist: "Artist One" },
+			{ id: "b", name: "Home", primaryArtist: "Artist Two" },
+		];
+		expect(selectCanonicalTracks(tracks)).toHaveLength(2);
+	});
+
+	it("breaks a same-length-name tie by the lexicographically smaller ID", () => {
+		const result = selectCanonicalTracks([
+			{ id: "z", name: "Song", primaryArtist: "Artist" },
+			{ id: "a", name: "Song", primaryArtist: "Artist" },
+		]);
+		expect(result).toEqual([
+			{ id: "a", name: "Song", primaryArtist: "Artist" },
+		]);
+	});
+
+	it("passes a user with only the deluxe version through unchanged", () => {
+		const tracks = [
+			{ id: "a", name: "Song (Deluxe Edition)", primaryArtist: "Artist" },
+		];
+		expect(selectCanonicalTracks(tracks)).toEqual(tracks);
+	});
+});

--- a/packages/common/src/utils/normalize-track-title.ts
+++ b/packages/common/src/utils/normalize-track-title.ts
@@ -1,0 +1,40 @@
+// Matches a trailing version-suffix parenthetical/bracket — e.g. "(Deluxe Edition)",
+// "(2009 Remaster)", "[Radio Edit]" — so different releases of the same song
+// collapse to one canonical title. Deliberately does NOT strip "Live", "Acoustic",
+// "feat./ft.", "Instrumental", or arrangement tags — those are genuinely
+// different recordings, not just re-releases of the same one.
+const VERSION_SUFFIX_RE =
+	/[\s\-–]+[([](deluxe( edition| version)?|remastered?(\s+\d{4})?|\d{4}\s+remaster|radio (edit|version)|single (version|edit)|bonus( track)?|extended( mix| version)?|anniversary edition|special edition|expanded edition|explicit|clean|album version|original album version)[)\]]\s*$/i;
+
+export function normalizeTrackTitle(name: string): string {
+	return name.replace(VERSION_SUFFIX_RE, "").trim();
+}
+
+/**
+ * Groups tracks by normalized (title, primary artist) and keeps one canonical
+ * version per group — so a library with both "Song" and "Song (Deluxe
+ * Edition)" ends up with just one of them (#130). Prefers the shorter name
+ * (the plain version over a version-suffixed one); ties broken by the
+ * lexicographically smaller Spotify track ID, for a deterministic result.
+ */
+export function selectCanonicalTracks<
+	T extends { id: string; name: string; primaryArtist: string },
+>(tracks: T[]): T[] {
+	const canonicalByKey = new Map<string, T>();
+
+	for (const t of tracks) {
+		const key = `${normalizeTrackTitle(t.name).toLowerCase()}|||${t.primaryArtist.toLowerCase()}`;
+		const existing = canonicalByKey.get(key);
+		if (!existing) {
+			canonicalByKey.set(key, t);
+			continue;
+		}
+		const isBetter =
+			t.name.length !== existing.name.length
+				? t.name.length < existing.name.length
+				: t.id < existing.id;
+		if (isBetter) canonicalByKey.set(key, t);
+	}
+
+	return [...canonicalByKey.values()];
+}


### PR DESCRIPTION
## Summary
- New `normalizeTrackTitle()` (`packages/common/src/utils/normalize-track-title.ts`) strips trailing version-suffix parentheticals — Deluxe Edition, Remastered (with or without year), Radio Edit, Single Version, Bonus Track, Extended Mix, Explicit/Clean, etc. Deliberately does **not** strip Live, Acoustic, feat./ft., Instrumental, or arrangement tags — those are genuinely different recordings, not re-releases.
- New `selectCanonicalTracks()` groups a user's synced tracks by (normalized title, primary artist) and keeps one per group: shorter name wins (plain version over version-suffixed), ties broken by the lexicographically smaller Spotify track ID for a deterministic result.
- Wired into `syncLibraryTracks`: the shared `track` table upsert stays unfiltered (another user might own the non-canonical version — it's a cross-user catalog table), only **this user's** `userTracks` (library membership) rows get filtered to canonical tracks. Logs the deduped count each sync.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — new `normalize-track-title.test.ts` (16 cases covering both functions, including all acceptance-criteria examples from the issue: Deluxe Edition strip, Live-tag preservation, feat./Acoustic/Instrumental preservation, same-title-different-artist, tie-breaking), full suite green (75/75)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `pnpm build` — all 17 tasks compiled successfully (a trailing turbo cache-write warning was disk-space related, not a build failure)
- [x] `npx biome check` — clean
- [ ] Not verified against a live sync — Docker (local DB) still unresponsive. Recommend spot-checking dedup counts in the logs on the next real sync for an account with known duplicate releases.

Closes #130