### PR TITLE
fix(dashboard): auto-refresh playlists/clusters when pipeline completes

### DIFF
--- a/apps/dashboard/src/shared/lib/pipeline/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/pipeline/controller.hook.ts
@@ -151,6 +151,12 @@ export function usePipelineProgressDrive(): PipelineProgressContextValue {
 
 		function invalidatePipeline() {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.pipeline() });
+			// Playlists/clusters are written by the trigger job before the pipeline
+			// reaches a terminal state — without this the dashboard shows stale
+			// data until the user navigates away or hard-refreshes (#85). Only
+			// called from terminal transitions below, never on a "progress" tick.
+			void queryClient.invalidateQueries({ queryKey: queryKeys.playlists() });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.clusters() });
 		}
 
 		function failRunNotFound() {


### PR DESCRIPTION
## Summary
- `invalidatePipeline()` only invalidated `queryKeys.pipeline()` — playlists and clusters (already written to the DB by the trigger job before the pipeline reaches a terminal state) stayed stale in the dashboard until the user navigated away or hard-refreshed.
- Now also invalidates `queryKeys.playlists()` and `queryKeys.clusters()`. Verified every call site of `invalidatePipeline()` is on a terminal transition (completed/partial/failed/error/run-not-found) — never on a "progress" tick — so this adds zero extra requests while a run is actually in flight.

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [ ] Not verified live — Docker (local DB) still unresponsive, would need a full pipeline run to confirm end-to-end.

Closes #85