### PR TITLE
feat(dashboard): build the /tracks library page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Harmonia
 
+<p align="center">
+  <a href="https://github.com/FindMalek/harmonia/commits/main">
+    <img alt="Last commit" src="https://shieldcn.dev/github/last-commit/FindMalek/harmonia.svg?variant=secondary&mode=dark&color=18181b" />
+  </a>
+  <a href="#license">
+    <img alt="License: MIT" src="https://shieldcn.dev/badge/license-MIT-18181b.svg?variant=secondary&mode=dark" />
+  </a>
+  <img alt="Next.js" src="https://shieldcn.dev/badge/-Next.js-18181b.svg?logo=nextdotjs&variant=secondary&mode=dark" />
+  <img alt="TypeScript" src="https://shieldcn.dev/badge/-TypeScript-18181b.svg?logo=typescript&variant=secondary&mode=dark" />
+  <img alt="Drizzle ORM" src="https://shieldcn.dev/badge/-Drizzle-18181b.svg?logo=drizzle&variant=secondary&mode=dark" />
+  <img alt="Turborepo" src="https://shieldcn.dev/badge/-Turborepo-18181b.svg?logo=turborepo&variant=secondary&mode=dark" />
+</p>
+
 > AI-powered music organization — sync your Spotify library, classify every track, and auto-generate playlists by mood, theme, and vibe.
 
 ## What it does

