### PR TITLE
feat(dashboard): replace theme toggle with a System/Light/Dark select

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
-import { Badge, Button } from "@harmonia/ui";
+import {
+	Badge,
+	Button,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@harmonia/ui";
 import { formatDistanceToNow } from "date-fns";
 import type { Route } from "next";
 import { useRouter } from "next/navigation";
@@ -28,6 +36,7 @@ export default function SettingsPage() {
 		spotifyLoading,
 		lastSync,
 		statsLoading,
+		theme,
 		resolvedTheme,
 		setTheme,
 		signOut,
@@ -43,12 +52,7 @@ export default function SettingsPage() {
 			? formatDistanceToNow(lastSync, { addSuffix: true })
 			: "Never";
 
-	const themeLabel =
-		resolvedTheme === "dark"
-			? "Dark"
-			: resolvedTheme === "light"
-				? "Light"
-				: "System default";
+	const resolvedThemeLabel = resolvedTheme === "dark" ? "Dark" : "Light";
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -82,11 +86,21 @@ export default function SettingsPage() {
 			</DashboardSettingsSection>
 
 			<DashboardSettingsSection label="PREFERENCES">
-				<DashboardSettingsNavRow
-					label="Theme"
-					subtitle={themeLabel}
-					onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-				/>
+				<div className="flex items-center justify-between border-b py-4 last:border-b-0">
+					<span className="text-muted-foreground text-sm">Theme</span>
+					<Select value={theme ?? "system"} onValueChange={setTheme}>
+						<SelectTrigger className="h-8 w-44 text-sm">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="system">
+								{`System default (${resolvedThemeLabel})`}
+							</SelectItem>
+							<SelectItem value="light">Light</SelectItem>
+							<SelectItem value="dark">Dark</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
 				<DashboardSettingsRow
 					label="Analysis Frequency"
 					value={


### PR DESCRIPTION
## Summary
Closes #69. The Theme row in Settings > Preferences used to cycle dark<->light on click with no System option. Replaced with a `Select` showing all three options; "System default" shows the resolved OS preference parenthetically (e.g. "System default (Dark)").

Note: touches the same file as #246 (account deletion) but a different section (Preferences vs. the new Danger Zone at the bottom) — no overlap, should merge cleanly regardless of order.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] Not verified live in browser — Chrome automation unresponsive this session