### PR TITLE
fix(api): stop trigger.config.ts from requiring the full app env in CI

### DIFF
--- a/apps/api/trigger.config.ts
+++ b/apps/api/trigger.config.ts
@@ -1,10 +1,9 @@
-import { apiEnv } from "@harmonia/env/presets/api";
 import { defineConfig } from "@trigger.dev/sdk";
 
 export default defineConfig({
-	// standard Trigger.dev var, not in @harmonia/env — fall back to it when HARMONIA_TRIGGER_PROJECT_REF is unset
+	// process.env, not apiEnv — apiEnv validates the entire api schema eagerly, which `trigger deploy` in CI doesn't have.
 	project:
-		apiEnv.HARMONIA_TRIGGER_PROJECT_REF ??
+		process.env.HARMONIA_TRIGGER_PROJECT_REF ??
 		process.env.TRIGGER_PROJECT_REF ??
 		"",
 	dirs: ["./src/trigger"],


### PR DESCRIPTION
## Summary

The `Trigger.dev Deploy` workflow added in #276 fails in CI with:

\`\`\`
❌ Invalid environment variables: [
  { expected: 'string', code: 'invalid_type', path: [ 'NEXT_PUBLIC_HARMONIA_API_URL' ], message: 'Invalid input: expected string, received undefined' }
]
\`\`\`

Root cause: `apps/api/trigger.config.ts` did `import { apiEnv } from "@harmonia/env/presets/api"` just to read one field (`HARMONIA_TRIGGER_PROJECT_REF`). Importing `apiEnv` eagerly validates the **entire** api env schema — database URL, Spotify credentials, `NEXT_PUBLIC_HARMONIA_API_URL`, etc. The deploy workflow only sets `TRIGGER_ACCESS_TOKEN` and `HARMONIA_TRIGGER_PROJECT_REF` (correctly — deploy doesn't need the rest), so the CLI crashed before it ever got to actually deploying: the config file itself couldn't load.

## Fix

Read `process.env.HARMONIA_TRIGGER_PROJECT_REF` directly instead of going through `apiEnv`, matching the `TRIGGER_PROJECT_REF` fallback already on the same line. Nothing else in the app imports `trigger.config.ts` — it's only ever read by the Trigger.dev CLI itself (both `trigger dev` locally and `trigger deploy` in CI), so this has no effect on the running app.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Loaded the config directly with only `HARMONIA_TRIGGER_PROJECT_REF` set (`env -i ... npx tsx -e "import config from './trigger.config.ts'"`) — matches CI's actual env, loads cleanly now instead of throwing
- [ ] Manual: re-run the `Trigger.dev Deploy` workflow via `workflow_dispatch` once this merges, confirm it gets past config loading and actually deploys