### PR TITLE
feat(dashboard): self-service account deletion

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,19 @@
 "use client";
 
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
-import { Badge, Button } from "@harmonia/ui";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+	Badge,
+	Button,
+} from "@harmonia/ui";
 import { formatDistanceToNow } from "date-fns";
 import type { Route } from "next";
 import { useRouter } from "next/navigation";
@@ -31,6 +43,7 @@ export default function SettingsPage() {
 		resolvedTheme,
 		setTheme,
 		signOut,
+		deleteAccount,
 	} = useSettingsController();
 
 	if (!mounted) {
@@ -113,6 +126,37 @@ export default function SettingsPage() {
 			>
 				Sign out
 			</Button>
+
+			<DashboardSettingsSection label="DANGER ZONE">
+				<AlertDialog>
+					<AlertDialogTrigger asChild>
+						<Button variant="destructive" className="w-full">
+							Delete account
+						</Button>
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Delete your account?</AlertDialogTitle>
+							<AlertDialogDescription>
+								This permanently deletes your Harmonia account, your library
+								cache, generated playlists, and all AI analysis. This does not
+								affect your actual Spotify account or library. This cannot be
+								undone.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction
+								variant="destructive"
+								disabled={deleteAccount.isPending}
+								onClick={() => deleteAccount.mutate({})}
+							>
+								{deleteAccount.isPending ? "Deleting..." : "Delete account"}
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</DashboardSettingsSection>
 		</div>
 	);
 }

