### PR TITLE
feat(dashboard): artist avatar images on /tracks/[id]

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-track-detail.tsx
+++ b/apps/dashboard/src/components/app/dashboard-track-detail.tsx
@@ -125,9 +125,23 @@ export function DashboardTrackDetail({ track }: { track: TrackGetByIdOutput }) {
 						<p className="inline-flex flex-wrap items-center gap-1 text-muted-foreground">
 							{artists.map((name, index) => {
 								const artistId = track.artistIds?.[index];
+								const imageUrl = track.artistImageUrls?.[index];
 								return (
-									<span key={`${name}-${index}`}>
+									<span
+										key={`${name}-${index}`}
+										className="inline-flex items-center gap-1"
+									>
 										{index > 0 ? ", " : ""}
+										{imageUrl ? (
+											<Image
+												src={imageUrl}
+												alt=""
+												width={16}
+												height={16}
+												className="size-4 shrink-0 rounded-full"
+												unoptimized
+											/>
+										) : null}
 										{artistId ? (
 											<a
 												href={`https://open.spotify.com/artist/${artistId}`}

--- a/packages/common/src/schemas/spotify/api-types.ts
+++ b/packages/common/src/schemas/spotify/api-types.ts
@@ -43,3 +43,13 @@ export type SpotifyCreatePlaylistResponse = {
 	id: string;
 	external_urls: { spotify: string };
 };
+
+export type SpotifyArtistSimplified = {
+	id: string;
+	name: string;
+	images?: Array<{ url: string }>;
+} | null; // Spotify returns null in the array for an ID it couldn't resolve
+
+export type SpotifyArtistsResponse = {
+	artists: SpotifyArtistSimplified[];
+};

--- a/packages/common/src/schemas/track/output.ts
+++ b/packages/common/src/schemas/track/output.ts
@@ -99,5 +99,7 @@ export const trackGetByIdOutputSchema = z.object({
 	harmoniaPlaylists: z.array(z.object({ id: z.number(), name: z.string() })),
 	/** The user's own Spotify playlists (any, not just Harmonia's) that currently contain this track. */
 	spotifyPlaylists: z.array(z.object({ id: z.string(), name: z.string() })),
+	/** Parallel to artistIds, same order — null where the image isn't cached yet. */
+	artistImageUrls: z.array(z.string().nullable()),
 });
 export type TrackGetByIdOutput = z.infer<typeof trackGetByIdOutputSchema>;

--- a/packages/common/src/services/music/index.ts
+++ b/packages/common/src/services/music/index.ts
@@ -2,6 +2,7 @@ export {
 	fetchLyricsForPendingTracks,
 	fetchLyricsForTrackIds,
 } from "./lyrics/fetch-lyrics";
+export { fetchAndCacheArtistImages } from "./spotify/artist-images";
 export { autoExportUpdatedPlaylists } from "./spotify/auto-export";
 export {
 	fetchAllUserPlaylists,

--- a/packages/common/src/services/music/spotify/artist-images.ts
+++ b/packages/common/src/services/music/spotify/artist-images.ts
@@ -1,0 +1,74 @@
+import { conflictValue, db } from "@harmonia/db";
+import { artist } from "@harmonia/db/schema/artist";
+import { track, userTracks } from "@harmonia/db/schema/track";
+import { logger } from "@harmonia/logger";
+import { eq, inArray } from "drizzle-orm";
+
+import { fetchArtistsByIds, getUserSpotifyAccessToken } from "./client";
+
+// No fan-out/worker split needed here (unlike lyrics/classify/embed) — a
+// batch of 50 artist IDs is a single Spotify request, so even a library with
+// a couple thousand unique artists is a few dozen sequential calls.
+export async function fetchAndCacheArtistImages(
+	userId: string,
+	pipelineRunId?: number,
+): Promise<{ fetched: number }> {
+	const userTrackRows = await db
+		.select({ artistIds: track.artistIds })
+		.from(userTracks)
+		.innerJoin(track, eq(track.id, userTracks.trackId))
+		.where(eq(userTracks.userId, userId));
+
+	const allArtistIds = new Set<string>();
+	for (const row of userTrackRows) {
+		for (const id of row.artistIds ?? []) {
+			if (id) allArtistIds.add(id);
+		}
+	}
+	if (allArtistIds.size === 0) return { fetched: 0 };
+
+	const cachedRows = await db
+		.select({ id: artist.id })
+		.from(artist)
+		.where(inArray(artist.id, [...allArtistIds]));
+	const cachedIds = new Set(cachedRows.map((r) => r.id));
+	const missingIds = [...allArtistIds].filter((id) => !cachedIds.has(id));
+
+	if (missingIds.length === 0) return { fetched: 0 };
+
+	const accessToken = await getUserSpotifyAccessToken(userId);
+	if (!accessToken) {
+		logger.warn(
+			{ userId },
+			"No Spotify access token; skipping artist image fetch",
+		);
+		return { fetched: 0 };
+	}
+
+	const artists = await fetchArtistsByIds(accessToken, missingIds, {
+		userId,
+		pipelineRunId,
+	});
+	if (artists.length === 0) return { fetched: 0 };
+
+	await db
+		.insert(artist)
+		.values(
+			artists.map((a) => ({ id: a.id, name: a.name, imageUrl: a.imageUrl })),
+		)
+		.onConflictDoUpdate({
+			target: artist.id,
+			set: {
+				name: conflictValue(artist.name),
+				imageUrl: conflictValue(artist.imageUrl),
+				fetchedAt: conflictValue(artist.fetchedAt),
+			},
+		});
+
+	logger.info(
+		{ userId, requested: missingIds.length, fetched: artists.length },
+		"Cached artist images",
+	);
+
+	return { fetched: artists.length };
+}

--- a/packages/common/src/services/music/spotify/artist-images.ts
+++ b/packages/common/src/services/music/spotify/artist-images.ts
@@ -6,9 +6,7 @@ import { eq, inArray } from "drizzle-orm";
 
 import { fetchArtistsByIds, getUserSpotifyAccessToken } from "./client";
 
-// No fan-out/worker split needed here (unlike lyrics/classify/embed) — a
-// batch of 50 artist IDs is a single Spotify request, so even a library with
-// a couple thousand unique artists is a few dozen sequential calls.
+// No fan-out/worker split needed — a batch of 50 artist IDs is one Spotify request.
 export async function fetchAndCacheArtistImages(
 	userId: string,
 	pipelineRunId?: number,

--- a/packages/common/src/services/music/spotify/client.ts
+++ b/packages/common/src/services/music/spotify/client.ts
@@ -1,4 +1,5 @@
 import type {
+	SpotifyArtistsResponse,
 	SpotifyPlaylistSimplified,
 	SpotifyPlaylistsResponse,
 	SpotifyPlaylistTrackItem,
@@ -463,4 +464,34 @@ export async function fetchAllPlaylistTracks(
 	context?: SpotifyCallContext,
 ): Promise<SpotifyPlaylistTrackItem[]> {
 	return fetchPlaylistItems(accessToken, playlistId, { context });
+}
+
+const ARTISTS_BATCH_SIZE = 50; // GET /artists max ids per request
+
+export async function fetchArtistsByIds(
+	accessToken: string,
+	artistIds: string[],
+	context: SpotifyCallContext = {},
+): Promise<Array<{ id: string; name: string; imageUrl: string | null }>> {
+	const results: Array<{ id: string; name: string; imageUrl: string | null }> =
+		[];
+
+	for (let i = 0; i < artistIds.length; i += ARTISTS_BATCH_SIZE) {
+		const batch = artistIds.slice(i, i + ARTISTS_BATCH_SIZE);
+		const page = await spotifyGet<SpotifyArtistsResponse>(
+			`/artists?ids=${batch.join(",")}`,
+			accessToken,
+			context,
+		);
+		for (const a of page.artists) {
+			if (!a) continue;
+			results.push({
+				id: a.id,
+				name: a.name,
+				imageUrl: a.images?.[0]?.url ?? null,
+			});
+		}
+	}
+
+	return results;
 }

--- a/packages/common/src/trigger/tasks/organize.ts
+++ b/packages/common/src/trigger/tasks/organize.ts
@@ -7,6 +7,7 @@ import {
 
 import { PipelineCancelledError, updateRun } from "../../services/organize";
 import { sendOrganizeCompleteEmailTask } from "./emails/send-organize-complete";
+import { artistsStageTask } from "./stages/artists";
 import { classifyStageTask } from "./stages/classify";
 import { clusterStageTask } from "./stages/cluster";
 import { embedStageTask } from "./stages/embed";
@@ -108,6 +109,25 @@ export const organizePipeline = task({
 			await updateRun(runId, { status: "running", startedAt: new Date() });
 
 			const syncRun = await syncStageTask.triggerAndWait({ userId, runId });
+
+			try {
+				// Cosmetic enrichment for the track detail page — fire-and-forget,
+				// doesn't gate pipeline success/failure or the rest of the run.
+				await artistsStageTask.trigger({ userId, runId });
+			} catch (artistsErr) {
+				logger.warn(
+					{
+						userId,
+						runId,
+						error:
+							artistsErr instanceof Error
+								? artistsErr.message
+								: String(artistsErr),
+					},
+					"Failed to queue artist image fetch task",
+				);
+			}
+
 			const lyricsRun = await lyricsStageTask.triggerAndWait({
 				userId,
 				runId,

--- a/packages/common/src/trigger/tasks/organize.ts
+++ b/packages/common/src/trigger/tasks/organize.ts
@@ -111,8 +111,7 @@ export const organizePipeline = task({
 			const syncRun = await syncStageTask.triggerAndWait({ userId, runId });
 
 			try {
-				// Cosmetic enrichment for the track detail page — fire-and-forget,
-				// doesn't gate pipeline success/failure or the rest of the run.
+				// Cosmetic enrichment — fire-and-forget, doesn't gate the run's outcome.
 				await artistsStageTask.trigger({ userId, runId });
 			} catch (artistsErr) {
 				logger.warn(

--- a/packages/common/src/trigger/tasks/stages/artists.ts
+++ b/packages/common/src/trigger/tasks/stages/artists.ts
@@ -1,0 +1,13 @@
+import { task } from "@trigger.dev/sdk";
+
+import { fetchAndCacheArtistImages } from "../../../services/music";
+import { checkCancelled } from "../../../services/organize";
+
+export const artistsStageTask = task({
+	id: "organize-stage-artists",
+	retry: { maxAttempts: 2, minTimeoutInMs: 2000, factor: 2 },
+	run: async ({ userId, runId }: { userId: string; runId: number }) => {
+		await checkCancelled(runId, userId);
+		return await fetchAndCacheArtistImages(userId, runId);
+	},
+});

--- a/packages/db/src/migrations/0028_silky_puck.sql
+++ b/packages/db/src/migrations/0028_silky_puck.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "artist" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"image_url" text,
+	"fetched_at" timestamp DEFAULT now() NOT NULL
+);

--- a/packages/db/src/migrations/meta/0028_snapshot.json
+++ b/packages/db/src/migrations/meta/0028_snapshot.json
@@ -1,0 +1,2743 @@
+{
+	"id": "2f545bde-9829-41c4-921d-8ee6041d2b76",
+	"prevId": "d29d62d2-2d36-499a-b1cf-28c5cdaad937",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.artist": {
+			"name": "artist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image_url": {
+					"name": "image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"session_impersonated_by_user_id_fk": {
+					"name": "session_impersonated_by_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["impersonated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				},
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["token"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_completed_onboarding": {
+					"name": "has_completed_onboarding",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_approved": {
+					"name": "is_approved",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'user'"
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_single_admin_idx": {
+					"name": "user_single_admin_idx",
+					"columns": [
+						{
+							"expression": "role",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"user\".\"role\" = 'admin'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character": {
+			"name": "character",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_user_id_user_id_fk": {
+					"name": "character_user_id_user_id_fk",
+					"tableFrom": "character",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_genre_domain_id_genre_domain_id_fk": {
+					"name": "character_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "character",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_clusters": {
+			"name": "character_clusters",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_clusters_character_id_character_id_fk": {
+					"name": "character_clusters_character_id_character_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_clusters_cluster_id_cluster_id_fk": {
+					"name": "character_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "character_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_clusters_character_id_cluster_id_pk": {
+					"name": "character_clusters_character_id_cluster_id_pk",
+					"columns": ["character_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.character_tracks": {
+			"name": "character_tracks",
+			"schema": "",
+			"columns": {
+				"character_id": {
+					"name": "character_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"character_tracks_character_id_character_id_fk": {
+					"name": "character_tracks_character_id_character_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "character",
+					"columnsFrom": ["character_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"character_tracks_track_id_track_id_fk": {
+					"name": "character_tracks_track_id_track_id_fk",
+					"tableFrom": "character_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"character_tracks_character_id_track_id_pk": {
+					"name": "character_tracks_character_id_track_id_pk",
+					"columns": ["character_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster": {
+			"name": "cluster",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"centroid": {
+					"name": "centroid",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"size": {
+					"name": "size",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"avg_valence": {
+					"name": "avg_valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_energy": {
+					"name": "avg_energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"avg_tempo": {
+					"name": "avg_tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"cluster_user_id_idx": {
+					"name": "cluster_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"cluster_user_id_user_id_fk": {
+					"name": "cluster_user_id_user_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_genre_domain_id_genre_domain_id_fk": {
+					"name": "cluster_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "cluster",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.cluster_tracks": {
+			"name": "cluster_tracks",
+			"schema": "",
+			"columns": {
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"cluster_tracks_cluster_id_cluster_id_fk": {
+					"name": "cluster_tracks_cluster_id_cluster_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"cluster_tracks_track_id_track_id_fk": {
+					"name": "cluster_tracks_track_id_track_id_fk",
+					"tableFrom": "cluster_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"cluster_tracks_cluster_id_track_id_pk": {
+					"name": "cluster_tracks_cluster_id_track_id_pk",
+					"columns": ["cluster_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_send_log": {
+			"name": "email_send_log",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"template_key": {
+					"name": "template_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'queued'"
+				},
+				"skip_reason": {
+					"name": "skip_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_message_id": {
+					"name": "provider_message_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"sent_at": {
+					"name": "sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"email_send_log_user_id_idx": {
+					"name": "email_send_log_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_status_idx": {
+					"name": "email_send_log_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_template_key_idx": {
+					"name": "email_send_log_template_key_idx",
+					"columns": [
+						{
+							"expression": "template_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_created_at_idx": {
+					"name": "email_send_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"email_send_log_provider_message_id_idx": {
+					"name": "email_send_log_provider_message_id_idx",
+					"columns": [
+						{
+							"expression": "provider_message_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"email_send_log_user_id_user_id_fk": {
+					"name": "email_send_log_user_id_user_id_fk",
+					"tableFrom": "email_send_log",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_send_log_idempotency_key_unique": {
+					"name": "email_send_log_idempotency_key_unique",
+					"nullsNotDistinct": false,
+					"columns": ["idempotency_key"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.email_suppression": {
+			"name": "email_suppression",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reason": {
+					"name": "reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suppressed_at": {
+					"name": "suppressed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"email_suppression_suppressed_at_idx": {
+					"name": "email_suppression_suppressed_at_idx",
+					"columns": [
+						{
+							"expression": "suppressed_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"email_suppression_email_unique": {
+					"name": "email_suppression_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.external_api_call": {
+			"name": "external_api_call",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pipeline_run_id": {
+					"name": "pipeline_run_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"endpoint": {
+					"name": "endpoint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"method": {
+					"name": "method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'GET'"
+				},
+				"request_payload": {
+					"name": "request_payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"http_status": {
+					"name": "http_status",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_payload": {
+					"name": "response_payload",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status_category": {
+					"name": "status_category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"retry_attempt": {
+					"name": "retry_attempt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"eac_user_id_idx": {
+					"name": "eac_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_pipeline_run_id_idx": {
+					"name": "eac_pipeline_run_id_idx",
+					"columns": [
+						{
+							"expression": "pipeline_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_provider_idx": {
+					"name": "eac_provider_idx",
+					"columns": [
+						{
+							"expression": "provider",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_status_category_idx": {
+					"name": "eac_status_category_idx",
+					"columns": [
+						{
+							"expression": "status_category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_created_at_idx": {
+					"name": "eac_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_provider_created_at_idx": {
+					"name": "eac_provider_created_at_idx",
+					"columns": [
+						{
+							"expression": "provider",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"eac_user_status_idx": {
+					"name": "eac_user_status_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status_category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"external_api_call_user_id_user_id_fk": {
+					"name": "external_api_call_user_id_user_id_fk",
+					"tableFrom": "external_api_call",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"external_api_call_pipeline_run_id_pipeline_run_id_fk": {
+					"name": "external_api_call_pipeline_run_id_pipeline_run_id_fk",
+					"tableFrom": "external_api_call",
+					"tableTo": "pipeline_run",
+					"columnsFrom": ["pipeline_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.genre_domain": {
+			"name": "genre_domain",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"genre_domain_name_unique": {
+					"name": "genre_domain_name_unique",
+					"nullsNotDistinct": false,
+					"columns": ["name"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pipeline_run": {
+			"name": "pipeline_run",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"triggered_by": {
+					"name": "triggered_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_stage": {
+					"name": "current_stage",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"progress": {
+					"name": "progress",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"error": {
+					"name": "error",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"last_client_seen_at": {
+					"name": "last_client_seen_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"pipeline_run_user_id_idx": {
+					"name": "pipeline_run_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_status_idx": {
+					"name": "pipeline_run_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"pipeline_run_one_running_per_user": {
+					"name": "pipeline_run_one_running_per_user",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"pipeline_run\".\"status\" = 'running'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"pipeline_run_user_id_user_id_fk": {
+					"name": "pipeline_run_user_id_user_id_fk",
+					"tableFrom": "pipeline_run",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist": {
+			"name": "playlist",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ai_generated_name": {
+					"name": "ai_generated_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"theme": {
+					"name": "theme",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"taxonomy": {
+					"name": "taxonomy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy_curve": {
+					"name": "energy_curve",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cover_color": {
+					"name": "cover_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tags": {
+					"name": "tags",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"track_count": {
+					"name": "track_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"is_generated": {
+					"name": "is_generated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"spotify_playlist_id": {
+					"name": "spotify_playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"exported_at": {
+					"name": "exported_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auto_sync_enabled": {
+					"name": "auto_sync_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"playlist_user_id_idx": {
+					"name": "playlist_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"playlist_taxonomy_idx": {
+					"name": "playlist_taxonomy_idx",
+					"columns": [
+						{
+							"expression": "taxonomy",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"playlist_user_id_user_id_fk": {
+					"name": "playlist_user_id_user_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_genre_domain_id_genre_domain_id_fk": {
+					"name": "playlist_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "playlist",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_clusters": {
+			"name": "playlist_clusters",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"cluster_id": {
+					"name": "cluster_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"weight": {
+					"name": "weight",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_clusters_playlist_id_playlist_id_fk": {
+					"name": "playlist_clusters_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_clusters_cluster_id_cluster_id_fk": {
+					"name": "playlist_clusters_cluster_id_cluster_id_fk",
+					"tableFrom": "playlist_clusters",
+					"tableTo": "cluster",
+					"columnsFrom": ["cluster_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_clusters_playlist_id_cluster_id_pk": {
+					"name": "playlist_clusters_playlist_id_cluster_id_pk",
+					"columns": ["playlist_id", "cluster_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.playlist_tracks": {
+			"name": "playlist_tracks",
+			"schema": "",
+			"columns": {
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"playlist_tracks_playlist_id_playlist_id_fk": {
+					"name": "playlist_tracks_playlist_id_playlist_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "playlist",
+					"columnsFrom": ["playlist_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"playlist_tracks_track_id_track_id_fk": {
+					"name": "playlist_tracks_track_id_track_id_fk",
+					"tableFrom": "playlist_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"playlist_tracks_playlist_id_track_id_pk": {
+					"name": "playlist_tracks_playlist_id_track_id_pk",
+					"columns": ["playlist_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_item_artists": {
+			"name": "user_playlist_snapshot_item_artists",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_position": {
+					"name": "artist_position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_id": {
+					"name": "artist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"artist_name": {
+					"name": "artist_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_item_artists_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_item_artists",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk": {
+					"name": "user_playlist_snapshot_item_artists_user_id_playlist_id_position_artist_position_pk",
+					"columns": ["user_id", "playlist_id", "position", "artist_position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshot_items": {
+			"name": "user_playlist_snapshot_items",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"position": {
+					"name": "position",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_name": {
+					"name": "track_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_uri": {
+					"name": "track_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshot_items_user_id_user_id_fk": {
+					"name": "user_playlist_snapshot_items_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshot_items",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshot_items_user_id_playlist_id_position_pk": {
+					"name": "user_playlist_snapshot_items_user_id_playlist_id_position_pk",
+					"columns": ["user_id", "playlist_id", "position"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_playlist_snapshots": {
+			"name": "user_playlist_snapshots",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"playlist_id": {
+					"name": "playlist_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"snapshot_id": {
+					"name": "snapshot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_playlist_snapshots_user_id_user_id_fk": {
+					"name": "user_playlist_snapshots_user_id_user_id_fk",
+					"tableFrom": "user_playlist_snapshots",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_playlist_snapshots_user_id_playlist_id_pk": {
+					"name": "user_playlist_snapshots_user_id_playlist_id_pk",
+					"columns": ["user_id", "playlist_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_spotify_library_stats": {
+			"name": "user_spotify_library_stats",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"total_tracks": {
+					"name": "total_tracks",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"total_playlists": {
+					"name": "total_playlists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_albums": {
+					"name": "unique_albums",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"unique_artists": {
+					"name": "unique_artists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_spotify_library_stats_user_id_user_id_fk": {
+					"name": "user_spotify_library_stats_user_id_user_id_fk",
+					"tableFrom": "user_spotify_library_stats",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.track": {
+			"name": "track",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"spotify_uri": {
+					"name": "spotify_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_names": {
+					"name": "artist_names",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"artist_ids": {
+					"name": "artist_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_name": {
+					"name": "album_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_id": {
+					"name": "album_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"album_image_url": {
+					"name": "album_image_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"release_date": {
+					"name": "release_date",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"explicit": {
+					"name": "explicit",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"popularity": {
+					"name": "popularity",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spotify_genres": {
+					"name": "spotify_genres",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"genre_domain_id": {
+					"name": "genre_domain_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"valence": {
+					"name": "valence",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"energy": {
+					"name": "energy",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"danceability": {
+					"name": "danceability",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tempo": {
+					"name": "tempo",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"acousticness": {
+					"name": "acousticness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"instrumentalness": {
+					"name": "instrumentalness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"speechiness": {
+					"name": "speechiness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"liveness": {
+					"name": "liveness",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"key": {
+					"name": "key",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics": {
+					"name": "lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_lyrics": {
+					"name": "synced_lyrics",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_instrumental": {
+					"name": "lyrics_instrumental",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lrclib_id": {
+					"name": "lrclib_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_fetched_at": {
+					"name": "lyrics_fetched_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"lyrics_status": {
+					"name": "lyrics_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_mood": {
+					"name": "llm_mood",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_tags": {
+					"name": "llm_tags",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"llm_classified_at": {
+					"name": "llm_classified_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding": {
+					"name": "embedding",
+					"type": "vector(1536)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_generated_at": {
+					"name": "embedding_generated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"embedding_input": {
+					"name": "embedding_input",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_assigned_at": {
+					"name": "domain_assigned_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"analysis_snapshot": {
+					"name": "analysis_snapshot",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"track_genre_domain_id_idx": {
+					"name": "track_genre_domain_id_idx",
+					"columns": [
+						{
+							"expression": "genre_domain_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_lyrics_status_idx": {
+					"name": "track_lyrics_status_idx",
+					"columns": [
+						{
+							"expression": "lyrics_status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"track_embedding_idx": {
+					"name": "track_embedding_idx",
+					"columns": [
+						{
+							"expression": "embedding",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last",
+							"opclass": "vector_cosine_ops"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "hnsw",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"track_genre_domain_id_genre_domain_id_fk": {
+					"name": "track_genre_domain_id_genre_domain_id_fk",
+					"tableFrom": "track",
+					"tableTo": "genre_domain",
+					"columnsFrom": ["genre_domain_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_tracks": {
+			"name": "user_tracks",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"track_id": {
+					"name": "track_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"user_tracks_user_id_idx": {
+					"name": "user_tracks_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"user_tracks_track_id_idx": {
+					"name": "user_tracks_track_id_idx",
+					"columns": [
+						{
+							"expression": "track_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"user_tracks_user_id_user_id_fk": {
+					"name": "user_tracks_user_id_user_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_tracks_track_id_track_id_fk": {
+					"name": "user_tracks_track_id_track_id_fk",
+					"tableFrom": "user_tracks",
+					"tableTo": "track",
+					"columnsFrom": ["track_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_tracks_user_id_track_id_pk": {
+					"name": "user_tracks_user_id_track_id_pk",
+					"columns": ["user_id", "track_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.user_email_preferences": {
+			"name": "user_email_preferences",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"transactional_enabled": {
+					"name": "transactional_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"product_updates_enabled": {
+					"name": "product_updates_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"marketing_enabled": {
+					"name": "marketing_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"feedback_enabled": {
+					"name": "feedback_enabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"consent_source": {
+					"name": "consent_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"consent_captured_at": {
+					"name": "consent_captured_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unsubscribed_at": {
+					"name": "unsubscribed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_email_preferences_user_id_user_id_fk": {
+					"name": "user_email_preferences_user_id_user_id_fk",
+					"tableFrom": "user_email_preferences",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.waitlist_signup": {
+			"name": "waitlist_signup",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "waitlist_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"note": {
+					"name": "note",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confirmation_email_sent_at": {
+					"name": "confirmation_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approved_at": {
+					"name": "approved_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"approval_email_sent_at": {
+					"name": "approval_email_sent_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token": {
+					"name": "invite_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_raw": {
+					"name": "invite_token_raw",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_token_expires_at": {
+					"name": "invite_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_at": {
+					"name": "invite_redeemed_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"invite_redeemed_by_user_id": {
+					"name": "invite_redeemed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {
+				"waitlist_signup_status_idx": {
+					"name": "waitlist_signup_status_idx",
+					"columns": [
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_created_at_idx": {
+					"name": "waitlist_signup_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"waitlist_signup_invite_token_idx": {
+					"name": "waitlist_signup_invite_token_idx",
+					"columns": [
+						{
+							"expression": "invite_token",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"waitlist_signup_invite_redeemed_by_user_id_user_id_fk": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_user_id_fk",
+					"tableFrom": "waitlist_signup",
+					"tableTo": "user",
+					"columnsFrom": ["invite_redeemed_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"waitlist_signup_email_unique": {
+					"name": "waitlist_signup_email_unique",
+					"nullsNotDistinct": false,
+					"columns": ["email"]
+				},
+				"waitlist_signup_invite_token_unique": {
+					"name": "waitlist_signup_invite_token_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_token"]
+				},
+				"waitlist_signup_invite_redeemed_by_user_id_unique": {
+					"name": "waitlist_signup_invite_redeemed_by_user_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["invite_redeemed_by_user_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.waitlist_status": {
+			"name": "waitlist_status",
+			"schema": "public",
+			"values": ["pending", "approved", "rejected"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
 			"when": 1786094486974,
 			"tag": "0027_user_single_admin_index",
 			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1786114969740,
+			"tag": "0028_silky_puck",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/artist.ts
+++ b/packages/db/src/schema/artist.ts
@@ -1,0 +1,8 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const artist = pgTable("artist", {
+	id: text("id").primaryKey(), // Spotify artist ID
+	name: text("name").notNull(),
+	imageUrl: text("image_url"),
+	fetchedAt: timestamp("fetched_at").defaultNow().notNull(),
+});

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,3 +1,4 @@
+export * from "./artist";
 export * from "./auth";
 export * from "./cluster";
 export * from "./email-send-log";

--- a/packages/orpc/src/routers/protected/tracks.ts
+++ b/packages/orpc/src/routers/protected/tracks.ts
@@ -9,6 +9,7 @@ import {
 	tracksListOutputSchema,
 } from "@harmonia/common/schemas";
 import { db } from "@harmonia/db";
+import { artist } from "@harmonia/db/schema/artist";
 import { clusterTracks } from "@harmonia/db/schema/cluster";
 import { genreDomain } from "@harmonia/db/schema/genre-domain";
 import { playlist, playlistTracks } from "@harmonia/db/schema/playlist";
@@ -141,6 +142,23 @@ export const tracksRouter = {
 
 			if (!result) return null;
 
+			const artistIds = (result.track.artistIds ?? []).filter(
+				(id): id is string => Boolean(id),
+			);
+			const artistImageRows =
+				artistIds.length > 0
+					? await db
+							.select({ id: artist.id, imageUrl: artist.imageUrl })
+							.from(artist)
+							.where(inArray(artist.id, artistIds))
+					: [];
+			const imageUrlByArtistId = new Map(
+				artistImageRows.map((a) => [a.id, a.imageUrl]),
+			);
+			const artistImageUrls = (result.track.artistIds ?? []).map((id) =>
+				id ? (imageUrlByArtistId.get(id) ?? null) : null,
+			);
+
 			const clusterAssignment = await db
 				.select({ clusterId: clusterTracks.clusterId })
 				.from(clusterTracks)
@@ -209,6 +227,7 @@ export const tracksRouter = {
 				likedAt: result.likedAt,
 				harmoniaPlaylists,
 				spotifyPlaylists,
+				artistImageUrls,
 			};
 		}),
 };


### PR DESCRIPTION
## Summary

Tier 2 of #222 — small avatar image next to each artist name on the track detail page.

- **New `artist` table**: `id` (Spotify artist ID, PK), `name`, `imageUrl`, `fetchedAt`. Standalone cache table, no FK — keyed off the artist IDs already stored in `track.artistIds`.
- **`fetchArtistsByIds`** in the Spotify client: batches `GET /artists?ids=...` 50 at a time (Spotify's max per request).
- **New `artists` pipeline stage**, wired in right after `sync` (needs `track.artistIds`, which sync populates). Went with **proactive fetch during the pipeline** over lazy on-view fetch — the issue's own two options — mainly for architectural consistency: every other enrichment in this app (lyrics, classification, embeddings) is already a pipeline stage, and lazy-on-view would mean inventing a second fetch-and-cache mechanism just for this one field. It's a single coordinator task with no worker/queue split, unlike lyrics/classify/embed — batching 50 IDs per Spotify call means even a few thousand unique artists is only a few dozen sequential requests, comfortably within one task's budget, so the fan-out complexity those other stages need isn't warranted here.
- It's **fire-and-forget** from the pipeline's perspective — doesn't gate run success/failure, doesn't block later stages. Avatar images are cosmetic; nothing downstream depends on them.
- **`tracks.getById`** now returns `artistImageUrls` (parallel array to `artistIds`/`artistNames`, `null` per-artist where not cached) via a plain cache lookup — not a fetch-on-read, so viewing an unclassified/unfetched track never triggers a Spotify call. Satisfies the acceptance criteria's "no N+1" requirement directly.
- Dashboard track-detail page renders a 16px circular avatar next to each artist name where available, using the same conditional-`Image`-with-no-fallback pattern already used for album art in the same component.

## Test plan
- [x] `tsc --noEmit` clean across `db`, `common`, `orpc`, `dashboard`, `api`
- [x] `pnpm --filter @harmonia/common test` — 95/95 passing
- [x] `pnpm --filter @harmonia/orpc test` — 10/10 passing
- [x] `biome check` clean
- [x] Applied the migration to a full copy of local dev data and verified the artist table shape against a real track's `artist_ids` (confirmed the JSONB array shape and insert/conflict/read cycle work end-to-end)
- [ ] Manual: run the organize pipeline for a real user with `HARMONIA_SPOTIFY_CLIENT_ID`/`SECRET` configured, confirm `artist` rows populate and avatars render on `/tracks/[id]`

## Note on migration numbering
Same as #278: this migration also generated as `0028_*`. Whichever of #275/#278/this PR merges last will need `pnpm db:generate` re-run to renumber before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artist images now appear as rounded avatars alongside artist names in track details.
  * Track details include artist image data when available, while preserving artist names, separators, and Spotify links.
  * Artist images are automatically retrieved and cached from Spotify during synchronization.
  * Missing images are handled gracefully without interrupting synchronization, and unavailable images remain omitted without affecting track details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->