### PR TITLE
fix(dashboard): hide Tempo/Key/Mode stat cards when unpopulated

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-track-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-track-detail.tsx
@@ -72,6 +72,33 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 	const hasTags = themes.length > 0 || topics.length > 0 || vibe.length > 0;
 	const hasLyrics = Boolean(track.lyrics || track.syncedLyrics);
 
+	// Tempo/key/mode aren't currently populated by the sync pipeline (#241) —
+	// only show stat cards that have a real value instead of a permanent "—".
+	const statCards = [
+		{
+			key: "duration",
+			label: "Duration",
+			value: formatDuration(track.durationMs),
+		},
+		track.tempo != null
+			? {
+					key: "tempo",
+					label: "Tempo",
+					value: `${Math.round(track.tempo)} BPM`,
+				}
+			: null,
+		track.key != null && KEY_NAMES[track.key]
+			? { key: "key", label: "Key", value: KEY_NAMES[track.key] }
+			: null,
+		track.mode === 1 || track.mode === 0
+			? {
+					key: "mode",
+					label: "Mode",
+					value: track.mode === 1 ? "Major" : "Minor",
+				}
+			: null,
+	].filter((stat): stat is NonNullable<typeof stat> => stat !== null);
+
 	return (
 		<div className="flex flex-col gap-6">
 			<DashboardDetailBackLink
@@ -155,23 +182,20 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 				</a>
 			</div>
 
-			<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-				<InsightStatCard
-					label="Duration"
-					value={formatDuration(track.durationMs)}
-				/>
-				<InsightStatCard
-					label="Tempo"
-					value={track.tempo != null ? `${Math.round(track.tempo)} BPM` : "—"}
-				/>
-				<InsightStatCard
-					label="Key"
-					value={track.key != null ? (KEY_NAMES[track.key] ?? "—") : "—"}
-				/>
-				<InsightStatCard
-					label="Mode"
-					value={track.mode === 1 ? "Major" : track.mode === 0 ? "Minor" : "—"}
-				/>
+			<div
+				className={cn(
+					"grid grid-cols-2 gap-3",
+					statCards.length >= 4 && "sm:grid-cols-4",
+					statCards.length === 3 && "sm:grid-cols-3",
+				)}
+			>
+				{statCards.map((stat) => (
+					<InsightStatCard
+						key={stat.key}
+						label={stat.label}
+						value={stat.value}
+					/>
+				))}
 			</div>
 
 			<DashboardInsightsSonicDna


### PR DESCRIPTION
## Summary
Partial mitigation for #241. `track.tempo`/`track.key`/`track.mode` are never written anywhere in the sync pipeline, so these 3 of the 4 stat cards on `/tracks/[id]` always rendered "—" for every track, for every user. `DashboardInsightsSonicDna` already handled this correctly (returns `null` when every feature is null) — this brings the stat-card row in line with that same pattern instead of showing permanently-empty cards.

Grid now renders 1–4 columns depending on how many stat cards actually have data (today: just Duration, so 1 card in a 2-col grid on mobile / no forced 4-col stretch on desktop).

This does **not** fix the underlying data gap (#241 — no data source currently populates these columns, and Spotify's Audio Features endpoint is deprecated for non-grandfathered apps) — that still needs a product decision. This just stops the UI from looking broken in the meantime.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] Not verified live in browser — Chrome automation unresponsive this session; worth a quick visual check once merged