--- a/apps/dashboard/src/app/(dashboard)/tracks/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/tracks/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Icons } from "@harmonia/ui";
+import { Fragment } from "react";
+import {
+	DashboardTracksListRow,
+	DashboardTracksListSkeleton,
+} from "@/components/app/dashboard-tracks-list-row";
+import { DashboardTracksPageHeader } from "@/components/app/dashboard-tracks-page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { ErrorState } from "@/components/shared/error-state";
+import { ScrollToTopButton } from "@/components/shared/scroll-to-top-button";
+import { useDashboardScrollContainer } from "@/hooks/use-dashboard-scroll-container";
+import { useInfiniteScrollSentinel } from "@/hooks/use-infinite-scroll-sentinel";
+import { useScrollFlags } from "@/hooks/use-scroll-flags";
+import { useTracksController } from "@/shared/lib/tracks/controller.hook";
+
+export default function TracksPage() {
+	const { list, search, setSearch, sort, setSort } = useTracksController();
+	const {
+		data,
+		isLoading,
+		isError,
+		error,
+		refetch,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = list;
+
+	const scrollContainerRef = useDashboardScrollContainer();
+	const { showBackToTop, scrollDirection } = useScrollFlags(
+		scrollContainerRef,
+		{ collapseAt: 24, backToTopAt: 400 },
+	);
+
+	const sentinelRef = useInfiniteScrollSentinel({
+		rootRef: scrollContainerRef,
+		hasNextPage: Boolean(hasNextPage),
+		isFetchingNextPage,
+		fetchNextPage,
+	});
+
+	const tracks = data?.pages.flatMap((page) => page.tracks) ?? [];
+
+	// Backend returns album-sorted rows contiguously when sort === "album", so
+	// a plain consecutive scan is enough to find group boundaries — no need to
+	// re-sort or bucket client-side.
+	const albumGroupStartIds =
+		sort === "album"
+			? new Set(
+					tracks
+						.filter(
+							(t, i) =>
+								i === 0 ||
+								(t.albumId ?? t.albumName) !==
+									(tracks[i - 1]?.albumId ?? tracks[i - 1]?.albumName),
+						)
+						.map((t) => t.id),
+				)
+			: null;
+
+	if (isError) {
+		return (
+			<div className="space-y-8">
+				<DashboardTracksPageHeader
+					search={search}
+					onSearchChange={setSearch}
+					sort={sort}
+					onSortChange={setSort}
+				/>
+				<ErrorState
+					message={
+						error instanceof Error ? error.message : "Failed to load tracks"
+					}
+					onRetry={() => refetch()}
+				/>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="space-y-8">
+				<DashboardTracksPageHeader
+					search={search}
+					onSearchChange={setSearch}
+					sort={sort}
+					onSortChange={setSort}
+				/>
+				<DashboardTracksListSkeleton />
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-8">
+			<DashboardTracksPageHeader
+				search={search}
+				onSearchChange={setSearch}
+				sort={sort}
+				onSortChange={setSort}
+			/>
+
+			{tracks.length === 0 ? (
+				<EmptyState
+					icon={Icons.music}
+					title={search ? "No matching tracks" : "No tracks yet"}
+					description={
+						search
+							? "Try a different search."
+							: "Sync your Spotify library to see tracks here."
+					}
+					variant="card"
+				/>
+			) : (
+				<div>
+					{tracks.map((t) => (
+						<Fragment key={t.id}>
+							{albumGroupStartIds?.has(t.id) ? (
+								<p className="pt-4 pb-1 font-mono text-[9px] text-muted-foreground uppercase tracking-widest">
+									{t.albumName ?? "Unknown album"}
+								</p>
+							) : null}
+							<DashboardTracksListRow track={t} />
+						</Fragment>
+					))}
+				</div>
+			)}
+
+			{hasNextPage ? <div ref={sentinelRef} className="h-1" /> : null}
+
+			<ScrollToTopButton
+				visible={showBackToTop}
+				scrollDirection={scrollDirection}
+				containerRef={scrollContainerRef}
+			/>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-playlist-detail-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlist-detail-header.tsx
@@ -42,12 +42,11 @@ export function DashboardPlaylistDetailHeader({
 				) : null}
 			</div>
 
+			{scrolled ? (
+				<p className="mt-3 truncate font-medium text-sm">{name}</p>
+			) : null}
+
 			<div className="mt-3 flex items-center gap-2">
-				{scrolled ? (
-					<span className="max-w-[40%] shrink-0 truncate font-medium text-sm">
-						{name}
-					</span>
-				) : null}
 				<div className="relative flex-1">
 					<Icons.search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
 					<Input

--- a/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-list-row.tsx
@@ -1,6 +1,5 @@
 import type { playlistListItemSchema } from "@harmonia/common/schemas";
 import {
-	Badge,
 	Breadcrumb,
 	BreadcrumbItem,
 	BreadcrumbList,
@@ -37,29 +36,26 @@ export function DashboardPlaylistsListRow({
 			)}
 		>
 			<div className="flex items-center justify-between gap-3">
-				<div className="flex flex-wrap items-center gap-2">
-					<p className="text-muted-foreground text-xs uppercase tracking-wide">
-						{playlist.trackCount} tracks
-					</p>
+				<p className="text-muted-foreground text-xs uppercase tracking-wide">
+					{playlist.trackCount} tracks
+				</p>
+				<div className="flex shrink-0 items-center gap-3">
 					{playlist.spotifyPlaylistId ? (
-						<Badge variant="outline" className="border-primary/40 text-primary">
-							<Icons.circleCheck className="size-3" />
-							Exported
-						</Badge>
-					) : null}
-					{playlist.spotifyPlaylistId && playlist.exportedAt ? (
-						<span className="text-muted-foreground text-xs">
-							Synced{" "}
-							{formatDistanceToNow(playlist.exportedAt, { addSuffix: true })}
+						<span
+							role="img"
+							aria-label="Exported to Spotify"
+							className="text-primary"
+						>
+							<Icons.spotify className="size-4" aria-hidden />
 						</span>
 					) : null}
+					<span
+						className="flex size-11 shrink-0 items-center justify-end text-muted-foreground"
+						aria-hidden
+					>
+						<Icons.arrowUpRight className="size-5" />
+					</span>
 				</div>
-				<span
-					className="flex size-11 shrink-0 items-center justify-end text-muted-foreground"
-					aria-hidden
-				>
-					<Icons.arrowUpRight className="size-5" />
-				</span>
 			</div>
 			<h2 className="mt-3 font-bold text-foreground text-xl leading-tight tracking-tight">
 				{playlist.name}
@@ -88,6 +84,11 @@ export function DashboardPlaylistsListRow({
 						))}
 					</BreadcrumbList>
 				</Breadcrumb>
+			) : null}
+			{playlist.spotifyPlaylistId && playlist.exportedAt ? (
+				<p className="mt-3 text-muted-foreground text-xs">
+					Synced {formatDistanceToNow(playlist.exportedAt, { addSuffix: true })}
+				</p>
 			) : null}
 		</Link>
 	);

--- a/apps/dashboard/src/components/app/dashboard-playlists-page-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-playlists-page-header.tsx
@@ -27,7 +27,7 @@ export function DashboardPlaylistsPageHeader({
 	const isBusy = exportMutation.isPending || organizeMutation.isPending;
 
 	return (
-		<div className="flex items-start justify-between gap-4">
+		<div className="sticky -top-5 z-10 -mx-4 -mt-4 flex items-start justify-between gap-4 bg-background px-4 pt-4 pb-3">
 			<PageHeader
 				title="AI Playlists"
 				description="Generated from your taste."

--- a/apps/dashboard/src/components/app/dashboard-track-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-track-detail.tsx
@@ -79,43 +79,42 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 				label="Playlists"
 			/>
 
-			<div className="flex flex-col items-start gap-4 sm:flex-row">
-				{track.albumImageUrl ? (
-					<Image
-						src={track.albumImageUrl}
-						alt=""
-						width={160}
-						height={160}
-						className="size-32 shrink-0 sm:size-40"
-						unoptimized
-					/>
-				) : (
-					<div className="size-32 shrink-0 bg-muted sm:size-40" />
-				)}
-				<div className="flex min-w-0 flex-1 flex-col gap-1">
-					<h1 className="font-bold text-2xl tracking-tight">{track.name}</h1>
-					<p className="text-muted-foreground">{artists.join(", ")}</p>
-					{track.albumName ? (
-						<p className="text-muted-foreground text-sm">{track.albumName}</p>
-					) : null}
-					<a
-						href={track.spotifyUri.replace(
-							"spotify:track:",
-							"https://open.spotify.com/track/",
-						)}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="mt-2"
-					>
-						<Button
-							variant="outline"
-							className="font-bold uppercase tracking-widest"
-						>
-							Open in Spotify
-							<Icons.externalLink className="ml-2 size-4" />
-						</Button>
-					</a>
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+				<div className="flex flex-col items-start gap-4 sm:flex-row">
+					{track.albumImageUrl ? (
+						<Image
+							src={track.albumImageUrl}
+							alt=""
+							width={224}
+							height={224}
+							className="size-44 shrink-0 sm:size-56"
+							unoptimized
+						/>
+					) : (
+						<div className="size-44 shrink-0 bg-muted sm:size-56" />
+					)}
+					<div className="flex min-w-0 flex-1 flex-col gap-1 sm:pt-2">
+						<h1 className="font-bold text-2xl tracking-tight">{track.name}</h1>
+						<p className="text-muted-foreground">{artists.join(", ")}</p>
+						{track.albumName ? (
+							<p className="text-muted-foreground text-sm">{track.albumName}</p>
+						) : null}
+					</div>
 				</div>
+				<a
+					href={track.spotifyUri.replace(
+						"spotify:track:",
+						"https://open.spotify.com/track/",
+					)}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="shrink-0"
+				>
+					<Button className="w-full bg-primary font-bold text-primary-foreground uppercase tracking-widest hover:bg-primary/90 sm:w-auto">
+						Open in Spotify
+						<Icons.externalLink className="ml-2 size-4" />
+					</Button>
+				</a>
 			</div>
 
 			<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -288,7 +287,7 @@ export function DashboardTrackDetailSkeleton() {
 				<Skeleton className="h-px w-full" />
 			</div>
 			<div className="flex gap-4">
-				<Skeleton className="size-32 shrink-0 sm:size-40" />
+				<Skeleton className="size-44 shrink-0 sm:size-56" />
 				<div className="flex flex-1 flex-col gap-2">
 					<Skeleton className="h-8 w-64" />
 					<Skeleton className="h-4 w-48" />

--- a/apps/dashboard/src/components/app/dashboard-tracks-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-list-row.tsx
@@ -1,0 +1,75 @@
+import type { TracksListOutput } from "@harmonia/common/schemas";
+import { parseJsonStringArray } from "@harmonia/common/utils/parse-json-string-array";
+import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
+import { Skeleton } from "@harmonia/ui";
+import type { Route } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+export type DashboardTracksListRowTrack = TracksListOutput["tracks"][number];
+
+export function DashboardTracksListRow({
+	track,
+}: {
+	track: DashboardTracksListRowTrack;
+}) {
+	const artists = parseJsonStringArray(track.artistNames);
+
+	return (
+		<Link
+			href={DASHBOARD_ROUTES.tracks.children.detail.makePath(track.id) as Route}
+			className="flex items-center gap-4 border-b py-4 last:border-b-0 hover:bg-accent/50"
+		>
+			{track.albumImageUrl ? (
+				<Image
+					src={track.albumImageUrl}
+					alt=""
+					width={48}
+					height={48}
+					className="size-12 shrink-0 rounded object-cover"
+					unoptimized
+				/>
+			) : (
+				<div className="size-12 shrink-0 rounded bg-muted" />
+			)}
+			<div className="min-w-0 flex-1">
+				<p className="truncate font-medium text-sm">{track.name}</p>
+				<p className="truncate text-muted-foreground text-xs">
+					{artists.join(", ")}
+					{track.albumName ? ` • ${track.albumName}` : ""}
+				</p>
+			</div>
+		</Link>
+	);
+}
+
+export function DashboardTracksListRowSkeleton() {
+	return (
+		<div className="flex items-center gap-4 border-b py-4 last:border-b-0">
+			<Skeleton className="size-12 shrink-0 rounded" />
+			<div className="min-w-0 flex-1 space-y-2">
+				<Skeleton className="h-4 w-2/5" />
+				<Skeleton className="h-3 w-3/5" />
+			</div>
+		</div>
+	);
+}
+
+const TRACKS_SKELETON_KEYS = [
+	"tr-sk-1",
+	"tr-sk-2",
+	"tr-sk-3",
+	"tr-sk-4",
+	"tr-sk-5",
+	"tr-sk-6",
+] as const;
+
+export function DashboardTracksListSkeleton() {
+	return (
+		<div className="divide-y divide-border">
+			{TRACKS_SKELETON_KEYS.map((key) => (
+				<DashboardTracksListRowSkeleton key={key} />
+			))}
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-tracks-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-list-row.tsx
@@ -66,7 +66,7 @@ const TRACKS_SKELETON_KEYS = [
 
 export function DashboardTracksListSkeleton() {
 	return (
-		<div className="divide-y divide-border">
+		<div>
 			{TRACKS_SKELETON_KEYS.map((key) => (
 				<DashboardTracksListRowSkeleton key={key} />
 			))}

--- a/apps/dashboard/src/components/app/dashboard-tracks-page-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-page-header.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { TracksListSort } from "@harmonia/common/schemas";
+import { Icons, Input } from "@harmonia/ui";
+import { PageHeader } from "../shared/page-header";
+import { DashboardTracksSortSelect } from "./dashboard-tracks-sort-select";
+
+export function DashboardTracksPageHeader({
+	search,
+	onSearchChange,
+	sort,
+	onSortChange,
+}: {
+	search: string;
+	onSearchChange: (value: string) => void;
+	sort: TracksListSort;
+	onSortChange: (value: TracksListSort) => void;
+}) {
+	return (
+		<div className="sticky -top-5 z-10 -mx-4 -mt-4 flex flex-col gap-3 bg-background px-4 pt-4 pb-3">
+			<PageHeader title="Tracks" description="Your full synced library." />
+			<div className="flex items-center gap-2">
+				<div className="relative flex-1">
+					<Icons.search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						placeholder="Search tracks"
+						aria-label="Search tracks"
+						className="pl-9"
+					/>
+				</div>
+				<DashboardTracksSortSelect value={sort} onChange={onSortChange} />
+			</div>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-tracks-sort-select.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-sort-select.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { TracksListSort } from "@harmonia/common/schemas";
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+	Icons,
+} from "@harmonia/ui";
+
+const SORT_OPTIONS: Array<{ value: TracksListSort; label: string }> = [
+	{ value: "recent", label: "Recently added" },
+	{ value: "album", label: "By album" },
+];
+
+export function DashboardTracksSortSelect({
+	value,
+	onChange,
+}: {
+	value: TracksListSort;
+	onChange: (value: TracksListSort) => void;
+}) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					className="size-11 shrink-0 rounded-none"
+					aria-label="Sort tracks"
+				>
+					<Icons.sort className="size-5 shrink-0" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="min-w-48">
+				<DropdownMenuRadioGroup
+					value={value}
+					onValueChange={(next) => onChange(next as TracksListSort)}
+				>
+					{SORT_OPTIONS.map((option) => (
+						<DropdownMenuRadioItem key={option.value} value={option.value}>
+							{option.label}
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/dashboard/src/shared/lib/pipeline/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/pipeline/controller.hook.ts
@@ -151,6 +151,12 @@ export function usePipelineProgressDrive(): PipelineProgressContextValue {
 
 		function invalidatePipeline() {
 			void queryClient.invalidateQueries({ queryKey: queryKeys.pipeline() });
+			// Playlists/clusters are written by the trigger job before the pipeline
+			// reaches a terminal state — without this the dashboard shows stale
+			// data until the user navigates away or hard-refreshes (#85). Only
+			// called from terminal transitions below, never on a "progress" tick.
+			void queryClient.invalidateQueries({ queryKey: queryKeys.playlists() });
+			void queryClient.invalidateQueries({ queryKey: queryKeys.clusters() });
 		}
 
 		function failRunNotFound() {

--- a/apps/dashboard/src/shared/lib/tracks/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/tracks/controller.hook.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useDeferredValue } from "react";
+import { orpc } from "@/shared/api/orpc";
+import { useTracksStore } from "./store";
+
+const TRACKS_PAGE_SIZE = 50;
+
+export function useTracksController() {
+	const store = useTracksStore();
+	const deferredSearch = useDeferredValue(store.search.trim());
+
+	const list = useInfiniteQuery({
+		...orpc.tracks.list.infiniteOptions({
+			input: (page: number) => ({
+				page,
+				pageSize: TRACKS_PAGE_SIZE,
+				search: deferredSearch || undefined,
+				sort: store.sort,
+			}),
+			initialPageParam: 1,
+			getNextPageParam: (lastPage) =>
+				lastPage.page * lastPage.pageSize < lastPage.total
+					? lastPage.page + 1
+					: undefined,
+		}),
+	});
+
+	return {
+		list,
+		search: store.search,
+		setSearch: store.setSearch,
+		sort: store.sort,
+		setSort: store.setSort,
+	};
+}

--- a/apps/dashboard/src/shared/lib/tracks/store.ts
+++ b/apps/dashboard/src/shared/lib/tracks/store.ts
@@ -1,0 +1,16 @@
+import type { TracksListSort } from "@harmonia/common/schemas";
+import { create } from "zustand";
+
+interface TracksStore {
+	search: string;
+	setSearch: (value: string) => void;
+	sort: TracksListSort;
+	setSort: (value: TracksListSort) => void;
+}
+
+export const useTracksStore = create<TracksStore>((set) => ({
+	search: "",
+	setSearch: (value) => set({ search: value }),
+	sort: "recent",
+	setSort: (value) => set({ sort: value }),
+}));

--- a/packages/common/src/schemas/track/input.ts
+++ b/packages/common/src/schemas/track/input.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+// "album" orders by albumName (then id for stable pagination), letting the UI
+// render contiguous album groups instead of an interleaved recent-first feed.
+export const tracksListSortEnum = z.enum(["recent", "album"]);
+export type TracksListSort = z.infer<typeof tracksListSortEnum>;
+
 export const tracksListInput = z.object({
 	page: z.number().default(1),
 	pageSize: z.number().default(50),
@@ -7,6 +12,7 @@ export const tracksListInput = z.object({
 	lyricsStatus: z.string().optional(),
 	classified: z.boolean().optional(),
 	embedded: z.boolean().optional(),
+	sort: tracksListSortEnum.default("recent"),
 });
 export type TracksListInput = z.infer<typeof tracksListInput>;
 

--- a/packages/common/src/services/brain/__tests__/playlist-generator.test.ts
+++ b/packages/common/src/services/brain/__tests__/playlist-generator.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@harmonia/db", () => ({ db: {} }));
 
-import { findPrunableOrphanedPlaylists } from "../playlist-generator";
+import {
+	dedupeTracksBySongIdentity,
+	findPrunableOrphanedPlaylists,
+} from "../playlist-generator";
 
 describe("findPrunableOrphanedPlaylists", () => {
 	it("returns no prunable playlists when every playlist is matched", () => {
@@ -49,5 +52,54 @@ describe("findPrunableOrphanedPlaylists", () => {
 		);
 		expect(result.prunable.sort()).toEqual([1, 2, 3]);
 		expect(result.exportedOrphanCount).toBe(0);
+	});
+});
+
+describe("dedupeTracksBySongIdentity", () => {
+	function track(id: string, name: string, artistNames: string[] = ["Artist"]) {
+		return {
+			id,
+			name,
+			artistNames: JSON.stringify(artistNames),
+			llmMood: null,
+			llmTags: null,
+		};
+	}
+
+	it("keeps one copy of an exact duplicate (same name, same artist)", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("b", "Song"),
+			track("a", "Song"),
+		]);
+		expect(result).toEqual([track("a", "Song")]);
+	});
+
+	it("collapses a version-variant pair that slipped past sync-time dedup (#130)", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("b", "Song (Deluxe Edition)"),
+			track("a", "Song"),
+		]);
+		expect(result.map((t) => t.id)).toEqual(["a"]);
+	});
+
+	it("keeps a Live version distinct from the studio version", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("a", "Hurt"),
+			track("b", "Hurt (Live at MSG 2007)"),
+		]);
+		expect(result).toHaveLength(2);
+	});
+
+	it("keeps the same title by different artists distinct", () => {
+		const result = dedupeTracksBySongIdentity([
+			track("a", "Home", ["Artist One"]),
+			track("b", "Home", ["Artist Two"]),
+		]);
+		expect(result).toHaveLength(2);
+	});
+
+	it("is a no-op when nothing collides", () => {
+		const tracks = [track("a", "Song A"), track("b", "Song B")];
+		expect(dedupeTracksBySongIdentity(tracks)).toEqual(tracks);
 	});
 });

--- a/packages/common/src/services/brain/playlist-generator.ts
+++ b/packages/common/src/services/brain/playlist-generator.ts
@@ -25,6 +25,7 @@ import { generateText, Output } from "ai";
 import { and, eq, inArray } from "drizzle-orm";
 import pLimit from "p-limit";
 import pRetry from "p-retry";
+import { normalizeTrackTitle } from "../../utils/normalize-track-title";
 import { parseJsonStringArray } from "../../utils/parse-json-string-array";
 import { getLatestPlaylistTrackIds } from "../music/spotify/playlist-cache";
 import {
@@ -352,13 +353,14 @@ async function updateExistingPlaylist(args: {
 		usedPlaylistNames,
 	} = args;
 
-	const trackRows = await reconcileManualSpotifyEdits({
+	const reconciledTrackRows = await reconcileManualSpotifyEdits({
 		userId,
 		playlistId,
 		spotifyPlaylistId,
 		clusterTrackRows: args.trackRows,
 		oldTrackIds,
 	});
+	const trackRows = dedupeTracksBySongIdentity(reconciledTrackRows);
 
 	const newTrackIds = new Set(trackRows.map((t) => t.id));
 	const similarity = jaccardSimilarity(oldTrackIds, newTrackIds);
@@ -470,14 +472,8 @@ async function createNewPlaylist(args: {
 	trackRows: TrackRow[];
 	usedPlaylistNames: Set<string>;
 }): Promise<CreatedPlaylist | null> {
-	const {
-		userId,
-		clusterId,
-		genreDomainId,
-		meta,
-		trackRows,
-		usedPlaylistNames,
-	} = args;
+	const { userId, clusterId, genreDomainId, meta, usedPlaylistNames } = args;
+	const trackRows = dedupeTracksBySongIdentity(args.trackRows);
 
 	try {
 		const generated = await generateUniquePlaylistMetadata(
@@ -558,6 +554,30 @@ export function findPrunableOrphanedPlaylists(
 		.map((p) => p.id);
 	const exportedOrphanCount = orphaned.length - prunable.length;
 	return { prunable, exportedOrphanCount };
+}
+
+/**
+ * Drops same-song duplicates from a single playlist's track set — a
+ * duplicate library entry, or two near-identical versions that both landed
+ * in the same cluster despite #130's sync-time dedup, would otherwise mean
+ * hearing the same song twice in one playlist (#160). Keyed by normalized
+ * (title, primary artist); keeps the lexicographically smallest track ID per
+ * group for a deterministic result. This is per-playlist only — the same
+ * song can still appear across two different Harmonia playlists.
+ */
+export function dedupeTracksBySongIdentity(trackRows: TrackRow[]): TrackRow[] {
+	const canonicalByKey = new Map<string, TrackRow>();
+
+	for (const t of trackRows) {
+		const primaryArtist = parseJsonStringArray(t.artistNames)[0] ?? "";
+		const key = `${normalizeTrackTitle(t.name).toLowerCase()}|||${primaryArtist.toLowerCase()}`;
+		const existing = canonicalByKey.get(key);
+		if (!existing || t.id < existing.id) {
+			canonicalByKey.set(key, t);
+		}
+	}
+
+	return [...canonicalByKey.values()];
 }
 
 function deriveTags(meta: ClusterMeta | null, trackRows: TrackRow[]): string[] {

--- a/packages/common/src/services/music/spotify/library-sync.ts
+++ b/packages/common/src/services/music/spotify/library-sync.ts
@@ -19,6 +19,8 @@ import {
 	PLAYLIST_FETCH_DELAY_MS,
 	TRACK_UPSERT_BATCH_SIZE,
 } from "../../../constants/spotify";
+import { selectCanonicalTracks } from "../../../utils/normalize-track-title";
+import { parseJsonStringArray } from "../../../utils/parse-json-string-array";
 import {
 	fetchAllSavedTracks,
 	fetchAllUserPlaylists,
@@ -423,11 +425,32 @@ export async function syncLibraryTracks(
 			});
 	}
 
+	// Collapse version variants (Deluxe/Remastered/Radio Edit/etc.) of the same
+	// song down to one canonical userTracks entry (#130) — the underlying
+	// `track` table upsert above stays unfiltered since other users may own
+	// the non-canonical version.
+	const canonicalTracks = selectCanonicalTracks(
+		tracks.map((t) => ({
+			id: t.id,
+			name: t.name,
+			primaryArtist: parseJsonStringArray(t.artistNames)[0] ?? "",
+		})),
+	);
+	const canonicalTrackIds = new Set(canonicalTracks.map((t) => t.id));
+	logger.info(
+		{
+			userId,
+			total: tracks.length,
+			deduped: tracks.length - canonicalTrackIds.size,
+		},
+		"Sync dedup removed version variants",
+	);
+
 	// Tracks with a known real liked-at date self-heal a stale placeholder on
 	// every sync; tracks without one must never touch an existing row's
 	// addedAt with the insert-time default (#214).
 	const { withLikedAt, withoutLikedAt } = partitionTracksByKnownLikedAt(
-		tracks,
+		tracks.filter((t) => canonicalTrackIds.has(t.id)),
 		likedAtByTrackId,
 	);
 

--- a/packages/common/src/utils/__tests__/normalize-track-title.test.ts
+++ b/packages/common/src/utils/__tests__/normalize-track-title.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	normalizeTrackTitle,
+	selectCanonicalTracks,
+} from "../normalize-track-title";
+
+describe("normalizeTrackTitle", () => {
+	it("strips a Deluxe Edition suffix", () => {
+		expect(normalizeTrackTitle("The Unforgiven (Deluxe Edition)")).toBe(
+			"The Unforgiven",
+		);
+	});
+
+	it("strips a bare Deluxe suffix", () => {
+		expect(normalizeTrackTitle("Song (Deluxe)")).toBe("Song");
+	});
+
+	it("strips a Remastered suffix with a year", () => {
+		expect(normalizeTrackTitle("Song (Remastered 2009)")).toBe("Song");
+	});
+
+	it("strips a year-prefixed Remaster suffix", () => {
+		expect(normalizeTrackTitle("Song (2009 Remaster)")).toBe("Song");
+	});
+
+	it("strips a Radio Edit suffix in brackets", () => {
+		expect(normalizeTrackTitle("Song [Radio Edit]")).toBe("Song");
+	});
+
+	it("strips an Explicit tag", () => {
+		expect(normalizeTrackTitle("Song (Explicit)")).toBe("Song");
+	});
+
+	it("leaves a title with no parenthetical unchanged", () => {
+		expect(normalizeTrackTitle("Live and Let Die")).toBe("Live and Let Die");
+	});
+
+	it("keeps a Live recording tag (different recording, not a re-release)", () => {
+		expect(normalizeTrackTitle("Hurt (Live at MSG 2007)")).toBe(
+			"Hurt (Live at MSG 2007)",
+		);
+	});
+
+	it("keeps a feat. credit", () => {
+		expect(normalizeTrackTitle("Song (feat. Someone)")).toBe(
+			"Song (feat. Someone)",
+		);
+	});
+
+	it("keeps an Acoustic tag", () => {
+		expect(normalizeTrackTitle("Song (Acoustic)")).toBe("Song (Acoustic)");
+	});
+
+	it("keeps an Instrumental tag", () => {
+		expect(normalizeTrackTitle("Song (Instrumental)")).toBe(
+			"Song (Instrumental)",
+		);
+	});
+});
+
+describe("selectCanonicalTracks", () => {
+	it("keeps the plain version over a Deluxe Edition duplicate", () => {
+		const result = selectCanonicalTracks([
+			{
+				id: "b",
+				name: "The Unforgiven (Deluxe Edition)",
+				primaryArtist: "Metallica",
+			},
+			{ id: "a", name: "The Unforgiven", primaryArtist: "Metallica" },
+		]);
+		expect(result).toEqual([
+			{ id: "a", name: "The Unforgiven", primaryArtist: "Metallica" },
+		]);
+	});
+
+	it("keeps both a Live version and the studio version", () => {
+		const tracks = [
+			{ id: "a", name: "Hurt", primaryArtist: "Johnny Cash" },
+			{
+				id: "b",
+				name: "Hurt (Live at MSG 2007)",
+				primaryArtist: "Johnny Cash",
+			},
+		];
+		const result = selectCanonicalTracks(tracks);
+		expect(result).toHaveLength(2);
+	});
+
+	it("keeps tracks with different primary artists separate even with the same title", () => {
+		const tracks = [
+			{ id: "a", name: "Home", primaryArtist: "Artist One" },
+			{ id: "b", name: "Home", primaryArtist: "Artist Two" },
+		];
+		expect(selectCanonicalTracks(tracks)).toHaveLength(2);
+	});
+
+	it("breaks a same-length-name tie by the lexicographically smaller ID", () => {
+		const result = selectCanonicalTracks([
+			{ id: "z", name: "Song", primaryArtist: "Artist" },
+			{ id: "a", name: "Song", primaryArtist: "Artist" },
+		]);
+		expect(result).toEqual([
+			{ id: "a", name: "Song", primaryArtist: "Artist" },
+		]);
+	});
+
+	it("passes a user with only the deluxe version through unchanged", () => {
+		const tracks = [
+			{ id: "a", name: "Song (Deluxe Edition)", primaryArtist: "Artist" },
+		];
+		expect(selectCanonicalTracks(tracks)).toEqual(tracks);
+	});
+});

--- a/packages/common/src/utils/normalize-track-title.ts
+++ b/packages/common/src/utils/normalize-track-title.ts
@@ -1,0 +1,40 @@
+// Matches a trailing version-suffix parenthetical/bracket — e.g. "(Deluxe Edition)",
+// "(2009 Remaster)", "[Radio Edit]" — so different releases of the same song
+// collapse to one canonical title. Deliberately does NOT strip "Live", "Acoustic",
+// "feat./ft.", "Instrumental", or arrangement tags — those are genuinely
+// different recordings, not just re-releases of the same one.
+const VERSION_SUFFIX_RE =
+	/[\s\-–]+[([](deluxe( edition| version)?|remastered?(\s+\d{4})?|\d{4}\s+remaster|radio (edit|version)|single (version|edit)|bonus( track)?|extended( mix| version)?|anniversary edition|special edition|expanded edition|explicit|clean|album version|original album version)[)\]]\s*$/i;
+
+export function normalizeTrackTitle(name: string): string {
+	return name.replace(VERSION_SUFFIX_RE, "").trim();
+}
+
+/**
+ * Groups tracks by normalized (title, primary artist) and keeps one canonical
+ * version per group — so a library with both "Song" and "Song (Deluxe
+ * Edition)" ends up with just one of them (#130). Prefers the shorter name
+ * (the plain version over a version-suffixed one); ties broken by the
+ * lexicographically smaller Spotify track ID, for a deterministic result.
+ */
+export function selectCanonicalTracks<
+	T extends { id: string; name: string; primaryArtist: string },
+>(tracks: T[]): T[] {
+	const canonicalByKey = new Map<string, T>();
+
+	for (const t of tracks) {
+		const key = `${normalizeTrackTitle(t.name).toLowerCase()}|||${t.primaryArtist.toLowerCase()}`;
+		const existing = canonicalByKey.get(key);
+		if (!existing) {
+			canonicalByKey.set(key, t);
+			continue;
+		}
+		const isBetter =
+			t.name.length !== existing.name.length
+				? t.name.length < existing.name.length
+				: t.id < existing.id;
+		if (isBetter) canonicalByKey.set(key, t);
+	}
+
+	return [...canonicalByKey.values()];
+}

--- a/packages/db/src/migrations/0002_cloudy_medusa.sql
+++ b/packages/db/src/migrations/0002_cloudy_medusa.sql
@@ -10,8 +10,6 @@ CREATE TABLE "pipeline_run" (
 	"created_at" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "todo" ADD COLUMN "user_id" text NOT NULL;--> statement-breakpoint
 ALTER TABLE "pipeline_run" ADD CONSTRAINT "pipeline_run_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "pipeline_run_user_id_idx" ON "pipeline_run" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "pipeline_run_status_idx" ON "pipeline_run" USING btree ("status");--> statement-breakpoint
-ALTER TABLE "todo" ADD CONSTRAINT "todo_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+CREATE INDEX "pipeline_run_status_idx" ON "pipeline_run" USING btree ("status");

--- a/packages/orpc/src/routers/protected/tracks.ts
+++ b/packages/orpc/src/routers/protected/tracks.ts
@@ -17,6 +17,7 @@ import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import {
 	and,
+	asc,
 	count,
 	desc,
 	eq,
@@ -97,7 +98,11 @@ export const tracksRouter = {
 				})
 				.from(track)
 				.where(where)
-				.orderBy(desc(track.createdAt))
+				.orderBy(
+					...(input.sort === "album"
+						? [asc(track.albumName), asc(track.id)]
+						: [desc(track.createdAt)]),
+				)
 				.limit(input.pageSize)
 				.offset(offset);
 

--- a/packages/ui/src/components/shared/icons.tsx
+++ b/packages/ui/src/components/shared/icons.tsx
@@ -20,6 +20,7 @@ import {
 	IconArrowUpRight,
 	IconBrain,
 	IconBrandBandlab,
+	IconBrandSpotifyFilled,
 	IconChartBar,
 	IconCheck,
 	IconChevronDown,
@@ -104,6 +105,7 @@ export const Icons = {
 
 	// Brand
 	logo: IconBrandBandlab,
+	spotify: IconBrandSpotifyFilled,
 
 	// Navigation / App
 	settings: IconSettings,


### PR DESCRIPTION
## Stacked on #230

Needs `albumId` for reliable album grouping (`albumName` alone could collide across different artists' same-named albums). Base is set to that branch — merge #230 into `main` first, then this one.

## Summary
`/tracks` had no page at all — verified earlier while scoping #78 that only `/tracks/[id]` existed, the list view was never built despite `tracksRouter.list` and the nav entry already existing.

- New `/tracks` page: sticky header (title + search + sort), infinite scroll past the old hard page cap, following the exact pattern already established for `/playlists`
- `tracksRouter.list` gains a `sort` option: `recent` (existing default) or `album` (orders by `albumName`, then `id` for stable pagination) — the frontend groups consecutive same-album rows with a linear scan since the backend already returns them contiguous, no client-side re-sorting needed
- Every row links to `/tracks/[id]`

## Scope notes
- Search is the existing name+artist search already in `tracksRouter.list` — didn't add the `lyricsStatus`/`classified`/`embedded` filters to the UI in this pass, kept to the issue's strict acceptance criteria (real page, infinite scroll, album browsing, working nav)
- Album grouping falls back to `albumId ?? albumName` so tracks synced before #78/#230 (no `albumId` yet) still group reasonably by name until their next sync

## Test plan
- [x] `pnpm --filter dashboard exec tsc --noEmit` — clean
- [x] `pnpm --filter @harmonia/orpc exec tsc --noEmit` — clean
- [x] `pnpm --filter @harmonia/common exec vitest run` — full suite green, no regressions
- [x] `pnpm build` — 17/17 tasks, confirmed `/tracks` and `/tracks/[id]` both in the route output
- [x] `npx biome check` — clean
- [ ] Not verified live — Docker (local DB) still unresponsive.

Closes #229