### PR TITLE
fix(brain): dedupe the same song within a single generated playlist

### DIFF
--- a/packages/common/src/services/brain/__tests__/playlist-generator.test.ts
+++ b/packages/common/src/services/brain/__tests__/playlist-generator.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@harmonia/db", () => ({ db: {} }));
 
-import { findPrunableOrphanedPlaylists } from "../playlist-generator";
+import {
+	dedupeTracksBySongIdentity,
+	findPrunableOrphanedPlaylists,
+} from "../playlist-generator";
 
 describe("findPrunableOrphanedPlaylists", () => {
 	it("returns no prunable playlists when every playlist is matched", () => {
@@ -49,5 +52,54 @@ describe("findPrunableOrphanedPlaylists", () => {
 		);
 		expect(result.prunable.sort()).toEqual([1, 2, 3]);
 		expect(result.exportedOrphanCount).toBe(0);
+	});
+});
+
+describe("dedupeTracksBySongIdentity", () => {
+	function track(id: string, name: string, artistNames: string[] = ["Artist"]) {
+		return {
+			id,
+			name,
+			artistNames: JSON.stringify(artistNames),
+			llmMood: null,
+			llmTags: null,
+		};
+	}
+
+	it("keeps one copy of an exact duplicate (same name, same artist)", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("b", "Song"),
+			track("a", "Song"),
+		]);
+		expect(result).toEqual([track("a", "Song")]);
+	});
+
+	it("collapses a version-variant pair that slipped past sync-time dedup (#130)", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("b", "Song (Deluxe Edition)"),
+			track("a", "Song"),
+		]);
+		expect(result.map((t) => t.id)).toEqual(["a"]);
+	});
+
+	it("keeps a Live version distinct from the studio version", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("a", "Hurt"),
+			track("b", "Hurt (Live at MSG 2007)"),
+		]);
+		expect(result).toHaveLength(2);
+	});
+
+	it("keeps the same title by different artists distinct", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("a", "Home", ["Artist One"]),
+			track("b", "Home", ["Artist Two"]),
+		]);
+		expect(result).toHaveLength(2);
+	});
+
+	it("is a no-op when nothing collides", () => {
+		const tracks = [track("a", "Song A"), track("b", "Song B")];
+		expect(dedupeTracksBySongIdentity(tracks)).toEqual(tracks);
 	});
 });

--- a/packages/common/src/services/brain/playlist-generator.ts
+++ b/packages/common/src/services/brain/playlist-generator.ts
@@ -25,6 +25,7 @@ import { generateText, Output } from "ai";
 import { and, eq, inArray } from "drizzle-orm";
 import pLimit from "p-limit";
 import pRetry from "p-retry";
+import { normalizeTrackTitle } from "../../utils/normalize-track-title";
 import { parseJsonStringArray } from "../../utils/parse-json-string-array";
 import { getLatestPlaylistTrackIds } from "../music/spotify/playlist-cache";
 import {
@@ -352,13 +353,14 @@ async function updateExistingPlaylist(args: {
 		usedPlaylistNames,
 	} = args;
 
-	const trackRows = await reconcileManualSpotifyEdits({
+	const reconciledTrackRows = await reconcileManualSpotifyEdits({
 		userId,
 		playlistId,
 		spotifyPlaylistId,
 		clusterTrackRows: args.trackRows,
 		oldTrackIds,
 	});
+	const trackRows = dedupeTracksBySongIdentity(reconciledTrackRows);
 
 	const newTrackIds = new Set(trackRows.map((t) => t.id));
 	const similarity = jaccardSimilarity(oldTrackIds, newTrackIds);
@@ -470,14 +472,8 @@ async function createNewPlaylist(args: {
 	trackRows: TrackRow[];
 	usedPlaylistNames: Set<string>;
 }): Promise<CreatedPlaylist | null> {
-	const {
-		userId,
-		clusterId,
-		genreDomainId,
-		meta,
-		trackRows,
-		usedPlaylistNames,
-	} = args;
+	const { userId, clusterId, genreDomainId, meta, usedPlaylistNames } = args;
+	const trackRows = dedupeTracksBySongIdentity(args.trackRows);
 
 	try {
 		const generated = await generateUniquePlaylistMetadata(
@@ -558,6 +554,30 @@ export function findPrunableOrphanedPlaylists(
 		.map((p) => p.id);
 	const exportedOrphanCount = orphaned.length - prunable.length;
 	return { prunable, exportedOrphanCount };
+}
+
+/**
+ * Drops same-song duplicates from a single playlist's track set — a
+ * duplicate library entry, or two near-identical versions that both landed
+ * in the same cluster despite #130's sync-time dedup, would otherwise mean
+ * hearing the same song twice in one playlist (#160). Keyed by normalized
+ * (title, primary artist); keeps the lexicographically smallest track ID per
+ * group for a deterministic result. This is per-playlist only — the same
+ * song can still appear across two different Harmonia playlists.
+ */
+export function dedupeTracksBySongIdentity(trackRows: TrackRow[]): TrackRow[] {
+	const canonicalByKey = new Map<string, TrackRow>();
+
+	for (const t of trackRows) {
+		const primaryArtist = parseJsonStringArray(t.artistNames)[0] ?? "";
+		const key = `${normalizeTrackTitle(t.name).toLowerCase()}|||${primaryArtist.toLowerCase()}`;
+		const existing = canonicalByKey.get(key);
+		if (!existing || t.id < existing.id) {
+			canonicalByKey.set(key, t);
+		}
+	}
+
+	return [...canonicalByKey.values()];
 }
 
 function deriveTags(meta: ClusterMeta | null, trackRows: TrackRow[]): string[] {


### PR DESCRIPTION
## Stacked on #227

This branches off `feat/dedupe-track-version-variants` (#227) since it reuses `normalizeTrackTitle()` from there. Base is set to that branch so this diff only shows the new changes — merge #227 into `main` first, then retarget/merge this one.

## Summary
- New `dedupeTracksBySongIdentity()` in `playlist-generator.ts`: groups a cluster's track rows by normalized (title, primary artist) — reusing #130's `normalizeTrackTitle()` — and keeps one per group (smallest track ID wins, deterministic; no popularity/playlist-membership signal is available at this point in the pipeline, and the issue explicitly allows this simpler fallback).
- Applied in both `updateExistingPlaylist` (after manual-edit reconciliation, since a reconciled-in track could itself collide with an existing one) and `createNewPlaylist`.
- Per-playlist only, as scoped — the same song can still appear across two different Harmonia playlists, just not twice within one.

## Test plan
- [x] `pnpm --filter @harmonia/common exec vitest run` — 5 new cases in `playlist-generator.test.ts` (exact duplicate, version-variant pair, Live-version preserved, same-title-different-artist preserved, no-op when nothing collides), full suite green (80/80)
- [x] `pnpm --filter @harmonia/common exec tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [ ] Not verified against a live pipeline run — Docker (local DB) still unresponsive.

Closes #160