### PR TITLE
chore: add shieldcn badge row to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Harmonia
 
+<p align="center">
+  <a href="https://github.com/FindMalek/harmonia/commits/main">
+    <img alt="Last commit" src="https://shieldcn.dev/github/last-commit/FindMalek/harmonia.svg?variant=secondary&mode=dark&color=18181b" />
+  </a>
+  <a href="#license">
+    <img alt="License: MIT" src="https://shieldcn.dev/badge/license-MIT-18181b.svg?variant=secondary&mode=dark" />
+  </a>
+  <img alt="Next.js" src="https://shieldcn.dev/badge/-Next.js-18181b.svg?logo=nextdotjs&variant=secondary&mode=dark" />
+  <img alt="TypeScript" src="https://shieldcn.dev/badge/-TypeScript-18181b.svg?logo=typescript&variant=secondary&mode=dark" />
+  <img alt="Drizzle ORM" src="https://shieldcn.dev/badge/-Drizzle-18181b.svg?logo=drizzle&variant=secondary&mode=dark" />
+  <img alt="Turborepo" src="https://shieldcn.dev/badge/-Turborepo-18181b.svg?logo=turborepo&variant=secondary&mode=dark" />
+</p>
+
 > AI-powered music organization — sync your Spotify library, classify every track, and auto-generate playlists by mood, theme, and vibe.
 
 ## What it does


### PR DESCRIPTION
## Summary
Root README had zero badges/visual header. Added a centered badge row right under the title using [shieldcn](https://shieldcn.dev) (renders shadcn/ui-styled badges instead of default shields.io):

- Last commit (dynamic, GitHub data)
- License: MIT (static — no LICENSE file exists in the repo yet even though the README's own License section says MIT and GitHub's license detection returns none; used a static badge so it doesn't render broken/unknown)
- Next.js, TypeScript, Drizzle ORM, Turborepo — stack badges with logos

Kept to a calm, neutral dark tone (`variant=secondary`, single neutral color across all badges) rather than a rainbow of brand colors, matching the project's own shadcn aesthetic. Verified every generated badge URL resolves with `curl -I` (all 200s) before committing.

Confirmed the repo is public (`gh repo view` → `isPrivate: false`), so the GitHub-data badge (last commit) will resolve correctly for anyone viewing it.

No other README content changed, per the issue's acceptance criteria.

## Test plan
- [x] All 6 badge URLs return HTTP 200
- [x] Spot-checked response sizes differ per logo (not silently falling back to a blank/no-logo badge)
- [x] `git diff` confirms only the header section changed

Closes #182

## Separate note
Noticed while doing this: there's no actual `LICENSE` file in the repo, only the README's own "## License" section claiming MIT. Not in scope for this PR (badges/header only), but worth adding a real `LICENSE` file at some point so GitHub's own license detection picks it up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered README header with badges highlighting the project’s latest commit, MIT license, and core technologies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->