### PR TITLE
fix(env): alias TRIGGER_SECRET_KEY at request runtime, not just build

### DIFF
--- a/apps/api/instrumentation.ts
+++ b/apps/api/instrumentation.ts
@@ -1,7 +1,16 @@
 import { apiEnv } from "@harmonia/env/presets/api";
 import { registerTracing } from "@harmonia/tracing";
+import { configure as configureTrigger } from "@trigger.dev/sdk";
 
 export function register() {
+	// @trigger.dev/sdk defaults to reading process.env.TRIGGER_SECRET_KEY, but
+	// this repo prefixes every third-party secret with HARMONIA_ — point the
+	// SDK at the real value directly instead of relying on an unprefixed env
+	// var that's never actually set in Vercel's runtime.
+	if (apiEnv.HARMONIA_TRIGGER_SECRET_KEY) {
+		configureTrigger({ accessToken: apiEnv.HARMONIA_TRIGGER_SECRET_KEY });
+	}
+
 	if (apiEnv.HARMONIA_OTEL_SERVICE_NAME) {
 		registerTracing({
 			serviceName: apiEnv.HARMONIA_OTEL_SERVICE_NAME ?? "harmonia-api",

--- a/packages/env/src/presets/api.ts
+++ b/packages/env/src/presets/api.ts
@@ -32,16 +32,3 @@ export const apiEnv = createEnv({
 		process.env.SKIP_ENV_VALIDATION === "true" ||
 		process.env.NODE_ENV === "test",
 });
-
-// @trigger.dev/sdk reads process.env.TRIGGER_SECRET_KEY / TRIGGER_PROJECT_REF
-// directly (its own unprefixed convention). scripts/with-root-env.mjs does
-// this same aliasing for local dev and build, but only as a shell wrapper —
-// Vercel's serverless runtime invokes the compiled function directly per
-// request, never through that wrapper, so it's done here instead where every
-// request path is guaranteed to import apiEnv before handling anything.
-if (!process.env.TRIGGER_SECRET_KEY && apiEnv.HARMONIA_TRIGGER_SECRET_KEY) {
-	process.env.TRIGGER_SECRET_KEY = apiEnv.HARMONIA_TRIGGER_SECRET_KEY;
-}
-if (!process.env.TRIGGER_PROJECT_REF && apiEnv.HARMONIA_TRIGGER_PROJECT_REF) {
-	process.env.TRIGGER_PROJECT_REF = apiEnv.HARMONIA_TRIGGER_PROJECT_REF;
-}

--- a/packages/env/src/presets/api.ts
+++ b/packages/env/src/presets/api.ts
@@ -32,3 +32,16 @@ export const apiEnv = createEnv({
 		process.env.SKIP_ENV_VALIDATION === "true" ||
 		process.env.NODE_ENV === "test",
 });
+
+// @trigger.dev/sdk reads process.env.TRIGGER_SECRET_KEY / TRIGGER_PROJECT_REF
+// directly (its own unprefixed convention). scripts/with-root-env.mjs does
+// this same aliasing for local dev and build, but only as a shell wrapper —
+// Vercel's serverless runtime invokes the compiled function directly per
+// request, never through that wrapper, so it's done here instead where every
+// request path is guaranteed to import apiEnv before handling anything.
+if (!process.env.TRIGGER_SECRET_KEY && apiEnv.HARMONIA_TRIGGER_SECRET_KEY) {
+	process.env.TRIGGER_SECRET_KEY = apiEnv.HARMONIA_TRIGGER_SECRET_KEY;
+}
+if (!process.env.TRIGGER_PROJECT_REF && apiEnv.HARMONIA_TRIGGER_PROJECT_REF) {
+	process.env.TRIGGER_PROJECT_REF = apiEnv.HARMONIA_TRIGGER_PROJECT_REF;
+}


### PR DESCRIPTION
## Summary

Production runtime logs on `harmonia-api` showed every `.trigger()` call failing:

```
ApiClientMissingError: You need to set the TRIGGER_SECRET_KEY environment variable.
```

This repo prefixes every third-party secret with `HARMONIA_` — the configured var is `HARMONIA_TRIGGER_SECRET_KEY`, but `@trigger.dev/sdk` reads the unprefixed `process.env.TRIGGER_SECRET_KEY` by default. `scripts/with-root-env.mjs` already aliases between the two, but only as a shell wrapper around `dev`/`build`/`start` — that works locally and for a traditional `next start` process, but not on Vercel, where the serverless runtime invokes the compiled function directly per request, never through that wrapper.

Rather than fighting `process.env` aliasing across every possible runtime, this uses the SDK's own supported mechanism instead: `configure({ accessToken })` from `@trigger.dev/sdk`, points it at `apiEnv.HARMONIA_TRIGGER_SECRET_KEY` directly. Called once in `apps/api/instrumentation.ts`'s `register()` — Next.js already runs this exactly once per cold start, before any request handling, regardless of which route ends up being hit (`/api/auth`, `/api/admin-auth`, `/api/rpc/*`, `/api/webhooks/*`). No env var indirection, no dependency on import order between route files.

Closes #266

## Test plan
- [x] `tsc --noEmit` clean for `apps/api` and `@harmonia/env`
- [ ] No existing test infra in `packages/env`/this instrumentation file — didn't add one for this
- [ ] Confirm in production after merge: waitlist signup should trigger the confirmation email without `ApiClientMissingError`