--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -13,8 +13,6 @@ import {
 	AlertDialogTrigger,
 	Badge,
 	Button,
-	Badge,
-	Button,
 	Select,
 	SelectContent,
 	SelectItem,

--- a/apps/dashboard/src/shared/lib/settings/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/settings/controller.hook.ts
@@ -56,6 +56,20 @@ export function useSettingsController() {
 		window.location.href = "/login";
 	};
 
+	const deleteAccount = useMutation(
+		orpc.deleteAccount.mutationOptions({
+			onSuccess: async () => {
+				useOrganizeStore.getState().setActiveRunId(null);
+				useOrganizeStore.getState().setIsAnalysisDrawerOpen(false);
+				await authClient.signOut();
+				window.location.href = "/login";
+			},
+			onError: (error) => {
+				toastError(error.message ?? "Failed to delete account");
+			},
+		}),
+	);
+
 	return {
 		session,
 		sessionPending,
@@ -71,5 +85,6 @@ export function useSettingsController() {
 		resolvedTheme,
 		setTheme,
 		signOut,
+		deleteAccount,
 	};
 }

--- a/apps/dashboard/src/shared/lib/settings/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/settings/controller.hook.ts
@@ -52,18 +52,16 @@ export function useSettingsController() {
 	const signOut = async () => {
 		useOrganizeStore.getState().setActiveRunId(null);
 		useOrganizeStore.getState().setIsAnalysisDrawerOpen(false);
-		await authClient.signOut();
+		// Best effort — the account-deletion flow calls this after the user row
+		// (and its session, via cascade) is already gone server-side, so this
+		// request can legitimately error. Redirect regardless.
+		await authClient.signOut().catch(() => {});
 		window.location.href = "/login";
 	};
 
 	const deleteAccount = useMutation(
 		orpc.deleteAccount.mutationOptions({
-			onSuccess: async () => {
-				useOrganizeStore.getState().setActiveRunId(null);
-				useOrganizeStore.getState().setIsAnalysisDrawerOpen(false);
-				await authClient.signOut();
-				window.location.href = "/login";
-			},
+			onSuccess: () => signOut(),
 			onError: (error) => {
 				toastError(error.message ?? "Failed to delete account");
 			},

--- a/packages/common/src/schemas/account/index.ts
+++ b/packages/common/src/schemas/account/index.ts
@@ -1,0 +1,1 @@
+export * from "./output";

--- a/packages/common/src/schemas/account/output.ts
+++ b/packages/common/src/schemas/account/output.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const accountDeleteOutputSchema = z.object({
+	success: z.boolean(),
+});
+export type AccountDeleteOutput = z.infer<typeof accountDeleteOutputSchema>;

--- a/packages/common/src/schemas/index.ts
+++ b/packages/common/src/schemas/index.ts
@@ -1,3 +1,4 @@
+export * from "./account";
 export * from "./admin";
 export * from "./classification";
 export * from "./cluster";

--- a/packages/orpc/src/routers/protected/index.ts
+++ b/packages/orpc/src/routers/protected/index.ts
@@ -29,6 +29,18 @@ export const protectedRouter = {
 			.limit(1);
 		return { hasSpotify: rows.length > 0 };
 	}),
+	// Every user-owned table's userId FK is `onDelete: cascade` (session,
+	// account, playlist, cluster, userTracks, userEmailPreferences, etc.) —
+	// deleting the user row cascades the rest at the DB level. `track` rows
+	// themselves are shared across users (not user-scoped), so they're
+	// correctly left in place; only this user's link to them is removed.
+	deleteAccount: protectedProcedure
+		.output(z.object({ success: z.boolean() }))
+		.handler(async ({ context }) => {
+			const userId = context.session.user.id;
+			await db.delete(user).where(eq(user.id, userId));
+			return { success: true };
+		}),
 	redeemInvite: protectedProcedure
 		.input(z.object({ token: z.string().regex(/^[0-9a-f]{64}$/) }))
 		.output(z.object({ success: z.boolean() }))

--- a/packages/orpc/src/routers/protected/index.ts
+++ b/packages/orpc/src/routers/protected/index.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { accountDeleteOutputSchema } from "@harmonia/common/schemas";
 import { db } from "@harmonia/db";
 import { account, user } from "@harmonia/db/schema/auth";
 import { waitlistSignup } from "@harmonia/db/schema/waitlist-signup";
@@ -35,7 +36,7 @@ export const protectedRouter = {
 	// themselves are shared across users (not user-scoped), so they're
 	// correctly left in place; only this user's link to them is removed.
 	deleteAccount: protectedProcedure
-		.output(z.object({ success: z.boolean() }))
+		.output(accountDeleteOutputSchema)
 		.handler(async ({ context }) => {
 			const userId = context.session.user.id;
 			await db.delete(user).where(eq(user.id, userId));

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,6 +15,20 @@ export {
 	AlertDescription,
 	AlertTitle,
 } from "./components/ui/alert";
+export {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogMedia,
+	AlertDialogOverlay,
+	AlertDialogPortal,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "./components/ui/alert-dialog";
 export { Badge, badgeVariants } from "./components/ui/badge";
 export {
 	Breadcrumb,


### PR DESCRIPTION
## Summary
Closes #242. Adds a "Delete account" action to dashboard settings, in a new Danger Zone section, behind an `AlertDialog` confirmation (irreversible action — no native `confirm()`, no accidental single-click deletes).

Backend (`packages/orpc/src/routers/protected/index.ts`): new `deleteAccount` procedure (`protectedProcedure`, not `approvedProcedure` — an unapproved or banned user should still be able to delete their own account) that deletes the `user` row for the calling session. I checked every user-owned table's schema first: `session`, `account`, `playlist`, `cluster`, `userTracks`, `userEmailPreferences`, `pipelineRun`, `character`, and the `spotify.ts` cache tables all already have `onDelete: "cascade"` on their `userId` FK to `user.id` — so deleting the user row cascades everything else at the database level, no manual per-table cleanup needed. `track` rows are shared across users (not user-scoped) and correctly stay in place; only this user's `userTracks` link is removed. `waitlistSignup.userId` is `onDelete: "set null"` by design (keeps the historical waitlist record, just unlinks the account) — left as-is.

Frontend: new mutation in `useSettingsController`, reuses the same sign-out/redirect flow already used for the existing "Sign out" button.

## Test plan
- [x] `tsc --noEmit` clean across `dashboard`, `orpc`, `ui`
- [x] `biome check` clean
- [x] Full test suite passing (83 tests)
- [ ] Not verified live — no local DB access this session (Docker unresponsive). Worth a real test-account deletion once merged, to confirm the cascade actually behaves as the schema promises before relying on it for real user requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Danger Zone section to settings with account deletion.
  * Added a confirmation dialog explaining the account deletion process.
  * Account deletion signs the user out and redirects to the login page.
* **Bug Fixes**
  * Added error notifications when account deletion fails.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->