### PR TITLE
fix(dashboard): redesign exported-playlist indicator, move synced text to card bottom

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
@@ -1,6 +1,5 @@
 import type { playlistListItemSchema } from "@harmonia/common/schemas";
 import {
-	Badge,
 	Breadcrumb,
 	BreadcrumbItem,
 	BreadcrumbList,
@@ -37,29 +36,26 @@ export function DashboardPlaylistsListRow({
 			)}
 		>
 			<div className="flex items-center justify-between gap-3">
-				<div className="flex flex-wrap items-center gap-2">
-					<p className="text-muted-foreground text-xs uppercase tracking-wide">
-						{playlist.trackCount} tracks
-					</p>
+				<p className="text-muted-foreground text-xs uppercase tracking-wide">
+					{playlist.trackCount} tracks
+				</p>
+				<div className="flex shrink-0 items-center gap-3">
 					{playlist.spotifyPlaylistId ? (
-						<Badge variant="outline" className="border-primary/40 text-primary">
-							<Icons.circleCheck className="size-3" />
-							Exported
-						</Badge>
-					) : null}
-					{playlist.spotifyPlaylistId && playlist.exportedAt ? (
-						<span className="text-muted-foreground text-xs">
-							Synced{" "}
-							{formatDistanceToNow(playlist.exportedAt, { addSuffix: true })}
+						<span
+							role="img"
+							aria-label="Exported to Spotify"
+							className="text-primary"
+						>
+							<Icons.spotify className="size-4" aria-hidden />
 						</span>
 					) : null}
+					<span
+						className="flex size-11 shrink-0 items-center justify-end text-muted-foreground"
+						aria-hidden
+					>
+						<Icons.arrowUpRight className="size-5" />
+					</span>
 				</div>
-				<span
-					className="flex size-11 shrink-0 items-center justify-end text-muted-foreground"
-					aria-hidden
-				>
-					<Icons.arrowUpRight className="size-5" />
-				</span>
 			</div>
 			<h2 className="mt-3 font-bold text-foreground text-xl leading-tight tracking-tight">
 				{playlist.name}
@@ -88,6 +84,11 @@ export function DashboardPlaylistsListRow({
 						))}
 					</BreadcrumbList>
 				</Breadcrumb>
+			) : null}
+			{playlist.spotifyPlaylistId && playlist.exportedAt ? (
+				<p className="mt-3 text-muted-foreground text-xs">
+					Synced {formatDistanceToNow(playlist.exportedAt, { addSuffix: true })}
+				</p>
 			) : null}
 		</Link>
 	);

--- a/packages/ui/src/components/shared/icons.tsx
+++ b/packages/ui/src/components/shared/icons.tsx
@@ -20,6 +20,7 @@ import {
 	IconArrowUpRight,
 	IconBrain,
 	IconBrandBandlab,
+	IconBrandSpotifyFilled,
 	IconChartBar,
 	IconCheck,
 	IconChevronDown,
@@ -104,6 +105,7 @@ export const Icons = {
 
 	// Brand
 	logo: IconBrandBandlab,
+	spotify: IconBrandSpotifyFilled,
 
 	// Navigation / App
 	settings: IconSettings,


### PR DESCRIPTION
## Summary
- Replaced the "Exported" badge (checkmark icon + text, competing with the track count in the card's busiest row) with a small icon-only Spotify-brand indicator (`IconBrandSpotifyFilled`, in `text-primary` to match the app's existing token-based color system rather than a hardcoded brand hex) — labeled via `role="img" aria-label` for accessibility.
- Moved "Synced X ago" out of the top row entirely, down to its own line at the bottom of the card (after the tags).

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm --filter @harmonia/ui exec tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [ ] Not verified live — Docker (local DB) still unresponsive. Recommend a quick look at an exported playlist's card on the Vercel preview.

Closes #220