### PR TITLE
ci(trigger): auto-deploy Trigger.dev tasks on merge to main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,11 @@ HARMONIA_TRIGGER_PROJECT_REF=""
 # Set to true to skip the Trigger.dev worker when the project ref is unset (API/dashboard/web still run; background jobs won’t)
 # HARMONIA_TRIGGER_DEV_SKIP="true"
 
+# Personal Access Token for `pnpm deploy:trigger` (pushes task code to Trigger.dev's infra).
+# Different credential from HARMONIA_TRIGGER_SECRET_KEY above — generate from your
+# Trigger.dev profile -> Personal Access Tokens, not the project's API Keys page.
+# HARMONIA_TRIGGER_ACCESS_TOKEN=""
+
 # -----------------------------------------------------------------------------
 # OBSERVABILITY (OpenTelemetry)
 # -----------------------------------------------------------------------------

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,45 @@
+# Trigger.dev deploy workflow
+# Pushes task code to Trigger.dev's own infrastructure when trigger-related
+# files change on main — separate from the Vercel deploy of the Next.js apps.
+#
+# Required secrets:
+#   TRIGGER_ACCESS_TOKEN        - Personal Access Token (Trigger.dev profile -> Personal Access Tokens).
+#                                  NOT the project API key (HARMONIA_TRIGGER_SECRET_KEY) — deploy needs
+#                                  account-level auth, not an environment-scoped runtime key.
+#   HARMONIA_TRIGGER_PROJECT_REF - Trigger.dev prod project ref (Project -> Settings).
+#   Add both in: GitHub repo → Settings → Secrets and variables → Actions.
+
+name: Trigger.dev Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/common/src/trigger/**"
+      - "apps/api/trigger.config.ts"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Trigger.dev tasks
+        env:
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
+          HARMONIA_TRIGGER_PROJECT_REF: ${{ secrets.HARMONIA_TRIGGER_PROJECT_REF }}
+        run: pnpm deploy:trigger

--- a/scripts/deploy-trigger.mjs
+++ b/scripts/deploy-trigger.mjs
@@ -10,8 +10,13 @@ config({ path: path.resolve(root, ".env") });
 const env = { ...process.env };
 // The Trigger.dev CLI reads TRIGGER_* vars; the repo standardises on the
 // HARMONIA_TRIGGER_* namespace, so map them across (mirrors run-trigger-dev.mjs).
-if (!env.TRIGGER_SECRET_KEY && env.HARMONIA_TRIGGER_SECRET_KEY) {
-	env.TRIGGER_SECRET_KEY = env.HARMONIA_TRIGGER_SECRET_KEY;
+//
+// `deploy` specifically authenticates via a Personal Access Token
+// (TRIGGER_ACCESS_TOKEN) — NOT the environment API key (TRIGGER_SECRET_KEY)
+// that `dev`/the SDK's configure() use at runtime. These are two different
+// credentials; see https://trigger.dev/docs/github-actions.
+if (!env.TRIGGER_ACCESS_TOKEN && env.HARMONIA_TRIGGER_ACCESS_TOKEN) {
+	env.TRIGGER_ACCESS_TOKEN = env.HARMONIA_TRIGGER_ACCESS_TOKEN;
 }
 if (!env.TRIGGER_PROJECT_REF && env.HARMONIA_TRIGGER_PROJECT_REF) {
 	env.TRIGGER_PROJECT_REF = env.HARMONIA_TRIGGER_PROJECT_REF;
@@ -25,9 +30,9 @@ if (!projectRef) {
 	process.exit(1);
 }
 
-if (!env.TRIGGER_SECRET_KEY) {
+if (!env.TRIGGER_ACCESS_TOKEN) {
 	console.error(
-		"Missing Trigger secret key: set TRIGGER_SECRET_KEY (or HARMONIA_TRIGGER_SECRET_KEY) to deploy.",
+		"Missing Trigger access token: set TRIGGER_ACCESS_TOKEN (or HARMONIA_TRIGGER_ACCESS_TOKEN) — a Personal Access Token from your Trigger.dev profile, not the environment secret key — to deploy.",
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/trigger-deploy.yml`, modeled directly on `drizzle-migrate.yml`: runs `pnpm deploy:trigger` on push to `main`, scoped to `packages/common/src/trigger/**` and `apps/api/trigger.config.ts` so unrelated changes don't trigger a redeploy.
- Fixes a real bug in `scripts/deploy-trigger.mjs` found while wiring this up.

## The env-var correction (worth reading before merging)

The issue proposed `HARMONIA_TRIGGER_SECRET_KEY` as the CI secret. I checked Trigger.dev's own docs (https://trigger.dev/docs/github-actions) before wiring that up, and that's the wrong credential:

- `TRIGGER_SECRET_KEY` — an environment-scoped **API key**, used by the SDK/`trigger dev` at runtime (this is what `apps/api/instrumentation.ts` already uses via `configure({ accessToken: ... })`).
- `TRIGGER_ACCESS_TOKEN` — an account-level **Personal Access Token**, which is what `trigger deploy` actually authenticates with in CI. Different credential, different privilege level.

`scripts/deploy-trigger.mjs` (added earlier for the manual `pnpm deploy:trigger` path) was validating `TRIGGER_SECRET_KEY`, not `TRIGGER_ACCESS_TOKEN`. It "worked" locally anyway because the Trigger.dev CLI falls back to a cached interactive `trigger login` session when no env var is set — so the check never actually got exercised. In CI there's no interactive login, so this would have failed non-obviously (or worse, silently done nothing useful) if shipped as originally proposed. Fixed the script to check the right variable, with a comment explaining the distinction so it doesn't regress.

## Action needed before this can run
Two new repo secrets (Settings → Secrets and variables → Actions):
- `TRIGGER_ACCESS_TOKEN` — generate from your Trigger.dev profile → Personal Access Tokens (**not** the project's API Keys page)
- `HARMONIA_TRIGGER_PROJECT_REF` — from Trigger.dev project → Settings

I can't generate the PAT myself (requires your Trigger.dev account), so this is a manual step. Workflow also has `workflow_dispatch` for a manual test run once the secrets are in place.

## Test plan
- [x] Workflow structure mirrors the already-working `drizzle-migrate.yml`
- [x] `biome check` clean on changed files
- [ ] Manual: add the two secrets, push a trigger-path change (or `workflow_dispatch`), confirm the deploy step succeeds and the run shows up in Trigger.dev's dashboard