### PR TITLE
chore(db): hardcode local admin seed credentials, drop env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,10 +53,6 @@ HARMONIA_BETTER_AUTH_SECRET="your-secret-key-here-generate-with-openssl"
 HARMONIA_SPOTIFY_CLIENT_ID=""
 HARMONIA_SPOTIFY_CLIENT_SECRET=""
 
-# Admin seed user (required for pnpm db:seed)
-HARMONIA_ADMIN_EMAIL="admin@harmonia.com"
-HARMONIA_ADMIN_PASSWORD=""
-
 # -----------------------------------------------------------------------------
 # AI / EMBEDDINGS (Optional)
 # -----------------------------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,15 +51,12 @@ pnpm dev:web        # web app only
 ### Admin dashboard (local)
 
 ```bash
-# In .env — required for db:seed
-HARMONIA_ADMIN_PASSWORD="changeme123!"
-
 pnpm db:push
-pnpm db:seed        # creates admin@harmonia.com (override with HARMONIA_ADMIN_EMAIL)
+pnpm db:seed        # creates admin@harmonia.com / changeme123!
 pnpm dev:ada        # API + dashboard + admin
 ```
 
-Open [http://127.0.0.1:3004/login](http://127.0.0.1:3004/login). Admin auth uses `/api/admin-auth` and is **separate** from dashboard Spotify sessions.
+Open [http://127.0.0.1:3004/login](http://127.0.0.1:3004/login) and sign in with `admin@harmonia.com` / `changeme123!`. Admin auth uses `/api/admin-auth` and is **separate** from dashboard Spotify sessions.
 
 ### Quality checks
 

--- a/README.md
+++ b/README.md
@@ -96,17 +96,17 @@ Returning approved users sign in at dashboard `/login` without an invite link.
 ## Admin dashboard (local)
 
 ```bash
-# Add to .env:
-HARMONIA_ADMIN_PASSWORD="changeme123!"
-
 pnpm db:push
-pnpm db:seed              # admin@harmonia.com (override: HARMONIA_ADMIN_EMAIL)
+pnpm db:seed              # seeds the admin user below
 pnpm dev:admin            # admin only (port 3004) — needs API on :3002
 # or
 pnpm dev:ada              # API + dashboard + admin (ports 3002/3003/3004)
 ```
 
-Open [http://127.0.0.1:3004/login](http://127.0.0.1:3004/login).
+Open [http://127.0.0.1:3004/login](http://127.0.0.1:3004/login) and sign in with:
+
+- Email: `admin@harmonia.com`
+- Password: `changeme123!`
 
 | Page | Purpose |
 |------|---------|
@@ -129,7 +129,6 @@ pnpm check                # Biome
 All variables are prefixed `HARMONIA_` (server) or `NEXT_PUBLIC_HARMONIA_` (client). Copy `.env.example` and fill in:
 
 - `HARMONIA_DATABASE_URL` — local: `postgresql://postgres:password@localhost:5433/harmonia`
-- `HARMONIA_ADMIN_PASSWORD` — required for `pnpm db:seed`
 - `HARMONIA_SPOTIFY_CLIENT_ID` / `HARMONIA_SPOTIFY_CLIENT_SECRET` — Spotify Developer Dashboard
 - `HARMONIA_RESEND_API_KEY` / `HARMONIA_EMAIL_FROM` — waitlist emails
 - `HARMONIA_OPENAI_API_KEY` — embeddings

--- a/packages/db/scripts/seed-admin.ts
+++ b/packages/db/scripts/seed-admin.ts
@@ -12,16 +12,10 @@ const { db } = await import("@harmonia/db");
 const { user, account } = await import("@harmonia/db/schema/auth");
 const { eq } = await import("drizzle-orm");
 
-const ADMIN_EMAIL = process.env.HARMONIA_ADMIN_EMAIL ?? "admin@harmonia.com";
-const ADMIN_PASSWORD = process.env.HARMONIA_ADMIN_PASSWORD;
+// Local dev seed only — see README's "Admin dashboard (local)" section.
+const ADMIN_EMAIL = "admin@harmonia.com";
+const ADMIN_PASSWORD = "changeme123!";
 const ADMIN_NAME = "Harmonia Admin";
-
-if (!ADMIN_PASSWORD) {
-	console.error(
-		"HARMONIA_ADMIN_PASSWORD is not set — refusing to seed an admin user with no password.",
-	);
-	process.exit(1);
-}
 
 // Same algorithm as @better-auth/utils/password (node export condition)
 async function hashPassword(password: string): Promise<string> {


### PR DESCRIPTION
## Summary
- `packages/db/scripts/seed-admin.ts` no longer reads `HARMONIA_ADMIN_PASSWORD` / `HARMONIA_ADMIN_EMAIL` from the environment — both are now fixed constants (`admin@harmonia.com` / `changeme123!`)
- Removed both vars from `.env.example`
- Updated `README.md` and `CONTRIBUTING.md` to document the credentials directly instead of pointing at env config

This is local-only dev tooling (seeds the admin user for the internal admin app at `:3004`) — not a production secret, so gating it behind required env vars was friction without benefit.

Closes #257

## Test plan
- [ ] `pnpm db:seed` against a local DB creates `admin@harmonia.com`, sign in at `:3004/login` with `changeme123!`