### PR TITLE
fix(brain): use /playlists/{id}/items instead of deprecated /tracks endpoint for export

### DIFF
--- a/packages/common/src/services/music/spotify/export.ts
+++ b/packages/common/src/services/music/spotify/export.ts
@@ -138,7 +138,7 @@ async function createNewPlaylist(
 	) {
 		const batch = trackUris.slice(i, i + SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST);
 		await retryableSpotifyRequest(() =>
-			spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
+			spotifyRequest(`/playlists/${spotifyPlaylistId}/items`, accessToken, {
 				method: "POST",
 				body: { uris: batch },
 			}),
@@ -179,7 +179,7 @@ async function updateExistingPlaylist(
 	);
 
 	await retryableSpotifyRequest(() =>
-		spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
+		spotifyRequest(`/playlists/${spotifyPlaylistId}/items`, accessToken, {
 			method: "PUT",
 			body: {
 				uris: trackUris.slice(0, SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST),
@@ -194,7 +194,7 @@ async function updateExistingPlaylist(
 	) {
 		const batch = trackUris.slice(i, i + SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST);
 		await retryableSpotifyRequest(() =>
-			spotifyRequest(`/playlists/${spotifyPlaylistId}/tracks`, accessToken, {
+			spotifyRequest(`/playlists/${spotifyPlaylistId}/items`, accessToken, {
 				method: "POST",
 				body: { uris: batch },
 			}),


### PR DESCRIPTION
## Summary
- Fixes #239: Spotify's `POST/PUT /playlists/{playlist_id}/tracks` endpoint is deprecated in favor of `/playlists/{playlist_id}/items` (confirmed directly against Spotify's own API reference). `export.ts` had 3 call sites still using the old path — add-tracks-on-create, replace-tracks-on-update, and append-tracks-on-update. The read path (`client.ts`) already correctly used `/items`.
- This is very likely the root cause of the previously-reported live export 500 error ("Unexpected end of JSON input") — Spotify's Feb 2026 migration deadline for this rename already passed (March 9, 2026).
- Request/response body shape is unchanged (`{ uris: [...] }` in, `{ snapshot_id }` out) per Spotify's docs — this is a pure path rename, no other logic changed.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm --filter @harmonia/common test` — 80/80 passing, including the existing export test (mocks generic paths, not endpoint-specific, so it exercises the same code path before/after)
- [x] `biome check` clean
- [ ] Not verified against a live Spotify export — worth a real smoke test once merged, since this directly affects a previously-broken user-facing flow