### PR TITLE
fix(web): swap the waitlist button's icon instead of stacking spinner + arrow

### DIFF
--- a/apps/web/src/components/waitlist-form.tsx
+++ b/apps/web/src/components/waitlist-form.tsx
@@ -59,10 +59,14 @@ export function WaitlistForm() {
 						type="submit"
 						size="icon-sm"
 						variant="default"
-						isLoading={signup.isPending}
+						disabled={signup.isPending}
 						aria-label="Join waitlist"
 					>
-						<Icons.arrowRight />
+						{signup.isPending ? (
+							<Icons.spinner className="animate-spin" />
+						) : (
+							<Icons.arrowRight />
+						)}
 					</InputGroupButton>
 				</InputGroupAddon>
 			</InputGroup>


### PR DESCRIPTION
## Summary

`Button`'s `isLoading` prop prepends the spinner before its children rather than replacing them — correct for text buttons, but the waitlist submit control (#256) is icon-only (just an arrow), so during loading both the spinner and the arrow rendered side by side.

This exact tradeoff was already hit in PR #250 ("migrate remaining hand-rolled spinner to Button isLoading"), which deliberately excluded two other icon-only buttons from that migration for the same reason, rather than changing `Button`'s shared prepend behavior and regressing the ~15 text-button call sites that depend on it.

Fixed the same way those buttons already handle it (e.g. `dashboard-playlists-page-header.tsx`): manual `disabled` + a ternary between `Icons.spinner` and the real icon, instead of `isLoading`.

Closes #267

## Test plan
- [x] `tsc --noEmit` clean for `web`
- [ ] Wasn't able to get a live browser confirmation this session (Chrome extension connectivity issue) — the fix mirrors an already-shipped, working pattern exactly, but worth a quick manual click-through before merging