### PR TITLE
chore(ui): shadcn compliance sweep — replace raw buttons, document toast exception

### DIFF
--- a/apps/admin/src/components/layout/admin-sidebar.tsx
+++ b/apps/admin/src/components/layout/admin-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { ADMIN_NAV_ITEMS } from "@harmonia/common/utils/routes";
 import {
+	Button,
 	Icons,
 	ModeToggle,
 	Sidebar,
@@ -82,14 +83,16 @@ export function AdminSidebar() {
 			<SidebarFooter>
 				<div className="flex items-center justify-between px-2 py-1">
 					<ModeToggle variant="immediate" />
-					<button
+					<Button
 						type="button"
+						variant="ghost"
+						size="xs"
 						onClick={handleSignOut}
-						className="flex items-center gap-1.5 text-muted-foreground text-xs transition-colors hover:text-foreground"
+						className="h-auto gap-1.5 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
 					>
 						<Icons.logout className="size-3.5" />
 						Sign out
-					</button>
+					</Button>
 				</div>
 			</SidebarFooter>
 		</Sidebar>

--- a/apps/admin/src/shared/api/orpc.tsx
+++ b/apps/admin/src/shared/api/orpc.tsx
@@ -13,6 +13,10 @@ export const queryClient = new QueryClient({
 			const message = error.message;
 			const fullText = `Error: ${message}`;
 			toast.error(fullText, {
+				// Raw <button> is deliberate here, not a missed shadcn conversion —
+				// these render inside a Sonner toast's compact action slot, where
+				// Button's base classes (border, rounded-none, focus ring) fight
+				// the toast's own minimal layout for no real benefit.
 				action: (
 					<div className="flex gap-1">
 						<button

--- a/apps/dashboard/src/components/app/dashboard-settings-section.tsx
+++ b/apps/dashboard/src/components/app/dashboard-settings-section.tsx
@@ -1,4 +1,4 @@
-import { Icons, Separator } from "@harmonia/ui";
+import { Button, Icons, Separator } from "@harmonia/ui";
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
@@ -49,10 +49,11 @@ export function DashboardSettingsNavRow({
 	onClick: () => void;
 }) {
 	return (
-		<button
+		<Button
 			type="button"
+			variant="ghost"
 			onClick={onClick}
-			className="flex w-full items-center justify-between border-b py-4 transition-colors last:border-b-0 hover:bg-muted/40"
+			className="h-auto w-full justify-between rounded-none border-b py-4 last:border-b-0 hover:bg-muted/40"
 		>
 			<div className="text-left">
 				<p className="font-medium text-sm">{label}</p>
@@ -61,7 +62,7 @@ export function DashboardSettingsNavRow({
 				)}
 			</div>
 			<Icons.chevronRight className="size-4 shrink-0 text-muted-foreground" />
-		</button>
+		</Button>
 	);
 }
 

--- a/apps/dashboard/src/shared/api/orpc.tsx
+++ b/apps/dashboard/src/shared/api/orpc.tsx
@@ -16,6 +16,10 @@ export const queryClient = new QueryClient({
 			const message = error.message;
 			const fullText = `Error: ${message}`;
 			toast.error(fullText, {
+				// Raw <button> is deliberate here, not a missed shadcn conversion —
+				// these render inside a Sonner toast's compact action slot, where
+				// Button's base classes (border, rounded-none, focus ring) fight
+				// the toast's own minimal layout for no real benefit.
 				action: (
 					<div className="flex gap-1">
 						<button

--- a/apps/web/src/utils/orpc.tsx
+++ b/apps/web/src/utils/orpc.tsx
@@ -10,6 +10,10 @@ export const queryClient = new QueryClient({
 			const message = error.message;
 			const fullText = `Error: ${message}`;
 			toast.error(fullText, {
+				// Raw <button> is deliberate here, not a missed shadcn conversion —
+				// these render inside a Sonner toast's compact action slot, where
+				// Button's base classes (border, rounded-none, focus ring) fight
+				// the toast's own minimal layout for no real benefit.
 				action: (
 					<div className="flex gap-1">
 						<button


### PR DESCRIPTION
## Summary

Went through #150's checklist against actual current code:

**Fixed (genuine violations):**
- `DashboardSettingsNavRow`'s raw `<button>` → `Button variant="ghost"`
- Admin sidebar's sign-out raw `<button>` → `Button variant="ghost" size="xs"`

**Already done, just undocumented:**
- `TooltipProvider` — already wrapped once in the shared `Providers` component (`packages/ui/src/components/providers/providers.tsx`), used by all three apps via their own `app-providers.tsx`. The issue's claim it was missing everywhere was stale.
- Destructive confirmations already use `AlertDialog`, not `Dialog` — verified via account deletion in `apps/dashboard/settings/page.tsx`.

**Deliberate exception, now documented inline (not fixed):**
- The `orpc.tsx` toast Copy/Retry buttons (identical across dashboard/admin/web) render inside a Sonner toast's compact `action` slot — `Button`'s base classes (border, rounded-none, focus ring) fight the toast's minimal layout for no real benefit. Added a one-line comment explaining this rather than converting.

Closes #150

## Test plan
- [x] `tsc --noEmit` clean for `dashboard`, `admin`, `web`