### PR TITLE
feat(web): embed waitlist submit button inside the email input

### DIFF
--- a/apps/web/src/components/waitlist-form.tsx
+++ b/apps/web/src/components/waitlist-form.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Button, Input, Label } from "@harmonia/ui";
+import {
+	Icons,
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+	Label,
+} from "@harmonia/ui";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -35,11 +42,11 @@ export function WaitlistForm() {
 				e.preventDefault();
 				signup.mutate({ email, website });
 			}}
-			className="flex flex-col gap-4 sm:flex-row sm:items-end"
+			className="flex flex-col gap-2"
 		>
-			<div className="flex flex-1 flex-col gap-2">
-				<Label htmlFor="email">Email address</Label>
-				<Input
+			<Label htmlFor="email">Email address</Label>
+			<InputGroup>
+				<InputGroupInput
 					id="email"
 					type="email"
 					required
@@ -47,12 +54,23 @@ export function WaitlistForm() {
 					onChange={(e) => setEmail(e.target.value)}
 					placeholder="you@example.com"
 				/>
-			</div>
+				<InputGroupAddon align="inline-end">
+					<InputGroupButton
+						type="submit"
+						size="icon-sm"
+						variant="default"
+						isLoading={signup.isPending}
+						aria-label="Join waitlist"
+					>
+						<Icons.arrowRight />
+					</InputGroupButton>
+				</InputGroupAddon>
+			</InputGroup>
 
 			{/* Honeypot field: hidden from real users, only bots fill it in. */}
 			<div className="absolute h-0 w-0 overflow-hidden opacity-0">
 				<Label htmlFor="website">Website</Label>
-				<Input
+				<InputGroupInput
 					id="website"
 					name="website"
 					type="text"
@@ -63,15 +81,6 @@ export function WaitlistForm() {
 					aria-hidden="true"
 				/>
 			</div>
-
-			<Button
-				type="submit"
-				size="xl"
-				className="uppercase"
-				isLoading={signup.isPending}
-			>
-				Join Waitlist
-			</Button>
 		</form>
 	);
 }

--- a/packages/ui/src/components/shared/icons.tsx
+++ b/packages/ui/src/components/shared/icons.tsx
@@ -16,6 +16,7 @@ import {
 	IconAlertOctagon,
 	IconAlertTriangle,
 	IconArrowLeft,
+	IconArrowRight,
 	IconArrowsSort,
 	IconArrowUpRight,
 	IconBrain,
@@ -71,6 +72,7 @@ export const Icons = {
 	trash: IconTrash,
 	externalLink: IconExternalLink,
 	arrowLeft: IconArrowLeft,
+	arrowRight: IconArrowRight,
 
 	// Chevrons
 	chevronDown: IconChevronDown,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -91,6 +91,14 @@ export {
 } from "./components/ui/field";
 export { Input } from "./components/ui/input";
 export {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupButton,
+	InputGroupInput,
+	InputGroupText,
+	InputGroupTextarea,
+} from "./components/ui/input-group";
+export {
 	InsightSectionCard,
 	InsightStatCard,
 } from "./components/ui/insight-stat-card";


### PR DESCRIPTION
## Summary
- Exports `InputGroup`/`InputGroupAddon`/`InputGroupButton`/`InputGroupInput`/`InputGroupText`/`InputGroupTextarea` from `@harmonia/ui` (the component already existed in the package, just wasn't exported)
- Adds `arrowRight` to the shared `Icons` map (`IconArrowRight` from tabler)
- Rewrites `WaitlistForm` to use `InputGroup` — the submit control is now a trailing icon button inside the input's border instead of a separate button, matching shadcn's input-group pattern

Closes #256

## Test plan
- [x] `tsc --noEmit` clean for `apps/web` and `@harmonia/ui`
- [ ] Visually verify in browser (loading state, focus ring, honeypot field still hidden)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the waitlist form with a streamlined inline email entry and submission experience.
  * Added a right-arrow icon to the shared interface icon set.
  * Expanded the UI component library with reusable input-group components.
* **Style**
  * Improved the waitlist form’s loading and submission controls for a more polished interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->