### PR TITLE
fix(brain): recognize Groq's schema-validation error as split-retryable

### DIFF
--- a/packages/common/src/services/brain/__tests__/llml.test.ts
+++ b/packages/common/src/services/brain/__tests__/llml.test.ts
@@ -1,0 +1,41 @@
+import { AbortError } from "p-retry";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@harmonia/db", () => ({ db: {} }));
+
+import { isSplitRetryableError } from "../llml";
+
+describe("isSplitRetryableError", () => {
+	it("recognizes Groq's schema-validation rejection (additionalProperties variant)", () => {
+		const err = new Error(
+			"Generated JSON does not match the expected schema. Please adjust your prompt. See 'failed_generation' for more details. Error: jsonschema: '' does not validate with /additionalProperties: additionalProperties '$schema', 'additionalProperties', 'properties', 'required', 'type' not allowed",
+		);
+		expect(isSplitRetryableError(err)).toBe(true);
+	});
+
+	it("recognizes Groq's schema-validation rejection (missing required property variant)", () => {
+		const err = new Error(
+			"Generated JSON does not match the expected schema. Please adjust your prompt. See 'failed_generation' for more details. Error: jsonschema: '' does not validate with /required: missing properties: 'results'",
+		);
+		expect(isSplitRetryableError(err)).toBe(true);
+	});
+
+	it("unwraps an AbortError to check its original error", () => {
+		const original = new Error(
+			"Generated JSON does not match the expected schema.",
+		);
+		const aborted = new AbortError(original);
+		expect(isSplitRetryableError(aborted)).toBe(true);
+	});
+
+	it("still recognizes the pre-existing message patterns", () => {
+		expect(isSplitRetryableError(new Error("Failed to validate JSON"))).toBe(
+			true,
+		);
+		expect(isSplitRetryableError(new Error("No output generated"))).toBe(true);
+	});
+
+	it("does not treat an unrelated error as split-retryable", () => {
+		expect(isSplitRetryableError(new Error("network timeout"))).toBe(false);
+	});
+});

--- a/packages/common/src/services/brain/llml.ts
+++ b/packages/common/src/services/brain/llml.ts
@@ -58,7 +58,7 @@ function buildClassificationPrompt(tracks: TrackForClassification[]): string {
 	});
 }
 
-function isSplitRetryableError(err: unknown): boolean {
+export function isSplitRetryableError(err: unknown): boolean {
 	const cause =
 		err instanceof AbortError && err.originalError != null
 			? err.originalError
@@ -68,7 +68,11 @@ function isSplitRetryableError(err: unknown): boolean {
 	const message = cause instanceof Error ? cause.message : String(cause);
 	return (
 		message.includes("Failed to validate JSON") ||
-		message.includes("No output generated")
+		message.includes("No output generated") ||
+		// Groq's structured-output rejection (surfaces as a 4xx APICallError,
+		// not NoObjectGeneratedError) — e.g. "Generated JSON does not match
+		// the expected schema... jsonschema: '' does not validate with ...".
+		message.includes("does not match the expected schema")
 	);
 }
 


### PR DESCRIPTION
## Summary

Production pipeline runs completed in a degraded state (\"no playlists were generated despite classified tracks\") with repeated Trigger.dev errors: `Generated JSON does not match the expected schema...`.

**Ruled out first**: tested directly against real Groq with the exact schema/model/SDK versions currently installed and a realistic 6-track batch — 5/5 clean successes. Not a deterministic schema-conversion bug; the model occasionally emits non-conforming output for specific input data.

**The real bug**: `isSplitRetryableError()` in `packages/common/src/services/brain/llml.ts` — the check that decides whether a failed classify batch gets split in half and retried — only matched two message substrings (`"Failed to validate JSON"`, `"No output generated"`) and a `NoObjectGeneratedError` instance check. Groq's actual rejection text matches none of those (it surfaces as a 4xx `APICallError`, converted to `AbortError` before reaching this check), so this real failure mode skipped the split-and-retry recovery path entirely and just dropped the batch's tracks.

## Fix

Added a message match for Groq's schema-validation error prefix. Exported `isSplitRetryableError` for direct testing.

Closes #272

## Test plan
- [x] `tsc --noEmit` clean for `@harmonia/common`
- [x] 5 new unit tests covering both observed Groq error variants, the `AbortError`-wrapped case, and that pre-existing message patterns still match
- [x] Full `@harmonia/common` suite passes (95/95)
- [x] Reproduced against real Groq API to rule out a schema/SDK-level bug before concluding this was the actual root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured-output validation errors so eligible AI responses can be retried automatically.
  * Preserved retry behavior for invalid JSON, missing output, and other recognized transient errors.

* **Tests**
  * Added coverage for schema validation failures, missing required properties, abort errors, retryable messages, and unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->