### PR TITLE
feat: instrument all external API calls (Spotify, LRCLib, OpenAI, Groq)

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,6 +2,7 @@ export * from "./constants";
 export * from "./schemas";
 export * from "./services/brain";
 export * from "./services/email";
+export * from "./services/external-api-log";
 export * from "./services/music";
 export * from "./services/organize";
 export * from "./types";

--- a/packages/common/src/services/__tests__/external-api-log.test.ts
+++ b/packages/common/src/services/__tests__/external-api-log.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+	insertMock: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+}));
+
+vi.mock("@harmonia/db", () => ({
+	db: { insert: dbMock.insertMock },
+}));
+
+import { logExternalApiCall } from "../external-api-log";
+
+function insertedValues() {
+	const valuesMock = dbMock.insertMock.mock.results[0]?.value.values;
+	return valuesMock.mock.calls[0]?.[0];
+}
+
+describe("logExternalApiCall", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("derives success from a 2xx status", async () => {
+		await logExternalApiCall({
+			provider: "spotify",
+			endpoint: "/me/tracks",
+			httpStatus: 200,
+		});
+		expect(insertedValues()).toMatchObject({ statusCategory: "success" });
+	});
+
+	it("derives rate_limited from 429", async () => {
+		await logExternalApiCall({
+			provider: "spotify",
+			endpoint: "/me/tracks",
+			httpStatus: 429,
+		});
+		expect(insertedValues()).toMatchObject({ statusCategory: "rate_limited" });
+	});
+
+	it("derives not_found from 404", async () => {
+		await logExternalApiCall({
+			provider: "lrclib",
+			endpoint: "/get",
+			httpStatus: 404,
+		});
+		expect(insertedValues()).toMatchObject({ statusCategory: "not_found" });
+	});
+
+	it("derives client_error from other 4xx", async () => {
+		await logExternalApiCall({
+			provider: "groq",
+			endpoint: "classify",
+			httpStatus: 400,
+		});
+		expect(insertedValues()).toMatchObject({ statusCategory: "client_error" });
+	});
+
+	it("derives server_error from 5xx", async () => {
+		await logExternalApiCall({
+			provider: "openai",
+			endpoint: "embeddings",
+			httpStatus: 500,
+		});
+		expect(insertedValues()).toMatchObject({ statusCategory: "server_error" });
+	});
+
+	it("derives error when no status is present (e.g. network failure)", async () => {
+		await logExternalApiCall({ provider: "spotify", endpoint: "/me/tracks" });
+		expect(insertedValues()).toMatchObject({ statusCategory: "error" });
+	});
+
+	it("respects an explicit statusCategory override", async () => {
+		await logExternalApiCall({
+			provider: "spotify",
+			endpoint: "/me/tracks",
+			httpStatus: 200,
+			statusCategory: "success",
+		});
+		expect(insertedValues()).toMatchObject({ statusCategory: "success" });
+	});
+
+	it("passes small payloads through untouched", async () => {
+		await logExternalApiCall({
+			provider: "spotify",
+			endpoint: "/me/tracks",
+			httpStatus: 200,
+			requestPayload: { limit: 50 },
+		});
+		expect(insertedValues().requestPayload).toEqual({ limit: 50 });
+	});
+
+	it("truncates payloads larger than 10 KB", async () => {
+		const bigPayload = { blob: "x".repeat(20_000) };
+		await logExternalApiCall({
+			provider: "spotify",
+			endpoint: "/me/tracks",
+			httpStatus: 200,
+			responsePayload: bigPayload,
+		});
+		const { responsePayload } = insertedValues();
+		expect(responsePayload._truncated).toBe(true);
+		expect(typeof responsePayload._preview).toBe("string");
+	});
+
+	it("never throws when the db insert fails", async () => {
+		dbMock.insertMock.mockImplementationOnce(() => ({
+			values: vi.fn(() => Promise.reject(new Error("connection lost"))),
+		}));
+		await expect(
+			logExternalApiCall({ provider: "spotify", endpoint: "/me/tracks" }),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/common/src/services/brain/classifier.ts
+++ b/packages/common/src/services/brain/classifier.ts
@@ -24,6 +24,7 @@ type ClassifyDeltaCallback = (deltaClassified: number) => Promise<void>;
 export async function classifyTracksBatch(
 	userId: string,
 	onProgress?: (progress: ClassifyProgress) => Promise<void>,
+	pipelineRunId?: number,
 ): Promise<ClassifyProgress> {
 	const userTrackIds = db
 		.select({ trackId: userTracks.trackId })
@@ -93,7 +94,10 @@ export async function classifyTracksBatch(
 					}),
 				);
 
-				const results = await classifyTracksWithLLM(trackInputs);
+				const results = await classifyTracksWithLLM(trackInputs, {
+					userId,
+					pipelineRunId,
+				});
 
 				if (results.length === 0) {
 					logger.warn(
@@ -210,6 +214,7 @@ export async function classifyTrackIds(
 	userId: string,
 	trackIds: string[],
 	onBatchComplete?: ClassifyDeltaCallback,
+	pipelineRunId?: number,
 ): Promise<ClassifyProgress> {
 	const stats: ClassifyProgress = {
 		classified: 0,
@@ -251,7 +256,10 @@ export async function classifyTrackIds(
 					}),
 				);
 
-				const results = await classifyTracksWithLLM(trackInputs);
+				const results = await classifyTracksWithLLM(trackInputs, {
+					userId,
+					pipelineRunId,
+				});
 
 				if (results.length === 0) {
 					logger.warn(

--- a/packages/common/src/services/brain/embeddings.ts
+++ b/packages/common/src/services/brain/embeddings.ts
@@ -13,13 +13,103 @@ import {
 	EMBEDDING_MODEL,
 } from "../../constants/brain";
 import { chunk } from "../../trigger/utils/chunk";
+import { logExternalApiCall } from "../external-api-log";
 import { buildEmbeddingInput } from "./build-embedding-input";
 
 type OpenAIEmbeddingResponse = {
 	data: Array<{
 		embedding: number[];
 	}>;
+	usage?: { prompt_tokens: number; total_tokens: number };
 };
+
+export type EmbeddingCallContext = {
+	userId?: string | null;
+	pipelineRunId?: number | null;
+};
+
+// Shared by embedTracksBatch and embedTrackIds — one chokepoint for the
+// OpenAI request, retry, and logging. Never logs input texts or embedding
+// vectors (too large) — only { model, inputCount } and usage stats.
+async function fetchEmbeddingsBatch(
+	inputTexts: string[],
+	context: EmbeddingCallContext,
+): Promise<OpenAIEmbeddingResponse> {
+	let attempt = 0;
+	return pRetry(
+		async () => {
+			const retryAttempt = attempt;
+			attempt += 1;
+			const startTime = Date.now();
+			const response = await fetch("https://api.openai.com/v1/embeddings", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${env.HARMONIA_OPENAI_API_KEY}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					model: EMBEDDING_MODEL,
+					input: inputTexts,
+				}),
+			});
+			const durationMs = Date.now() - startTime;
+
+			if (!response.ok) {
+				const text = await response.text();
+				const errorMessage = `OpenAI embeddings ${response.status}: ${text.slice(0, 200)}`;
+				await logExternalApiCall({
+					userId: context.userId,
+					pipelineRunId: context.pipelineRunId,
+					provider: "openai",
+					endpoint: "/v1/embeddings",
+					method: "POST",
+					httpStatus: response.status,
+					requestPayload: {
+						model: EMBEDDING_MODEL,
+						inputCount: inputTexts.length,
+					},
+					durationMs,
+					errorMessage,
+					retryAttempt,
+				});
+				throw new Error(errorMessage);
+			}
+
+			const json = (await response.json()) as OpenAIEmbeddingResponse;
+
+			await logExternalApiCall({
+				userId: context.userId,
+				pipelineRunId: context.pipelineRunId,
+				provider: "openai",
+				endpoint: "/v1/embeddings",
+				method: "POST",
+				httpStatus: response.status,
+				requestPayload: {
+					model: EMBEDDING_MODEL,
+					inputCount: inputTexts.length,
+				},
+				responsePayload: json.usage ? { usage: json.usage } : undefined,
+				durationMs,
+				retryAttempt,
+			});
+
+			return json;
+		},
+		{
+			retries: 3,
+			minTimeout: 2000,
+			onFailedAttempt: (error) => {
+				logger.warn(
+					{
+						attempt: error.attemptNumber,
+						retriesLeft: error.retriesLeft,
+					},
+					"OpenAI embeddings request failed, retrying",
+				);
+			},
+		},
+	);
+}
 
 // pgvector requires raw SQL: Drizzle's update builder bypasses mapToDriverValue for
 // vector columns, so ::vector and ::jsonb casts must be explicit. The AND embedding
@@ -88,6 +178,7 @@ type EmbedDeltaCallback = (deltaEmbedded: number) => Promise<void>;
 export async function embedTracksBatch(
 	userId: string,
 	onProgress?: (progress: EmbedProgress) => Promise<void>,
+	pipelineRunId?: number,
 ): Promise<EmbedProgress> {
 	const stats: EmbedProgress = { embedded: 0, total: 0, pending: 0 };
 
@@ -147,45 +238,9 @@ export async function embedTracksBatch(
 				const inputs = toEmbeddingInputs(pendingTracks);
 				if (inputs.length === 0) return;
 
-				const json = await pRetry(
-					async () => {
-						const response = await fetch(
-							"https://api.openai.com/v1/embeddings",
-							{
-								method: "POST",
-								headers: {
-									Authorization: `Bearer ${env.HARMONIA_OPENAI_API_KEY}`,
-									"Content-Type": "application/json",
-								},
-								body: JSON.stringify({
-									model: EMBEDDING_MODEL,
-									input: inputs.map((i) => i.text),
-								}),
-							},
-						);
-
-						if (!response.ok) {
-							const text = await response.text();
-							throw new Error(
-								`OpenAI embeddings ${response.status}: ${text.slice(0, 200)}`,
-							);
-						}
-
-						return (await response.json()) as OpenAIEmbeddingResponse;
-					},
-					{
-						retries: 3,
-						minTimeout: 2000,
-						onFailedAttempt: (error) => {
-							logger.warn(
-								{
-									attempt: error.attemptNumber,
-									retriesLeft: error.retriesLeft,
-								},
-								"OpenAI embeddings request failed, retrying",
-							);
-						},
-					},
+				const json = await fetchEmbeddingsBatch(
+					inputs.map((i) => i.text),
+					{ userId, pipelineRunId },
 				);
 
 				if (!json.data || json.data.length !== inputs.length) {
@@ -235,6 +290,7 @@ export async function embedTrackIds(
 	userId: string,
 	trackIds: string[],
 	onBatchComplete?: EmbedDeltaCallback,
+	pipelineRunId?: number,
 ): Promise<EmbedProgress> {
 	const stats: EmbedProgress = {
 		embedded: 0,
@@ -275,45 +331,9 @@ export async function embedTrackIds(
 				const inputs = toEmbeddingInputs(pendingTracks);
 				if (inputs.length === 0) return;
 
-				const json = await pRetry(
-					async () => {
-						const response = await fetch(
-							"https://api.openai.com/v1/embeddings",
-							{
-								method: "POST",
-								headers: {
-									Authorization: `Bearer ${env.HARMONIA_OPENAI_API_KEY}`,
-									"Content-Type": "application/json",
-								},
-								body: JSON.stringify({
-									model: EMBEDDING_MODEL,
-									input: inputs.map((i) => i.text),
-								}),
-							},
-						);
-
-						if (!response.ok) {
-							const text = await response.text();
-							throw new Error(
-								`OpenAI embeddings ${response.status}: ${text.slice(0, 200)}`,
-							);
-						}
-
-						return (await response.json()) as OpenAIEmbeddingResponse;
-					},
-					{
-						retries: 3,
-						minTimeout: 2000,
-						onFailedAttempt: (error) => {
-							logger.warn(
-								{
-									attempt: error.attemptNumber,
-									retriesLeft: error.retriesLeft,
-								},
-								"OpenAI embeddings request failed, retrying",
-							);
-						},
-					},
+				const json = await fetchEmbeddingsBatch(
+					inputs.map((i) => i.text),
+					{ userId, pipelineRunId },
 				);
 
 				if (!json.data || json.data.length !== inputs.length) {

--- a/packages/common/src/services/brain/llml.ts
+++ b/packages/common/src/services/brain/llml.ts
@@ -15,6 +15,12 @@ import {
 	CLASSIFICATION_MAX_OUTPUT_TOKENS,
 	GROQ_RATE_LIMIT_FALLBACK_DELAY_MS,
 } from "../../constants/brain";
+import { logExternalApiCall } from "../external-api-log";
+
+export type LLMCallContext = {
+	userId?: string | null;
+	pipelineRunId?: number | null;
+};
 
 function buildClassificationPrompt(tracks: TrackForClassification[]): string {
 	return formatPrompt({
@@ -88,10 +94,13 @@ function logInvalidJsonError(err: unknown): void {
 
 async function classifyTracksBatchOnce(
 	tracks: TrackForClassification[],
+	context: LLMCallContext,
+	retryAttempt: number,
 ): Promise<ClassificationResult[]> {
+	const startTime = Date.now();
 	try {
 		const groq = createGroq({ apiKey: env.HARMONIA_GROQ_API_KEY });
-		const { output } = await generateText({
+		const { output, usage, response } = await generateText({
 			model: groq(CLASSIFICATION_LLM_MODEL),
 			prompt: buildClassificationPrompt(tracks),
 			temperature: 0,
@@ -100,6 +109,7 @@ async function classifyTracksBatchOnce(
 				schema: classificationResultListSchema,
 			}),
 		});
+		const durationMs = Date.now() - startTime;
 
 		logger.info(
 			{
@@ -119,9 +129,55 @@ async function classifyTracksBatchOnce(
 			}
 		}
 
+		// Prompt text and per-track metadata are never logged (large,
+		// contains user library data) — only counts and token usage.
+		await logExternalApiCall({
+			userId: context.userId,
+			pipelineRunId: context.pipelineRunId,
+			provider: "groq",
+			endpoint: CLASSIFICATION_LLM_MODEL,
+			method: "POST",
+			httpStatus: 200,
+			requestPayload: {
+				model: CLASSIFICATION_LLM_MODEL,
+				trackCount: tracks.length,
+			},
+			responsePayload: {
+				usage,
+				resultCount: output.results.length,
+				responseId: response?.id,
+			},
+			durationMs,
+			retryAttempt,
+		});
+
 		return output.results;
 	} catch (err) {
 		logInvalidJsonError(err);
+		const durationMs = Date.now() - startTime;
+		const httpStatus = APICallError.isInstance(err)
+			? err.statusCode
+			: undefined;
+		await logExternalApiCall({
+			userId: context.userId,
+			pipelineRunId: context.pipelineRunId,
+			provider: "groq",
+			endpoint: CLASSIFICATION_LLM_MODEL,
+			method: "POST",
+			httpStatus,
+			requestPayload: {
+				model: CLASSIFICATION_LLM_MODEL,
+				trackCount: tracks.length,
+			},
+			durationMs,
+			errorMessage: err instanceof Error ? err.message : String(err),
+			// The Vercel AI SDK's generateText() doesn't always surface a raw
+			// HTTP status (e.g. NoObjectGeneratedError has none) — default the
+			// bucket to server_error rather than the generic "no status" case,
+			// since these are Groq-side failures, not client/request errors.
+			statusCategory: httpStatus ? undefined : "server_error",
+			retryAttempt,
+		});
 		throw err;
 	}
 }
@@ -145,12 +201,17 @@ function sleep(ms: number): Promise<void> {
 
 async function classifyTracksAdaptive(
 	tracks: TrackForClassification[],
+	context: LLMCallContext,
 ): Promise<ClassificationResult[]> {
 	try {
 		return await pRetry(
-			async () => {
+			async (attemptCount) => {
 				try {
-					return await classifyTracksBatchOnce(tracks);
+					return await classifyTracksBatchOnce(
+						tracks,
+						context,
+						attemptCount - 1,
+					);
 				} catch (err) {
 					if (isRateLimit(err)) {
 						const delayMs = getRateLimitDelayMs(err);
@@ -211,8 +272,8 @@ async function classifyTracksAdaptive(
 		);
 
 		const [left, right] = await Promise.all([
-			classifyTracksAdaptive(tracks.slice(0, mid)),
-			classifyTracksAdaptive(tracks.slice(mid)),
+			classifyTracksAdaptive(tracks.slice(0, mid), context),
+			classifyTracksAdaptive(tracks.slice(mid), context),
 		]);
 		return [...left, ...right];
 	}
@@ -220,6 +281,7 @@ async function classifyTracksAdaptive(
 
 export async function classifyTracksWithLLM(
 	tracks: TrackForClassification[],
+	context: LLMCallContext = {},
 ): Promise<ClassificationResult[]> {
 	if (!env.HARMONIA_GROQ_API_KEY) {
 		logger.warn(
@@ -229,5 +291,5 @@ export async function classifyTracksWithLLM(
 		return [];
 	}
 
-	return classifyTracksAdaptive(tracks);
+	return classifyTracksAdaptive(tracks, context);
 }

--- a/packages/common/src/services/external-api-log.ts
+++ b/packages/common/src/services/external-api-log.ts
@@ -1,0 +1,66 @@
+import { db } from "@harmonia/db";
+import { externalApiCall } from "@harmonia/db/schema/external-api-call";
+import { logger } from "@harmonia/logger";
+
+const PAYLOAD_TRUNCATE_BYTES = 10_000;
+
+function truncatePayload(
+	payload: unknown,
+): Record<string, unknown> | undefined {
+	if (payload == null) return undefined;
+	const str = JSON.stringify(payload);
+	if (str.length <= PAYLOAD_TRUNCATE_BYTES)
+		return payload as Record<string, unknown>;
+	return { _truncated: true, _preview: str.slice(0, PAYLOAD_TRUNCATE_BYTES) };
+}
+
+function deriveStatusCategory(httpStatus: number | undefined | null): string {
+	if (!httpStatus) return "error";
+	if (httpStatus >= 200 && httpStatus < 300) return "success";
+	if (httpStatus === 404) return "not_found";
+	if (httpStatus === 429) return "rate_limited";
+	if (httpStatus >= 400 && httpStatus < 500) return "client_error";
+	return "server_error";
+}
+
+export type LogExternalApiCallInput = {
+	userId?: string | null;
+	pipelineRunId?: number | null;
+	provider: "spotify" | "lrclib" | "openai" | "groq";
+	endpoint: string;
+	method?: string;
+	httpStatus?: number | null;
+	requestPayload?: unknown;
+	responsePayload?: unknown;
+	durationMs?: number | null;
+	errorMessage?: string | null;
+	retryAttempt?: number;
+	statusCategory?: string;
+};
+
+// Fire-and-forget — never throws; a logging failure must not fail the main request.
+export async function logExternalApiCall(
+	input: LogExternalApiCallInput,
+): Promise<void> {
+	try {
+		const statusCategory =
+			input.statusCategory ?? deriveStatusCategory(input.httpStatus);
+
+		await db.insert(externalApiCall).values({
+			userId: input.userId ?? null,
+			pipelineRunId: input.pipelineRunId ?? null,
+			provider: input.provider,
+			endpoint: input.endpoint,
+			method: input.method ?? "GET",
+			httpStatus: input.httpStatus ?? null,
+			requestPayload: truncatePayload(input.requestPayload),
+			responsePayload: truncatePayload(input.responsePayload),
+			durationMs: input.durationMs ?? null,
+			errorMessage: input.errorMessage ?? null,
+			statusCategory,
+			retryAttempt: input.retryAttempt ?? 0,
+		});
+	} catch (err) {
+		logger.error({ err }, "Failed to write external_api_call log row");
+	}
+}

--- a/packages/common/src/services/music/lyrics/fetch-lyrics.ts
+++ b/packages/common/src/services/music/lyrics/fetch-lyrics.ts
@@ -22,6 +22,7 @@ type LyricsDeltaCallback = (delta: {
 export async function fetchLyricsForPendingTracks(
 	userId: string,
 	onProgress?: (progress: LyricsProgress) => Promise<void>,
+	pipelineRunId?: number,
 ): Promise<LyricsProgress> {
 	const stats: LyricsProgress = {
 		found: 0,
@@ -100,12 +101,15 @@ export async function fetchLyricsForPendingTracks(
 				}
 
 				try {
-					const lyrics = await getLyricsFromLRCLib({
-						trackName: t.name,
-						artistName: primaryArtist,
-						albumName: t.albumName,
-						durationMs: t.durationMs,
-					});
+					const lyrics = await getLyricsFromLRCLib(
+						{
+							trackName: t.name,
+							artistName: primaryArtist,
+							albumName: t.albumName,
+							durationMs: t.durationMs,
+						},
+						{ userId, pipelineRunId },
+					);
 
 					if (!lyrics) {
 						await db
@@ -192,6 +196,7 @@ export async function fetchLyricsForTrackIds(
 	userId: string,
 	trackIds: string[],
 	onBatchComplete?: LyricsDeltaCallback,
+	pipelineRunId?: number,
 ): Promise<LyricsProgress> {
 	const stats: LyricsProgress = {
 		found: 0,
@@ -251,12 +256,15 @@ export async function fetchLyricsForTrackIds(
 				}
 
 				try {
-					const lyrics = await getLyricsFromLRCLib({
-						trackName: t.name,
-						artistName: primaryArtist,
-						albumName: t.albumName,
-						durationMs: t.durationMs,
-					});
+					const lyrics = await getLyricsFromLRCLib(
+						{
+							trackName: t.name,
+							artistName: primaryArtist,
+							albumName: t.albumName,
+							durationMs: t.durationMs,
+						},
+						{ userId, pipelineRunId },
+					);
 
 					if (!lyrics) {
 						await db

--- a/packages/common/src/services/music/lyrics/lrclib-client.ts
+++ b/packages/common/src/services/music/lyrics/lrclib-client.ts
@@ -1,5 +1,20 @@
 import { logger } from "@harmonia/logger";
 import pRetry, { AbortError } from "p-retry";
+import { logExternalApiCall } from "../../external-api-log";
+
+export type LRCLibCallContext = {
+	userId?: string | null;
+	pipelineRunId?: number | null;
+};
+
+function tryParseJson(text: string): unknown {
+	if (!text) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
 
 type LRCLibTrack = {
 	id: number;
@@ -34,15 +49,54 @@ function toTrack(raw: LRCLibRawTrack): LRCLibTrack {
 
 // Generic helper used by both /api/get (T = LRCLibRawTrack) and /api/search (T = LRCLibRawTrack[]).
 // url is closed over so the retry log always carries request context.
-async function fetchLRCLib<T = LRCLibRawTrack>(url: string): Promise<T | null> {
+async function fetchLRCLib<T = LRCLibRawTrack>(
+	url: string,
+	endpoint: "/api/get" | "/api/search",
+	context: LRCLibCallContext = {},
+): Promise<T | null> {
+	let attempt = 0;
 	return pRetry(
 		async () => {
+			const retryAttempt = attempt;
+			attempt += 1;
+			const params = Object.fromEntries(new URL(url).searchParams);
+			const startTime = Date.now();
 			const response = await fetch(url);
+			const durationMs = Date.now() - startTime;
 
-			if (response.status === 404) return null;
+			if (response.status === 404) {
+				await logExternalApiCall({
+					userId: context.userId,
+					pipelineRunId: context.pipelineRunId,
+					provider: "lrclib",
+					endpoint,
+					method: "GET",
+					httpStatus: 404,
+					requestPayload: params,
+					durationMs,
+					retryAttempt,
+				});
+				return null;
+			}
 
 			if (!response.ok) {
+				const bodyText = await response.clone().text();
 				const message = `LRCLib ${response.status}: ${response.statusText}`;
+				await logExternalApiCall({
+					userId: context.userId,
+					pipelineRunId: context.pipelineRunId,
+					provider: "lrclib",
+					endpoint,
+					method: "GET",
+					httpStatus: response.status,
+					requestPayload: params,
+					responsePayload: tryParseJson(bodyText) as
+						| Record<string, unknown>
+						| undefined,
+					durationMs,
+					errorMessage: message,
+					retryAttempt,
+				});
 				// 429 is rate-limited but transient — must NOT abort, let backoff handle it
 				if (
 					response.status !== 429 &&
@@ -54,6 +108,18 @@ async function fetchLRCLib<T = LRCLibRawTrack>(url: string): Promise<T | null> {
 				// 429 and 5xx — retried with exponential back-off + jitter
 				throw new Error(message);
 			}
+
+			await logExternalApiCall({
+				userId: context.userId,
+				pipelineRunId: context.pipelineRunId,
+				provider: "lrclib",
+				endpoint,
+				method: "GET",
+				httpStatus: response.status,
+				requestPayload: params,
+				durationMs,
+				retryAttempt,
+			});
 
 			return (await response.json()) as T;
 		},
@@ -69,12 +135,15 @@ async function fetchLRCLib<T = LRCLibRawTrack>(url: string): Promise<T | null> {
 	);
 }
 
-export async function getLyricsFromLRCLib(params: {
-	trackName: string;
-	artistName: string;
-	albumName?: string | null;
-	durationMs?: number | null;
-}): Promise<LRCLibTrack | null> {
+export async function getLyricsFromLRCLib(
+	params: {
+		trackName: string;
+		artistName: string;
+		albumName?: string | null;
+		durationMs?: number | null;
+	},
+	context: LRCLibCallContext = {},
+): Promise<LRCLibTrack | null> {
 	// ── 1. Exact-match via /api/get ──────────────────────────────────────────
 	const getParams = new URLSearchParams({
 		track_name: params.trackName,
@@ -87,6 +156,8 @@ export async function getLyricsFromLRCLib(params: {
 
 	const exact = await fetchLRCLib<LRCLibRawTrack>(
 		`https://lrclib.net/api/get?${getParams.toString()}`,
+		"/api/get",
+		context,
 	);
 	if (exact) return toTrack(exact);
 
@@ -99,6 +170,8 @@ export async function getLyricsFromLRCLib(params: {
 
 	const results = await fetchLRCLib<LRCLibRawTrack[]>(
 		`https://lrclib.net/api/search?${searchParams.toString()}`,
+		"/api/search",
+		context,
 	);
 
 	// results is null (404) or LRCLibRawTrack[]; optional-chain handles both

--- a/packages/common/src/services/music/spotify/__tests__/client.test.ts
+++ b/packages/common/src/services/music/spotify/__tests__/client.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@harmonia/db", () => ({ db: {} }));
+vi.mock("@harmonia/db", () => ({
+	db: { insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })) },
+}));
 
 import { SpotifyApiError, spotifyRequest } from "../client";
 

--- a/packages/common/src/services/music/spotify/client.ts
+++ b/packages/common/src/services/music/spotify/client.ts
@@ -19,10 +19,25 @@ import {
 	SPOTIFY_RATE_LIMIT_MAX_RETRIES,
 	SPOTIFY_RATE_LIMIT_MAX_WAIT_SEC,
 } from "../../../constants/spotify";
+import { logExternalApiCall } from "../../external-api-log";
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+function tryParseJson(text: string): unknown {
+	if (!text) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+export type SpotifyCallContext = {
+	userId?: string | null;
+	pipelineRunId?: number | null;
+};
 
 export async function getSpotifyAccount(userId: string) {
 	const rows = await db
@@ -82,6 +97,7 @@ export async function getUserSpotifyAccessToken(
 		refresh_token: spotifyAccount.refreshToken,
 	});
 
+	const startTime = Date.now();
 	const response = await fetch("https://accounts.spotify.com/api/token", {
 		method: "POST",
 		headers: {
@@ -90,6 +106,7 @@ export async function getUserSpotifyAccessToken(
 		},
 		body,
 	});
+	const durationMs = Date.now() - startTime;
 
 	if (!response.ok) {
 		logger.error(
@@ -100,6 +117,15 @@ export async function getUserSpotifyAccessToken(
 			},
 			"Failed to refresh Spotify access token",
 		);
+		await logExternalApiCall({
+			userId,
+			provider: "spotify",
+			endpoint: "/token",
+			method: "POST",
+			httpStatus: response.status,
+			durationMs,
+			errorMessage: response.statusText,
+		});
 		return null;
 	}
 
@@ -113,6 +139,15 @@ export async function getUserSpotifyAccessToken(
 			accessTokenExpiresAt: expiresAt,
 		})
 		.where(and(eq(account.userId, userId), eq(account.providerId, "spotify")));
+
+	await logExternalApiCall({
+		userId,
+		provider: "spotify",
+		endpoint: "/token",
+		method: "POST",
+		httpStatus: response.status,
+		durationMs,
+	});
 
 	return json.access_token;
 }
@@ -141,6 +176,7 @@ export async function spotifyRequest<T>(
 	accessToken: string,
 	options: SpotifyRequestOptions = {},
 	retriesLeft = SPOTIFY_RATE_LIMIT_MAX_RETRIES,
+	context: SpotifyCallContext = {},
 ): Promise<T | undefined> {
 	const { method = "GET", body } = options;
 	const init: RequestInit = {
@@ -152,7 +188,10 @@ export async function spotifyRequest<T>(
 		...(body !== undefined && { body: JSON.stringify(body) }),
 	};
 
+	const retryAttempt = SPOTIFY_RATE_LIMIT_MAX_RETRIES - retriesLeft;
+	const startTime = Date.now();
 	const response = await fetch(`${SPOTIFY_API_BASE}${path}`, init);
+	const durationMs = Date.now() - startTime;
 
 	if (response.status === 429 && retriesLeft > 0) {
 		const retryAfter = Number(response.headers.get("Retry-After") ?? "0");
@@ -168,8 +207,18 @@ export async function spotifyRequest<T>(
 			},
 			"Spotify rate limit (429); waiting before retry",
 		);
+		await logExternalApiCall({
+			userId: context.userId,
+			pipelineRunId: context.pipelineRunId,
+			provider: "spotify",
+			endpoint: path,
+			method,
+			httpStatus: 429,
+			durationMs,
+			retryAttempt,
+		});
 		await sleep(waitSec * 1000);
-		return spotifyRequest(path, accessToken, options, retriesLeft - 1);
+		return spotifyRequest(path, accessToken, options, retriesLeft - 1, context);
 	}
 
 	// Retry transient Spotify server errors (5xx) with exponential backoff.
@@ -181,8 +230,18 @@ export async function spotifyRequest<T>(
 			{ path, status: response.status, retriesLeft, waitMs },
 			"Spotify server error (5xx); retrying with backoff",
 		);
+		await logExternalApiCall({
+			userId: context.userId,
+			pipelineRunId: context.pipelineRunId,
+			provider: "spotify",
+			endpoint: path,
+			method,
+			httpStatus: response.status,
+			durationMs,
+			retryAttempt,
+		});
 		await sleep(waitMs);
-		return spotifyRequest(path, accessToken, options, retriesLeft - 1);
+		return spotifyRequest(path, accessToken, options, retriesLeft - 1, context);
 	}
 
 	if (!response.ok) {
@@ -207,6 +266,20 @@ export async function spotifyRequest<T>(
 			bodyJson.error_description ?? bodyJson.error ?? response.statusText;
 		const summary =
 			typeof rawSummary === "string" ? rawSummary : JSON.stringify(rawSummary);
+		await logExternalApiCall({
+			userId: context.userId,
+			pipelineRunId: context.pipelineRunId,
+			provider: "spotify",
+			endpoint: path,
+			method,
+			httpStatus: response.status,
+			responsePayload: tryParseJson(bodyText) as
+				| Record<string, unknown>
+				| undefined,
+			durationMs,
+			errorMessage: summary,
+			retryAttempt,
+		});
 		throw new SpotifyApiError(
 			response.status,
 			`Spotify API error ${response.status} for ${path}: ${summary}`,
@@ -217,6 +290,20 @@ export async function spotifyRequest<T>(
 	// an empty body — response.json() throws "Unexpected end of JSON input" on
 	// those, so read as text first and only parse when there's content.
 	const responseText = await response.text();
+
+	// responsePayload intentionally omitted on success — saved-track/playlist
+	// pages are large; a success row's existence is the useful signal.
+	await logExternalApiCall({
+		userId: context.userId,
+		pipelineRunId: context.pipelineRunId,
+		provider: "spotify",
+		endpoint: path,
+		method,
+		httpStatus: response.status,
+		durationMs,
+		retryAttempt,
+	});
+
 	if (!responseText) {
 		return undefined;
 	}
@@ -226,8 +313,18 @@ export async function spotifyRequest<T>(
 // GET endpoints used in this codebase always return a body (paginated list
 // responses) — fail loudly rather than silently propagating undefined if
 // that assumption is ever wrong, instead of an `as T` cast.
-async function spotifyGet<T>(path: string, accessToken: string): Promise<T> {
-	const result = await spotifyRequest<T>(path, accessToken, { method: "GET" });
+async function spotifyGet<T>(
+	path: string,
+	accessToken: string,
+	context: SpotifyCallContext = {},
+): Promise<T> {
+	const result = await spotifyRequest<T>(
+		path,
+		accessToken,
+		{ method: "GET" },
+		undefined,
+		context,
+	);
 	if (result === undefined) {
 		throw new Error(`Spotify GET ${path} returned an empty body`);
 	}
@@ -255,6 +352,7 @@ export async function fetchAllSavedTracks(
 	accessToken: string,
 	options?: {
 		onPage?: (args: FetchSavedTracksOnPageArgs) => void | Promise<void>;
+		context?: SpotifyCallContext;
 	},
 ): Promise<SpotifySavedTracksResponse["items"]> {
 	const limit = 50;
@@ -264,7 +362,11 @@ export async function fetchAllSavedTracks(
 	let reportedTotal: number | undefined;
 
 	for (;;) {
-		const page = await spotifyGet<SpotifySavedTracksResponse>(url, accessToken);
+		const page = await spotifyGet<SpotifySavedTracksResponse>(
+			url,
+			accessToken,
+			options?.context,
+		);
 		if (typeof page.total === "number") {
 			reportedTotal = page.total;
 		}
@@ -300,14 +402,18 @@ export async function fetchAllSavedTracks(
 
 export async function fetchAllUserPlaylists(
 	accessToken: string,
-	options?: { ownerId?: string },
+	options?: { ownerId?: string; context?: SpotifyCallContext },
 ): Promise<SpotifyPlaylistSimplified[]> {
 	const limit = 50;
 	let url = `/me/playlists?limit=${limit}`;
 	const allPlaylists: SpotifyPlaylistSimplified[] = [];
 
 	for (;;) {
-		const page = await spotifyGet<SpotifyPlaylistsResponse>(url, accessToken);
+		const page = await spotifyGet<SpotifyPlaylistsResponse>(
+			url,
+			accessToken,
+			options?.context,
+		);
 		allPlaylists.push(...page.items);
 
 		if (!page.next) {
@@ -327,7 +433,7 @@ export async function fetchAllUserPlaylists(
 export async function fetchPlaylistItems(
 	accessToken: string,
 	playlistId: string,
-	options?: { fields?: string },
+	options?: { fields?: string; context?: SpotifyCallContext },
 ): Promise<SpotifyPlaylistTrackItem[]> {
 	const fields = options?.fields ?? SPOTIFY_PLAYLIST_ITEMS_FIELDS;
 	let url = `/playlists/${playlistId}/items?limit=${SPOTIFY_PLAYLIST_ITEMS_LIMIT}&fields=${encodeURIComponent(fields)}`;
@@ -337,6 +443,7 @@ export async function fetchPlaylistItems(
 		const page = await spotifyGet<SpotifyPlaylistTracksResponse>(
 			url,
 			accessToken,
+			options?.context,
 		);
 		allItems.push(...page.items);
 
@@ -353,6 +460,7 @@ export async function fetchPlaylistItems(
 export async function fetchAllPlaylistTracks(
 	accessToken: string,
 	playlistId: string,
+	context?: SpotifyCallContext,
 ): Promise<SpotifyPlaylistTrackItem[]> {
-	return fetchPlaylistItems(accessToken, playlistId);
+	return fetchPlaylistItems(accessToken, playlistId, { context });
 }

--- a/packages/common/src/services/music/spotify/export.ts
+++ b/packages/common/src/services/music/spotify/export.ts
@@ -87,6 +87,7 @@ export async function exportPlaylistToSpotify(
 				pl,
 				filteredUris,
 				playlistId,
+				userId,
 			);
 		} catch (err) {
 			if (!(err instanceof SpotifyApiError) || err.status !== 404) {
@@ -104,7 +105,7 @@ export async function exportPlaylistToSpotify(
 
 async function createNewPlaylist(
 	accessToken: string,
-	_userId: string,
+	userId: string,
 	pl: { name: string; description: string | null },
 	trackUris: string[],
 	playlistId: number,
@@ -121,6 +122,8 @@ async function createNewPlaylist(
 					public: false,
 				},
 			},
+			undefined,
+			{ userId },
 		),
 	);
 
@@ -138,10 +141,16 @@ async function createNewPlaylist(
 	) {
 		const batch = trackUris.slice(i, i + SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST);
 		await retryableSpotifyRequest(() =>
-			spotifyRequest(`/playlists/${spotifyPlaylistId}/items`, accessToken, {
-				method: "POST",
-				body: { uris: batch },
-			}),
+			spotifyRequest(
+				`/playlists/${spotifyPlaylistId}/items`,
+				accessToken,
+				{
+					method: "POST",
+					body: { uris: batch },
+				},
+				undefined,
+				{ userId },
+			),
 		);
 	}
 
@@ -167,24 +176,37 @@ async function updateExistingPlaylist(
 	pl: { name: string; description: string | null },
 	trackUris: string[],
 	playlistId: number,
+	userId: string,
 ): Promise<{ spotifyPlaylistId: string; spotifyUrl: string }> {
 	await retryableSpotifyRequest(() =>
-		spotifyRequest(`/playlists/${spotifyPlaylistId}`, accessToken, {
-			method: "PUT",
-			body: {
-				name: pl.name,
-				description: pl.description ?? "",
+		spotifyRequest(
+			`/playlists/${spotifyPlaylistId}`,
+			accessToken,
+			{
+				method: "PUT",
+				body: {
+					name: pl.name,
+					description: pl.description ?? "",
+				},
 			},
-		}),
+			undefined,
+			{ userId },
+		),
 	);
 
 	await retryableSpotifyRequest(() =>
-		spotifyRequest(`/playlists/${spotifyPlaylistId}/items`, accessToken, {
-			method: "PUT",
-			body: {
-				uris: trackUris.slice(0, SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST),
+		spotifyRequest(
+			`/playlists/${spotifyPlaylistId}/items`,
+			accessToken,
+			{
+				method: "PUT",
+				body: {
+					uris: trackUris.slice(0, SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST),
+				},
 			},
-		}),
+			undefined,
+			{ userId },
+		),
 	);
 
 	for (
@@ -194,10 +216,16 @@ async function updateExistingPlaylist(
 	) {
 		const batch = trackUris.slice(i, i + SPOTIFY_EXPORT_MAX_TRACKS_PER_REQUEST);
 		await retryableSpotifyRequest(() =>
-			spotifyRequest(`/playlists/${spotifyPlaylistId}/items`, accessToken, {
-				method: "POST",
-				body: { uris: batch },
-			}),
+			spotifyRequest(
+				`/playlists/${spotifyPlaylistId}/items`,
+				accessToken,
+				{
+					method: "POST",
+					body: { uris: batch },
+				},
+				undefined,
+				{ userId },
+			),
 		);
 	}
 

--- a/packages/common/src/services/music/spotify/library-stats.ts
+++ b/packages/common/src/services/music/spotify/library-stats.ts
@@ -65,6 +65,7 @@ export async function refreshSpotifyLibraryStats(
 	const spotifyAccount = await getSpotifyAccount(userId);
 	const playlists = await fetchAllUserPlaylists(accessToken, {
 		ownerId: INCLUDE_FOLLOWED_PLAYLISTS ? undefined : spotifyAccount?.accountId,
+		context: { userId },
 	});
 	const totalPlaylists = playlists.length;
 
@@ -92,7 +93,9 @@ export async function refreshSpotifyLibraryStats(
 					await new Promise((r) =>
 						setTimeout(r, (i % STATS_FETCH_CONCURRENCY) * 100),
 					);
-					items = await fetchPlaylistItems(accessToken, playlist.id);
+					items = await fetchPlaylistItems(accessToken, playlist.id, {
+						context: { userId },
+					});
 					await setCachedPlaylistItems(userId, playlist.id, snapshotId, items);
 					await db
 						.insert(userPlaylistSnapshots)

--- a/packages/common/src/services/music/spotify/library-sync.ts
+++ b/packages/common/src/services/music/spotify/library-sync.ts
@@ -245,6 +245,7 @@ export async function syncLibraryTracks(
 	};
 
 	await fetchAllSavedTracks(accessToken, {
+		context: { userId },
 		onPage: async ({
 			items,
 			cumulativeTrackCount,
@@ -284,7 +285,9 @@ export async function syncLibraryTracks(
 	}
 
 	// 2. Playlists
-	const playlists = await fetchAllUserPlaylists(accessToken);
+	const playlists = await fetchAllUserPlaylists(accessToken, {
+		context: { userId },
+	});
 	const totalPlaylists = playlists.length;
 
 	// 3. For each playlist: use cache if snapshot matches, else fetch and cache
@@ -312,7 +315,9 @@ export async function syncLibraryTracks(
 						),
 					);
 					try {
-						items = await fetchPlaylistItems(accessToken, playlist.id);
+						items = await fetchPlaylistItems(accessToken, playlist.id, {
+							context: { userId },
+						});
 						await setCachedPlaylistItems(
 							userId,
 							playlist.id,

--- a/packages/common/src/services/organize/run-organize.ts
+++ b/packages/common/src/services/organize/run-organize.ts
@@ -142,6 +142,7 @@ export async function runOrganizeForUser({
 				progress.classify = p;
 				await updateRun(runId, { progress });
 			},
+			runId,
 		);
 		progress.classify = classifyResult;
 		await updateRun(runId, { progress });

--- a/packages/common/src/services/organize/run-organize.ts
+++ b/packages/common/src/services/organize/run-organize.ts
@@ -154,6 +154,7 @@ export async function runOrganizeForUser({
 				progress.embed = p;
 				await updateRun(runId, { progress });
 			},
+			runId,
 		);
 		progress.embed = embedResult;
 		await updateRun(runId, { progress });

--- a/packages/common/src/services/organize/run-organize.ts
+++ b/packages/common/src/services/organize/run-organize.ts
@@ -129,6 +129,7 @@ export async function runOrganizeForUser({
 				progress.lyrics = p;
 				await updateRun(runId, { progress });
 			},
+			runId,
 		);
 		progress.lyrics = lyricsResult;
 		await updateRun(runId, { progress });

--- a/packages/common/src/trigger/tasks/stages/classify.ts
+++ b/packages/common/src/trigger/tasks/stages/classify.ts
@@ -39,14 +39,19 @@ export const classifyWorkerTask = task({
 	}) => {
 		await checkCancelled(runId, userId);
 
-		return await classifyTrackIds(userId, trackIds, async (deltaClassified) => {
-			await incrementStageProgress(
-				runId,
-				"classify",
-				"classified",
-				deltaClassified,
-			);
-		});
+		return await classifyTrackIds(
+			userId,
+			trackIds,
+			async (deltaClassified) => {
+				await incrementStageProgress(
+					runId,
+					"classify",
+					"classified",
+					deltaClassified,
+				);
+			},
+			runId,
+		);
 	},
 });
 

--- a/packages/common/src/trigger/tasks/stages/embed.ts
+++ b/packages/common/src/trigger/tasks/stages/embed.ts
@@ -39,9 +39,14 @@ export const embedWorkerTask = task({
 	}) => {
 		await checkCancelled(runId, userId);
 
-		return await embedTrackIds(userId, trackIds, async (deltaEmbedded) => {
-			await incrementStageProgress(runId, "embed", "embedded", deltaEmbedded);
-		});
+		return await embedTrackIds(
+			userId,
+			trackIds,
+			async (deltaEmbedded) => {
+				await incrementStageProgress(runId, "embed", "embedded", deltaEmbedded);
+			},
+			runId,
+		);
 	},
 });
 

--- a/packages/common/src/trigger/tasks/stages/lyrics.ts
+++ b/packages/common/src/trigger/tasks/stages/lyrics.ts
@@ -39,24 +39,29 @@ export const lyricsWorkerTask = task({
 	}) => {
 		await checkCancelled(runId, userId);
 
-		return await fetchLyricsForTrackIds(userId, trackIds, async (delta) => {
-			if (delta.processed > 0)
-				await incrementStageProgress(
-					runId,
-					"lyrics",
-					"processed",
-					delta.processed,
-				);
-			if (delta.found > 0)
-				await incrementStageProgress(runId, "lyrics", "found", delta.found);
-			if (delta.notFound > 0)
-				await incrementStageProgress(
-					runId,
-					"lyrics",
-					"notFound",
-					delta.notFound,
-				);
-		});
+		return await fetchLyricsForTrackIds(
+			userId,
+			trackIds,
+			async (delta) => {
+				if (delta.processed > 0)
+					await incrementStageProgress(
+						runId,
+						"lyrics",
+						"processed",
+						delta.processed,
+					);
+				if (delta.found > 0)
+					await incrementStageProgress(runId, "lyrics", "found", delta.found);
+				if (delta.notFound > 0)
+					await incrementStageProgress(
+						runId,
+						"lyrics",
+						"notFound",
+						delta.notFound,
+					);
+			},
+			runId,
+		);
 	},
 });
 

--- a/packages/db/scripts/db-reset.ts
+++ b/packages/db/scripts/db-reset.ts
@@ -26,6 +26,7 @@ const TABLES_TO_TRUNCATE = [
 	"character_tracks",
 	"character_clusters",
 	"character",
+	"external_api_call",
 	"pipeline_run",
 	"user_tracks",
 ] as const;

--- a/packages/db/src/migrations/0026_square_hemingway.sql
+++ b/packages/db/src/migrations/0026_square_hemingway.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "external_api_call" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text,
+	"pipeline_run_id" integer,
+	"provider" text NOT NULL,
+	"endpoint" text NOT NULL,
+	"method" text DEFAULT 'GET' NOT NULL,
+	"request_payload" jsonb,
+	"http_status" integer,
+	"response_payload" jsonb,
+	"duration_ms" integer,
+	"error_message" text,
+	"status_category" text NOT NULL,
+	"retry_attempt" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "external_api_call" ADD CONSTRAINT "external_api_call_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "external_api_call" ADD CONSTRAINT "external_api_call_pipeline_run_id_pipeline_run_id_fk" FOREIGN KEY ("pipeline_run_id") REFERENCES "public"."pipeline_run"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "eac_user_id_idx" ON "external_api_call" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "eac_pipeline_run_id_idx" ON "external_api_call" USING btree ("pipeline_run_id");--> statement-breakpoint
+CREATE INDEX "eac_provider_idx" ON "external_api_call" USING btree ("provider");--> statement-breakpoint
+CREATE INDEX "eac_status_category_idx" ON "external_api_call" USING btree ("status_category");--> statement-breakpoint
+CREATE INDEX "eac_created_at_idx" ON "external_api_call" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "eac_provider_created_at_idx" ON "external_api_call" USING btree ("provider","created_at");--> statement-breakpoint
+CREATE INDEX "eac_user_status_idx" ON "external_api_call" USING btree ("user_id","status_category");

--- a/packages/db/src/migrations/meta/0026_snapshot.json
+++ b/packages/db/src/migrations/meta/0026_snapshot.json
@@ -1,0 +1,2688 @@
+{
+	"id": "46b95861-069f-444b-956c-1cd3baeffaa0",
+	"prevId": "a2fcc119-f614-432b-962a-c42803d6ef1f",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_impersonated_by_user_id_fk": {
+					"name": "session_impersonated_by_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["impersonated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_completed_onboarding": {
+					"name": "has_completed_onboarding",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_approved": {
+					"name": "is_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character": {
+			"name": "character",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_user_id_user_id_fk": {
+					"name": "character_user_id_user_id_fk",
+					"tableFrom": "character",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_genre_domain_id_genre_domain_id_fk": {
+					"name": "character_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "character",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_clusters": {
+			"name": "character_clusters",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_clusters_character_id_character_id_fk": {
+					"name": "character_clusters_character_id_character_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_clusters_cluster_id_cluster_id_fk": {
+					"name": "character_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_clusters_character_id_cluster_id_pk": {
+					"name": "character_clusters_character_id_cluster_id_pk",
+					"columns": ["character_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_tracks": {
+			"name": "character_tracks",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_tracks_character_id_character_id_fk": {
+					"name": "character_tracks_character_id_character_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_tracks_track_id_track_id_fk": {
+					"name": "character_tracks_track_id_track_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_tracks_character_id_track_id_pk": {
+					"name": "character_tracks_character_id_track_id_pk",
+					"columns": ["character_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster": {
+			"name": "cluster",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"centroid": {
+					"name": "centroid",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_valence": {
+					"name": "avg_valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_energy": {
+					"name": "avg_energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_tempo": {
+					"name": "avg_tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"cluster_user_id_idx": {
+					"name": "cluster_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"cluster_user_id_user_id_fk": {
+					"name": "cluster_user_id_user_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_genre_domain_id_genre_domain_id_fk": {
+					"name": "cluster_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster_tracks": {
+			"name": "cluster_tracks",
+			"schema": "",
+			"columns": {
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cluster_tracks_cluster_id_cluster_id_fk": {
+					"name": "cluster_tracks_cluster_id_cluster_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_tracks_track_id_track_id_fk": {
+					"name": "cluster_tracks_track_id_track_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"cluster_tracks_cluster_id_track_id_pk": {
+					"name": "cluster_tracks_cluster_id_track_id_pk",
+					"columns": ["cluster_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_send_log": {
+			"name": "email_send_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"template_key": {
+					"name": "template_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"skip_reason": {
+					"name": "skip_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_message_id": {
+					"name": "provider_message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"email_send_log_user_id_idx": {
+					"name": "email_send_log_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_status_idx": {
+					"name": "email_send_log_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_template_key_idx": {
+					"name": "email_send_log_template_key_idx",
+					"columns": [
+						{
+							"expression": "template_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_created_at_idx": {
+					"name": "email_send_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_provider_message_id_idx": {
+					"name": "email_send_log_provider_message_id_idx",
+					"columns": [
+						{
+							"expression": "provider_message_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"email_send_log_user_id_user_id_fk": {
+					"name": "email_send_log_user_id_user_id_fk",
+					"tableFrom": "email_send_log",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_send_log_idempotency_key_unique": {
+					"name": "email_send_log_idempotency_key_unique",
+					"nullsNotDistinct": false,
+					"columns": ["idempotency_key"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_suppression": {
+			"name": "email_suppression",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suppressed_at": {
+					"name": "suppressed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"email_suppression_suppressed_at_idx": {
+					"name": "email_suppression_suppressed_at_idx",
+					"columns": [
+						{
+							"expression": "suppressed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_suppression_email_unique": {
+					"name": "email_suppression_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.external_api_call": {
+			"name": "external_api_call",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pipeline_run_id": {
+					"name": "pipeline_run_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"method": {
+					"name": "method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'GET'"
+				},
+				"request_payload": {
+					"name": "request_payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"http_status": {
+					"name": "http_status",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_payload": {
+					"name": "response_payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status_category": {
+					"name": "status_category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"retry_attempt": {
+					"name": "retry_attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"eac_user_id_idx": {
+					"name": "eac_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_pipeline_run_id_idx": {
+					"name": "eac_pipeline_run_id_idx",
+					"columns": [
+						{
+							"expression": "pipeline_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_provider_idx": {
+					"name": "eac_provider_idx",
+					"columns": [
+						{
+							"expression": "provider",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_status_category_idx": {
+					"name": "eac_status_category_idx",
+					"columns": [
+						{
+							"expression": "status_category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_created_at_idx": {
+					"name": "eac_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_provider_created_at_idx": {
+					"name": "eac_provider_created_at_idx",
+					"columns": [
+						{
+							"expression": "provider",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_user_status_idx": {
+					"name": "eac_user_status_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status_category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"external_api_call_user_id_user_id_fk": {
+					"name": "external_api_call_user_id_user_id_fk",
+					"tableFrom": "external_api_call",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"external_api_call_pipeline_run_id_pipeline_run_id_fk": {
+					"name": "external_api_call_pipeline_run_id_pipeline_run_id_fk",
+					"tableFrom": "external_api_call",
+					"tableTo": "pipeline_run",
+					"columnsFrom": ["pipeline_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genre_domain": {
+			"name": "genre_domain",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"genre_domain_name_unique": {
+					"name": "genre_domain_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pipeline_run": {
+			"name": "pipeline_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"triggered_by": {
+					"name": "triggered_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_stage": {
+					"name": "current_stage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"progress": {
+					"name": "progress",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"last_client_seen_at": {
+					"name": "last_client_seen_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"pipeline_run_user_id_idx": {
+					"name": "pipeline_run_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_status_idx": {
+					"name": "pipeline_run_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_one_running_per_user": {
+					"name": "pipeline_run_one_running_per_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"pipeline_run\".\"status\" = 'running'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pipeline_run_user_id_user_id_fk": {
+					"name": "pipeline_run_user_id_user_id_fk",
+					"tableFrom": "pipeline_run",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist": {
+			"name": "playlist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_generated_name": {
+					"name": "ai_generated_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"taxonomy": {
+					"name": "taxonomy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_color": {
+					"name": "cover_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_count": {
+					"name": "track_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"exported_at": {
+					"name": "exported_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auto_sync_enabled": {
+					"name": "auto_sync_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"playlist_user_id_idx": {
+					"name": "playlist_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"playlist_taxonomy_idx": {
+					"name": "playlist_taxonomy_idx",
+					"columns": [
+						{
+							"expression": "taxonomy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"playlist_user_id_user_id_fk": {
+					"name": "playlist_user_id_user_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_genre_domain_id_genre_domain_id_fk": {
+					"name": "playlist_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_clusters": {
+			"name": "playlist_clusters",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_clusters_playlist_id_playlist_id_fk": {
+					"name": "playlist_clusters_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_clusters_cluster_id_cluster_id_fk": {
+					"name": "playlist_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_clusters_playlist_id_cluster_id_pk": {
+					"name": "playlist_clusters_playlist_id_cluster_id_pk",
+					"columns": ["playlist_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_tracks": {
+			"name": "playlist_tracks",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_tracks_playlist_id_playlist_id_fk": {
+					"name": "playlist_tracks_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_tracks_track_id_track_id_fk": {
+					"name": "playlist_tracks_track_id_track_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_tracks_playlist_id_track_id_pk": {
+					"name": "playlist_tracks_playlist_id_track_id_pk",
+					"columns": ["playlist_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_item_artists": {
+			"name": "user_playlist_snapshot_item_artists",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_position": {
+					"name": "artist_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_name": {
+					"name": "artist_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_item_artists",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+					"columns": ["user_id", "playlist_id", "position", "artist_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_items": {
+			"name": "user_playlist_snapshot_items",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_name": {
+					"name": "track_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_uri": {
+					"name": "track_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_items_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_items",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+					"columns": ["user_id", "playlist_id", "position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshots": {
+			"name": "user_playlist_snapshots",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshots_user_id_user_id_fk": {
+					"name": "user_playlist_snapshots_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshots",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshots_user_id_playlist_id_pk": {
+					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
+					"columns": ["user_id", "playlist_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_spotify_library_stats": {
+			"name": "user_spotify_library_stats",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"total_tracks": {
+					"name": "total_tracks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_playlists": {
+					"name": "total_playlists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_albums": {
+					"name": "unique_albums",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_artists": {
+					"name": "unique_artists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_spotify_library_stats_user_id_user_id_fk": {
+					"name": "user_spotify_library_stats_user_id_user_id_fk",
+					"tableFrom": "user_spotify_library_stats",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track": {
+			"name": "track",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"spotify_uri": {
+					"name": "spotify_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_names": {
+					"name": "artist_names",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_ids": {
+					"name": "artist_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_image_url": {
+					"name": "album_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"explicit": {
+					"name": "explicit",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"popularity": {
+					"name": "popularity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spotify_genres": {
+					"name": "spotify_genres",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"valence": {
+					"name": "valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy": {
+					"name": "energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"danceability": {
+					"name": "danceability",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tempo": {
+					"name": "tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acousticness": {
+					"name": "acousticness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instrumentalness": {
+					"name": "instrumentalness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"speechiness": {
+					"name": "speechiness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"liveness": {
+					"name": "liveness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics": {
+					"name": "lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_lyrics": {
+					"name": "synced_lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_instrumental": {
+					"name": "lyrics_instrumental",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lrclib_id": {
+					"name": "lrclib_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_fetched_at": {
+					"name": "lyrics_fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_status": {
+					"name": "lyrics_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_mood": {
+					"name": "llm_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_tags": {
+					"name": "llm_tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_classified_at": {
+					"name": "llm_classified_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_generated_at": {
+					"name": "embedding_generated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_input": {
+					"name": "embedding_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_assigned_at": {
+					"name": "domain_assigned_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"analysis_snapshot": {
+					"name": "analysis_snapshot",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"track_genre_domain_id_idx": {
+					"name": "track_genre_domain_id_idx",
+					"columns": [
+						{
+							"expression": "genre_domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_lyrics_status_idx": {
+					"name": "track_lyrics_status_idx",
+					"columns": [
+						{
+							"expression": "lyrics_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_embedding_idx": {
+					"name": "track_embedding_idx",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genre_domain_id_genre_domain_id_fk": {
+					"name": "track_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "track",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_tracks": {
+			"name": "user_tracks",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_tracks_user_id_idx": {
+					"name": "user_tracks_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_tracks_track_id_idx": {
+					"name": "user_tracks_track_id_idx",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_tracks_user_id_user_id_fk": {
+					"name": "user_tracks_user_id_user_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_tracks_track_id_track_id_fk": {
+					"name": "user_tracks_track_id_track_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_tracks_user_id_track_id_pk": {
+					"name": "user_tracks_user_id_track_id_pk",
+					"columns": ["user_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_email_preferences": {
+			"name": "user_email_preferences",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"transactional_enabled": {
+					"name": "transactional_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"product_updates_enabled": {
+					"name": "product_updates_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"marketing_enabled": {
+					"name": "marketing_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"feedback_enabled": {
+					"name": "feedback_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"consent_source": {
+					"name": "consent_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"consent_captured_at": {
+					"name": "consent_captured_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unsubscribed_at": {
+					"name": "unsubscribed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_email_preferences_user_id_user_id_fk": {
+					"name": "user_email_preferences_user_id_user_id_fk",
+					"tableFrom": "user_email_preferences",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.waitlist_signup": {
+			"name": "waitlist_signup",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "waitlist_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confirmation_email_sent_at": {
+					"name": "confirmation_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_email_sent_at": {
+					"name": "approval_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token": {
+					"name": "invite_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_raw": {
+					"name": "invite_token_raw",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_expires_at": {
+					"name": "invite_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_at": {
+					"name": "invite_redeemed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_by_user_id": {
+					"name": "invite_redeemed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"waitlist_signup_status_idx": {
+					"name": "waitlist_signup_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_created_at_idx": {
+					"name": "waitlist_signup_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_invite_token_idx": {
+					"name": "waitlist_signup_invite_token_idx",
+					"columns": [
+						{
+							"expression": "invite_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"waitlist_signup_invite_redeemed_by_user_id_user_id_fk": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_user_id_fk",
+					"tableFrom": "waitlist_signup",
+					"tableTo": "user",
+					"columnsFrom": ["invite_redeemed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"waitlist_signup_email_unique": {
+					"name": "waitlist_signup_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				},
+				"waitlist_signup_invite_token_unique": {
+					"name": "waitlist_signup_invite_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_token"]
+				},
+				"waitlist_signup_invite_redeemed_by_user_id_unique": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_redeemed_by_user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.waitlist_status": {
+			"name": "waitlist_status",
+			"schema": "public",
+			"values": ["pending", "approved", "rejected"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
 			"when": 1785771844390,
 			"tag": "0025_damp_lionheart",
 			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1785856104918,
+			"tag": "0026_square_hemingway",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/external-api-call.ts
+++ b/packages/db/src/schema/external-api-call.ts
@@ -1,0 +1,60 @@
+import {
+	index,
+	integer,
+	jsonb,
+	pgTable,
+	serial,
+	text,
+	timestamp,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+import { pipelineRun } from "./pipeline-run";
+
+export const externalApiCall = pgTable(
+	"external_api_call",
+	{
+		id: serial("id").primaryKey(),
+
+		// userId is nullable — Spotify token-refresh calls run before a user
+		// session is fully resolved.
+		userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+		// SET NULL so audit rows survive run deletion.
+		pipelineRunId: integer("pipeline_run_id").references(() => pipelineRun.id, {
+			onDelete: "set null",
+		}),
+
+		provider: text("provider").notNull(), // 'spotify' | 'lrclib' | 'openai' | 'groq'
+		endpoint: text("endpoint").notNull(), // REST path (e.g. '/me/tracks') or model ID for AI providers
+		method: text("method").notNull().default("GET"),
+
+		// Auth headers stripped before this is ever set; large fields replaced with counts.
+		requestPayload: jsonb("request_payload").$type<Record<string, unknown>>(),
+
+		httpStatus: integer("http_status"),
+		// Capped at ~10 KB at insertion — see truncatePayload in external-api-log.ts.
+		responsePayload: jsonb("response_payload").$type<Record<string, unknown>>(),
+		durationMs: integer("duration_ms"),
+		errorMessage: text("error_message"),
+
+		// Denormalized status bucket for O(1) dashboard WHERE clauses (no CASE
+		// in every query): 'success' | 'rate_limited' | 'not_found' |
+		// 'client_error' | 'server_error' | 'error'
+		statusCategory: text("status_category").notNull(),
+
+		// 0 = first attempt, 1+ = retry number
+		retryAttempt: integer("retry_attempt").notNull().default(0),
+
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+	},
+	(table) => [
+		index("eac_user_id_idx").on(table.userId),
+		index("eac_pipeline_run_id_idx").on(table.pipelineRunId),
+		index("eac_provider_idx").on(table.provider),
+		index("eac_status_category_idx").on(table.statusCategory),
+		index("eac_created_at_idx").on(table.createdAt),
+		// compound — "spotify calls in the last 24 h"
+		index("eac_provider_created_at_idx").on(table.provider, table.createdAt),
+		// compound — "all errors for user X"
+		index("eac_user_status_idx").on(table.userId, table.statusCategory),
+	],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -2,6 +2,7 @@ export * from "./auth";
 export * from "./cluster";
 export * from "./email-send-log";
 export * from "./email-suppression";
+export * from "./external-api-call";
 export * from "./genre-domain";
 export * from "./pipeline-run";
 export * from "./playlist";

--- a/packages/orpc/src/routers/protected/tracks.ts
+++ b/packages/orpc/src/routers/protected/tracks.ts
@@ -175,7 +175,9 @@ export const tracksRouter = {
 				try {
 					const accessToken = await getUserSpotifyAccessToken(userId);
 					if (accessToken) {
-						const allPlaylists = await fetchAllUserPlaylists(accessToken);
+						const allPlaylists = await fetchAllUserPlaylists(accessToken, {
+							context: { userId },
+						});
 						spotifyPlaylists = allPlaylists
 							.filter((p) => spotifyPlaylistIds.has(p.id))
 							.map((p) => ({ id: p.id, name: p.name }));


### PR DESCRIPTION
## Summary
Closes #92, #93, #94, #95, #96 — the full observability cluster. Originally #92 (schema + shared helper) only, but #93-96 depend directly on it and are small once #92 exists, so bundled them into this same PR/branch rather than stacking 4 more PRs on top (a stacked-PR merge mistake earlier this session — see #248 — is exactly the failure mode I wanted to avoid repeating).

**#92** — `packages/db/src/schema/external-api-call.ts` (new table, 7 indexes) + `packages/common/src/services/external-api-log.ts` (`logExternalApiCall()`, fire-and-forget, denormalized `statusCategory`, 10KB payload cap). Migration `0026_square_hemingway.sql`, purely additive.

**#93-96** — instrumented every outbound call: `spotifyRequest()` (429/5xx retry paths, final error, success — plus the token-refresh fetch), `getLyricsFromLRCLib()`, OpenAI embeddings, and Groq classification via the Vercel AI SDK.

**Important**: all 4 of these issues were written against code that has since diverged, in each case non-trivially:
- Spotify: the issue predates the 5xx-retry path and empty-body handling I added earlier this session for the export-endpoint bug (#244) — reconciled against current `client.ts`, not applied blind.
- LRCLib: the issue assumed a single `/api/get` call; current code has a shared `fetchLRCLib()` helper serving both `/api/get` (exact) and `/api/search` (fuzzy fallback) — instrumented that shared chokepoint instead of duplicating logic.
- Embeddings: `embedTracksBatch()` and `embedTrackIds()` each had their own duplicated fetch+retry block — extracted a shared `fetchEmbeddingsBatch()` helper instead of instrumenting both separately.
- Groq: the real chokepoint is an inner `classifyTracksBatchOnce()` wrapped by `classifyTracksAdaptive()`, which does Groq-specific 429 handling, hard-4xx abort, and adaptive batch-splitting on retryable JSON errors — none of that existed in the issue's proposed version.

`pipelineRunId` is threaded everywhere a caller already had `runId` in scope (all 4 pipeline stage tasks + `run-organize.ts`) — not invented anywhere it wasn't already available.

⚠️ **Touches `packages/db/src/migrations/**`** — auto-triggers `pnpm db:migrate` against production on merge to `main`. Single additive `CREATE TABLE`, nothing destructive.

## Test plan
- [x] `tsc --noEmit` clean across `db`, `common`, `orpc`
- [x] `pnpm --filter @harmonia/db db:generate` — clean, additive migration (verified fully offline)
- [x] `biome check` clean (migration meta JSON formatted before commit)
- [x] Full test suite passing (90 tests, +10 new for the pure logging logic); added a db-mock fix to `client.test.ts` so the new logging call doesn't produce spurious "Failed to write" noise in existing tests
- [ ] Not verified against a live DB or real Spotify/LRCLib/OpenAI/Groq credentials — Docker/local Postgres unresponsive this session