### PR TITLE
fix(dashboard): recover the /tracks library page — lost in a stacked-PR merge

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/tracks/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/tracks/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Icons } from "@harmonia/ui";
+import { Fragment } from "react";
+import {
+	DashboardTracksListRow,
+	DashboardTracksListSkeleton,
+} from "@/components/app/dashboard-tracks-list-row";
+import { DashboardTracksPageHeader } from "@/components/app/dashboard-tracks-page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { ErrorState } from "@/components/shared/error-state";
+import { ScrollToTopButton } from "@/components/shared/scroll-to-top-button";
+import { useDashboardScrollContainer } from "@/hooks/use-dashboard-scroll-container";
+import { useInfiniteScrollSentinel } from "@/hooks/use-infinite-scroll-sentinel";
+import { useScrollFlags } from "@/hooks/use-scroll-flags";
+import { useTracksController } from "@/shared/lib/tracks/controller.hook";
+
+export default function TracksPage() {
+	const { list, search, setSearch, sort, setSort } = useTracksController();
+	const {
+		data,
+		isLoading,
+		isError,
+		error,
+		refetch,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+	} = list;
+
+	const scrollContainerRef = useDashboardScrollContainer();
+	const { showBackToTop, scrollDirection } = useScrollFlags(
+		scrollContainerRef,
+		{ collapseAt: 24, backToTopAt: 400 },
+	);
+
+	const sentinelRef = useInfiniteScrollSentinel({
+		rootRef: scrollContainerRef,
+		hasNextPage: Boolean(hasNextPage),
+		isFetchingNextPage,
+		fetchNextPage,
+	});
+
+	const tracks = data?.pages.flatMap((page) => page.tracks) ?? [];
+
+	// Backend returns album-sorted rows contiguously when sort === "album", so
+	// a plain consecutive scan is enough to find group boundaries — no need to
+	// re-sort or bucket client-side.
+	const albumGroupStartIds =
+		sort === "album"
+			? new Set(
+					tracks
+						.filter(
+							(t, i) =>
+								i === 0 ||
+								(t.albumId ?? t.albumName) !==
+									(tracks[i - 1]?.albumId ?? tracks[i - 1]?.albumName),
+						)
+						.map((t) => t.id),
+				)
+			: null;
+
+	if (isError) {
+		return (
+			<div className="space-y-8">
+				<DashboardTracksPageHeader
+					search={search}
+					onSearchChange={setSearch}
+					sort={sort}
+					onSortChange={setSort}
+				/>
+				<ErrorState
+					message={
+						error instanceof Error ? error.message : "Failed to load tracks"
+					}
+					onRetry={() => refetch()}
+				/>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className="space-y-8">
+				<DashboardTracksPageHeader
+					search={search}
+					onSearchChange={setSearch}
+					sort={sort}
+					onSortChange={setSort}
+				/>
+				<DashboardTracksListSkeleton />
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-8">
+			<DashboardTracksPageHeader
+				search={search}
+				onSearchChange={setSearch}
+				sort={sort}
+				onSortChange={setSort}
+			/>
+
+			{tracks.length === 0 ? (
+				<EmptyState
+					icon={Icons.music}
+					title={search ? "No matching tracks" : "No tracks yet"}
+					description={
+						search
+							? "Try a different search."
+							: "Sync your Spotify library to see tracks here."
+					}
+					variant="card"
+				/>
+			) : (
+				<div>
+					{tracks.map((t) => (
+						<Fragment key={t.id}>
+							{albumGroupStartIds?.has(t.id) ? (
+								<p className="pt-4 pb-1 font-mono text-[9px] text-muted-foreground uppercase tracking-widest">
+									{t.albumName ?? "Unknown album"}
+								</p>
+							) : null}
+							<DashboardTracksListRow track={t} />
+						</Fragment>
+					))}
+				</div>
+			)}
+
+			{hasNextPage ? <div ref={sentinelRef} className="h-1" /> : null}
+
+			<ScrollToTopButton
+				visible={showBackToTop}
+				scrollDirection={scrollDirection}
+				containerRef={scrollContainerRef}
+			/>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-tracks-list-row.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-list-row.tsx
@@ -1,0 +1,75 @@
+import type { TracksListOutput } from "@harmonia/common/schemas";
+import { parseJsonStringArray } from "@harmonia/common/utils/parse-json-string-array";
+import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
+import { Skeleton } from "@harmonia/ui";
+import type { Route } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+export type DashboardTracksListRowTrack = TracksListOutput["tracks"][number];
+
+export function DashboardTracksListRow({
+	track,
+}: {
+	track: DashboardTracksListRowTrack;
+}) {
+	const artists = parseJsonStringArray(track.artistNames);
+
+	return (
+		<Link
+			href={DASHBOARD_ROUTES.tracks.children.detail.makePath(track.id) as Route}
+			className="flex items-center gap-4 border-b py-4 last:border-b-0 hover:bg-accent/50"
+		>
+			{track.albumImageUrl ? (
+				<Image
+					src={track.albumImageUrl}
+					alt=""
+					width={48}
+					height={48}
+					className="size-12 shrink-0 rounded object-cover"
+					unoptimized
+				/>
+			) : (
+				<div className="size-12 shrink-0 rounded bg-muted" />
+			)}
+			<div className="min-w-0 flex-1">
+				<p className="truncate font-medium text-sm">{track.name}</p>
+				<p className="truncate text-muted-foreground text-xs">
+					{artists.join(", ")}
+					{track.albumName ? ` • ${track.albumName}` : ""}
+				</p>
+			</div>
+		</Link>
+	);
+}
+
+export function DashboardTracksListRowSkeleton() {
+	return (
+		<div className="flex items-center gap-4 border-b py-4 last:border-b-0">
+			<Skeleton className="size-12 shrink-0 rounded" />
+			<div className="min-w-0 flex-1 space-y-2">
+				<Skeleton className="h-4 w-2/5" />
+				<Skeleton className="h-3 w-3/5" />
+			</div>
+		</div>
+	);
+}
+
+const TRACKS_SKELETON_KEYS = [
+	"tr-sk-1",
+	"tr-sk-2",
+	"tr-sk-3",
+	"tr-sk-4",
+	"tr-sk-5",
+	"tr-sk-6",
+] as const;
+
+export function DashboardTracksListSkeleton() {
+	return (
+		<div>
+			{TRACKS_SKELETON_KEYS.map((key) => (
+				<DashboardTracksListRowSkeleton key={key} />
+			))}
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-tracks-page-header.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-page-header.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { TracksListSort } from "@harmonia/common/schemas";
+import { Icons, Input } from "@harmonia/ui";
+import { PageHeader } from "../shared/page-header";
+import { DashboardTracksSortSelect } from "./dashboard-tracks-sort-select";
+
+export function DashboardTracksPageHeader({
+	search,
+	onSearchChange,
+	sort,
+	onSortChange,
+}: {
+	search: string;
+	onSearchChange: (value: string) => void;
+	sort: TracksListSort;
+	onSortChange: (value: TracksListSort) => void;
+}) {
+	return (
+		<div className="sticky -top-5 z-10 -mx-4 -mt-4 flex flex-col gap-3 bg-background px-4 pt-4 pb-3">
+			<PageHeader title="Tracks" description="Your full synced library." />
+			<div className="flex items-center gap-2">
+				<div className="relative flex-1">
+					<Icons.search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						placeholder="Search tracks"
+						aria-label="Search tracks"
+						className="pl-9"
+					/>
+				</div>
+				<DashboardTracksSortSelect value={sort} onChange={onSortChange} />
+			</div>
+		</div>
+	);
+}

--- a/apps/dashboard/src/components/app/dashboard-tracks-sort-select.tsx
+++ b/apps/dashboard/src/components/app/dashboard-tracks-sort-select.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { TracksListSort } from "@harmonia/common/schemas";
+import {
+	Button,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+	Icons,
+} from "@harmonia/ui";
+
+const SORT_OPTIONS: Array<{ value: TracksListSort; label: string }> = [
+	{ value: "recent", label: "Recently added" },
+	{ value: "album", label: "By album" },
+];
+
+export function DashboardTracksSortSelect({
+	value,
+	onChange,
+}: {
+	value: TracksListSort;
+	onChange: (value: TracksListSort) => void;
+}) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					className="size-11 shrink-0 rounded-none"
+					aria-label="Sort tracks"
+				>
+					<Icons.sort className="size-5 shrink-0" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="min-w-48">
+				<DropdownMenuRadioGroup
+					value={value}
+					onValueChange={(next) => onChange(next as TracksListSort)}
+				>
+					{SORT_OPTIONS.map((option) => (
+						<DropdownMenuRadioItem key={option.value} value={option.value}>
+							{option.label}
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/dashboard/src/shared/lib/tracks/controller.hook.ts
+++ b/apps/dashboard/src/shared/lib/tracks/controller.hook.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useDeferredValue } from "react";
+import { orpc } from "@/shared/api/orpc";
+import { useTracksStore } from "./store";
+
+const TRACKS_PAGE_SIZE = 50;
+
+export function useTracksController() {
+	const store = useTracksStore();
+	const deferredSearch = useDeferredValue(store.search.trim());
+
+	const list = useInfiniteQuery({
+		...orpc.tracks.list.infiniteOptions({
+			input: (page: number) => ({
+				page,
+				pageSize: TRACKS_PAGE_SIZE,
+				search: deferredSearch || undefined,
+				sort: store.sort,
+			}),
+			initialPageParam: 1,
+			getNextPageParam: (lastPage) =>
+				lastPage.page * lastPage.pageSize < lastPage.total
+					? lastPage.page + 1
+					: undefined,
+		}),
+	});
+
+	return {
+		list,
+		search: store.search,
+		setSearch: store.setSearch,
+		sort: store.sort,
+		setSort: store.setSort,
+	};
+}

--- a/apps/dashboard/src/shared/lib/tracks/store.ts
+++ b/apps/dashboard/src/shared/lib/tracks/store.ts
@@ -1,0 +1,16 @@
+import type { TracksListSort } from "@harmonia/common/schemas";
+import { create } from "zustand";
+
+interface TracksStore {
+	search: string;
+	setSearch: (value: string) => void;
+	sort: TracksListSort;
+	setSort: (value: TracksListSort) => void;
+}
+
+export const useTracksStore = create<TracksStore>((set) => ({
+	search: "",
+	setSearch: (value) => set({ search: value }),
+	sort: "recent",
+	setSort: (value) => set({ sort: value }),
+}));

--- a/packages/common/src/schemas/track/input.ts
+++ b/packages/common/src/schemas/track/input.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+// "album" orders by albumName (then id for stable pagination), letting the UI
+// render contiguous album groups instead of an interleaved recent-first feed.
+export const tracksListSortEnum = z.enum(["recent", "album"]);
+export type TracksListSort = z.infer<typeof tracksListSortEnum>;
+
 export const tracksListInput = z.object({
 	page: z.number().default(1),
 	pageSize: z.number().default(50),
@@ -7,6 +12,7 @@ export const tracksListInput = z.object({
 	lyricsStatus: z.string().optional(),
 	classified: z.boolean().optional(),
 	embedded: z.boolean().optional(),
+	sort: tracksListSortEnum.default("recent"),
 });
 export type TracksListInput = z.infer<typeof tracksListInput>;
 

--- a/packages/orpc/src/routers/protected/tracks.ts
+++ b/packages/orpc/src/routers/protected/tracks.ts
@@ -17,6 +17,7 @@ import { track, userTracks } from "@harmonia/db/schema/track";
 import { logger } from "@harmonia/logger";
 import {
 	and,
+	asc,
 	count,
 	desc,
 	eq,
@@ -97,7 +98,11 @@ export const tracksRouter = {
 				})
 				.from(track)
 				.where(where)
-				.orderBy(desc(track.createdAt))
+				.orderBy(
+					...(input.sort === "album"
+						? [asc(track.albumName), asc(track.id)]
+						: [desc(track.createdAt)]),
+				)
 				.limit(input.pageSize)
 				.offset(offset);
 


### PR DESCRIPTION
## Summary — this is a real production gap, not just cleanup

**`/tracks` has been 404ing (or rendering nothing) on `main` this whole time**, despite PR #237 showing as "Merged" and #229 (which it closes) looking done. Root cause:

#237 was set up as a stacked PR — its base was `feat/track-schema-album-artist-ids` (PR #230's branch), not `main`, because at the time it was still waiting on #230 for schema support. When it came time to merge, #230 got merged into `main` directly (correct), but #237 got merged into its *original* base branch (`feat/track-schema-album-artist-ids`) instead of being retargeted to `main` first. Since that base branch had already been squash-merged into `main` separately, #237's own commit was left stranded on an orphaned branch that nothing points to anymore — it never reached `main`.

I found this by validating #229 as "possibly already resolved" before moving on to other issues, and instead confirming via `git branch -a --contains <merge-commit>` that the commit only exists on the abandoned branch, never on `main`. Direct proof: `packages/common/src/schemas/track/input.ts` and `packages/orpc/src/routers/protected/tracks.ts` on `main` had zero `sort` support before this PR, and `apps/dashboard/src/app/(dashboard)/tracks/page.tsx` didn't exist on `main` at all.

## What this PR does

Recovers exactly the work from #237, checked against **current** `main` rather than blindly merging the stale branch (which would have reverted several things fixed since: the export endpoint fix, the settings page, the track detail page rework):
- 6 new files restored verbatim: the tracks list page, its 3 support components, and its controller hook + store
- 2 small additive patches applied by hand: `sort` param on `tracksListInput` and the tracks router's `list` handler

## Test plan
- [x] `tsc --noEmit` clean across `common`, `orpc`, `dashboard`
- [x] `pnpm --filter dashboard build` — `/tracks` compiles and routes correctly alongside every other dashboard route
- [x] `biome check` clean
- [x] Full test suite passing (83 tests)
- [ ] Not verified live in browser — Chrome automation unresponsive this session; this is exactly the kind of change worth a real click-through once merged

Closes #229.