### PR TITLE
fix(dashboard): redeem the invite cookie on /login and /waiting

### DIFF
--- a/apps/dashboard/src/app/login/page.tsx
+++ b/apps/dashboard/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
 import { HarmoniaBrandHeader } from "@harmonia/ui";
 import type { Route } from "next";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { AuthSpotifySignInButton } from "@/components/app/auth-spotify-sign-in-button";
 import { getServerSession } from "@/shared/api/session.server";
@@ -10,6 +11,11 @@ export default async function LoginPage() {
 
 	if (session?.user) {
 		if (!session.user.isApproved) {
+			// proxy.ts's middleware never runs on /login, so this is the only place left that can redeem a fresh invite cookie for a returning, already-signed-in user (#281).
+			const cookieStore = await cookies();
+			if (cookieStore.has("harmonia_invite")) {
+				redirect("/api/redeem-invite" as Route);
+			}
 			redirect("/waiting" as Route);
 		}
 		if (!session.user.hasCompletedOnboarding) {

--- a/apps/dashboard/src/app/waiting/page.tsx
+++ b/apps/dashboard/src/app/waiting/page.tsx
@@ -1,5 +1,6 @@
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
 import { cn, HarmoniaBrandHeader, Icons } from "@harmonia/ui";
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Fragment } from "react";
 import { serverClient } from "@/shared/api/orpc-server";
@@ -72,6 +73,14 @@ export default async function WaitingPage({
 			redirect(DASHBOARD_ROUTES.overview.path);
 		}
 		redirect(DASHBOARD_ROUTES.onboarding.introduction.path);
+	}
+
+	// proxy.ts's middleware never runs on /waiting either — same #281 fallback as /login.
+	if (session?.user && !session.user.isApproved) {
+		const cookieStore = await cookies();
+		if (cookieStore.has("harmonia_invite")) {
+			redirect("/api/redeem-invite");
+		}
 	}
 
 	const { token, reason } = await searchParams;


### PR DESCRIPTION
## Summary

Fixes #281 — approved waitlist users who already had a session before being approved were getting permanently stuck on `/waiting`, with the only workaround being an admin manually flipping `is_approved` in the DB editor.

Root cause: `proxy.ts`'s middleware is the only place in the app that reads the `harmonia_invite` cookie and redirects to `/api/redeem-invite` (the route that actually flips `user.isApproved`). Its matcher deliberately excludes `/login` and `/waiting`, and both pages have their own independent, simpler redirect logic that never looked at the cookie at all. A returning user landed on `/login` after clicking their approval email link, `/login` saw `isApproved: false` and bounced them straight to `/waiting` — the freshly-set cookie was never consulted, sat unused for its 1h TTL, and expired.

Full investigation with exact file/line citations and a step-by-step reproduction is in #281.

## Fix

Both `/login` and `/waiting` now check for the `harmonia_invite` cookie before falling back to their existing "not approved yet" behavior, redirecting to the same `/api/redeem-invite` route the middleware already uses — no new redemption logic duplicated, just routing the returning-user case to the one that already exists and already handles expiry/re-rejection/race-condition edge cases correctly.

Verified no redirect loop: `/api/redeem-invite` deletes the cookie unconditionally before redirecting (success or failure), so a failed redemption landing back on `/waiting?reason=invalid_invite` won't re-trigger either check on the next render.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] Manual: reproduce the original 7-step failure sequence from #281 against a real/staging environment pre-fix, then confirm it resolves post-fix
- [ ] Manual: confirm the existing "brand-new user, single sitting" path (already working) is unaffected
- [ ] Manual: confirm expired-token and rejected-then-reapproved edge cases still behave as `redeemInvite` already intends (unchanged by this PR — routing only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic invitation redemption for signed-in users with a valid invitation cookie.
  * Users with pending approval are redirected through the invitation redemption flow before reaching the waiting page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->