### PR TITLE
docs: add hero header banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Harmonia
 
 <p align="center">
+  <img alt="Harmonia" src="https://shieldcn.dev/header/graph.svg?title=Harmonia&subtitle=AI-powered+music+organization+for+Spotify&theme=zinc&mode=dark" />
+</p>
+
+<p align="center">
   <a href="https://github.com/FindMalek/harmonia/commits/main">
     <img alt="Last commit" src="https://shieldcn.dev/github/last-commit/FindMalek/harmonia.svg?variant=secondary&mode=dark&color=18181b" />
   </a>


### PR DESCRIPTION
## Summary
- Adds a shieldcn header banner (dark, zinc theme, matching the existing badge row styling) above the title/badges.

Also worth noting for the repo's actual social-preview card (what shows up when the URL is shared on Slack/Twitter): GitHub's "social preview" image is a manual upload in **Settings → General → Social preview**, no API for it — happy to help pick/generate an image for that if wanted, but the upload itself has to be done by a repo admin in the UI.

## Test plan
- [x] Verified the header image URL returns HTTP 200 via curl