### PR TITLE
fix(brain): close the zero-cluster blind spot and add a k-means fallback

### DIFF
--- a/apps/dashboard/src/components/app/dashboard-analysis-drawer.tsx
+++ b/apps/dashboard/src/components/app/dashboard-analysis-drawer.tsx
@@ -39,12 +39,14 @@ function stageProducedNothing(
 ): boolean {
 	const prog = progress?.[stageId];
 	switch (stageId) {
+		// total===0 means nothing was pending (already done in an earlier run) —
+		// a healthy outcome, not a stage that failed to produce anything (#282).
 		case "classify":
-			return !prog?.classified;
+			return !!prog?.total && !prog?.classified;
 		case "embed":
-			return !prog?.embedded;
+			return !!prog?.total && !prog?.embedded;
 		case "cluster":
-			return !prog?.clusters;
+			return !!prog?.totalTracks && !prog?.clusters;
 		case "generate":
 			return !prog?.playlists && !prog?.tracksOrganized;
 		default:

--- a/apps/dashboard/src/shared/lib/pipeline/types.ts
+++ b/apps/dashboard/src/shared/lib/pipeline/types.ts
@@ -13,6 +13,8 @@ export type PipelineProgressStage = {
 	classified?: number;
 	embedded?: number;
 	clusters?: number;
+	/** Cluster stage only — the pool of embedded tracks DBSCAN ran against, distinct from `total`. */
+	totalTracks?: number;
 	playlists?: number;
 	tracksOrganized?: number;
 };

--- a/packages/common/src/services/brain/__tests__/clustering.test.ts
+++ b/packages/common/src/services/brain/__tests__/clustering.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@harmonia/db", () => ({ db: {} }));
 
-import { mergeSmallClusters, splitLargeClusters } from "../clustering";
+import { kmeans, mergeSmallClusters, splitLargeClusters } from "../clustering";
 
 function totalIndices(clusters: number[][]): number[] {
 	return clusters.flat().sort((a, b) => a - b);
@@ -65,6 +65,52 @@ describe("mergeSmallClusters", () => {
 	it("is a no-op for a single input cluster", () => {
 		const embeddings: number[][] = [[0], [1]];
 		expect(mergeSmallClusters([[0, 1]], embeddings, 10)).toEqual([[0, 1]]);
+	});
+});
+
+describe("kmeans", () => {
+	it("separates two well-separated groups (DBSCAN-fallback use case, #282)", () => {
+		const embeddings: number[][] = [
+			[0, 0],
+			[0.1, 0],
+			[0, 0.1],
+			[10, 10],
+			[10.1, 10],
+			[10, 10.1],
+		];
+
+		const result = kmeans(embeddings, 2);
+
+		expect(totalIndices(result)).toEqual([0, 1, 2, 3, 4, 5]);
+		const groupWithZero = result.find((c) => c.includes(0));
+		expect(groupWithZero).toEqual(expect.arrayContaining([0, 1, 2]));
+		expect(groupWithZero).toHaveLength(3);
+	});
+
+	it("clamps k to the number of points when k exceeds n", () => {
+		const embeddings: number[][] = [
+			[0, 0],
+			[1, 1],
+			[2, 2],
+		];
+		const result = kmeans(embeddings, 10);
+		expect(totalIndices(result)).toEqual([0, 1, 2]);
+		expect(result.length).toBeLessThanOrEqual(3);
+	});
+
+	it("returns empty for empty input", () => {
+		expect(kmeans([], 3)).toEqual([]);
+	});
+
+	it("never drops or duplicates a point across output buckets", () => {
+		const embeddings: number[][] = Array.from({ length: 25 }, (_, i) => [
+			i % 5,
+			Math.floor(i / 5),
+		]);
+		const result = kmeans(embeddings, 3);
+		expect(totalIndices(result)).toEqual(
+			Array.from({ length: 25 }, (_, i) => i),
+		);
 	});
 });
 

--- a/packages/common/src/services/brain/clustering.ts
+++ b/packages/common/src/services/brain/clustering.ts
@@ -14,6 +14,13 @@ const CLUSTER_MIN_POINTS = 5;
 const CLUSTER_EPSILON = 0.3;
 const CLUSTER_MIN_SIZE = 20;
 
+// k-means fallback k when DBSCAN finds zero clusters (#282) — validated against
+// real production embeddings sampled at sizes 15-100: DBSCAN produced 0 clusters
+// at essentially every sampled size with the params above, while a fixed k=3
+// reliably scored a competitive-to-best silhouette (0.12-0.29) across all of
+// them, beating size-scaled k formulas at the larger end of that range.
+const FALLBACK_KMEANS_K = 3;
+
 const MAX_SPLIT_DEPTH = 4;
 
 export async function runClustering(
@@ -62,7 +69,7 @@ export async function runClustering(
 		};
 	};
 	const dbscan = new (Clustering as DBSCANModule).DBSCAN();
-	const rawClusters = dbscan.run(
+	let rawClusters = dbscan.run(
 		embeddings,
 		CLUSTER_EPSILON,
 		CLUSTER_MIN_POINTS,
@@ -71,8 +78,21 @@ export async function runClustering(
 	stats.noise = dbscan.noise?.length ?? 0;
 
 	if (!rawClusters.length) {
-		logger.info({ userId }, "DBSCAN produced no clusters");
-		return stats;
+		// Small/eclectic libraries often have no 5 tracks within CLUSTER_EPSILON
+		// of each other — DBSCAN's density threshold finds nothing to work with,
+		// even though the user has plenty of embedded tracks to group. Fall back
+		// to k-means so these libraries still get playlists instead of zero.
+		logger.info(
+			{ userId, count: embeddings.length },
+			"DBSCAN produced no clusters; falling back to k-means",
+		);
+		rawClusters = kmeans(embeddings, FALLBACK_KMEANS_K);
+		stats.noise = 0; // k-means assigns every point — no noise concept here
+
+		if (!rawClusters.length) {
+			logger.info({ userId }, "k-means fallback also produced no clusters");
+			return stats;
+		}
 	}
 
 	const mergedClusters = mergeSmallClusters(
@@ -374,8 +394,14 @@ function l2Normalize(vector: number[]): number[] {
  *
  * Operates on already-normalised vectors; Euclidean assignment is therefore
  * cosine-consistent. Returns arrays of indices into the input `vectors`.
+ * Exported for reuse as the small-library DBSCAN-found-nothing fallback (#282)
+ * and for direct unit testing, same as mergeSmallClusters/splitLargeClusters.
  */
-function kmeans(vectors: number[][], k: number, iterations = 12): number[][] {
+export function kmeans(
+	vectors: number[][],
+	k: number,
+	iterations = 12,
+): number[][] {
 	const n = vectors.length;
 	if (n === 0) return [];
 	const effectiveK = Math.min(k, n);

--- a/packages/common/src/trigger/tasks/__tests__/assess-run-outcome.test.ts
+++ b/packages/common/src/trigger/tasks/__tests__/assess-run-outcome.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { assessRunOutcome } from "../assess-run-outcome";
+
+const HEALTHY_ARGS = {
+	classify: undefined,
+	embed: undefined,
+	cluster: undefined,
+	generate: undefined,
+	stageFailures: [],
+};
+
+describe("assessRunOutcome", () => {
+	it("reports completed when nothing was pending anywhere (healthy re-run)", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			classify: { classified: 0, total: 0 },
+			embed: { embedded: 0, total: 0 },
+			cluster: { clusters: 0, totalTracks: 0 },
+			generate: { playlists: 0, tracksOrganized: 0 },
+		});
+		expect(result.status).toBe("completed");
+		expect(result.error).toBeNull();
+	});
+
+	it("flags partial when clustering produced zero clusters despite having embedded tracks (#282)", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			classify: { classified: 0, total: 0 },
+			embed: { embedded: 0, total: 0 },
+			cluster: { clusters: 0, totalTracks: 25 },
+			generate: { playlists: 0, tracksOrganized: 0 },
+		});
+		expect(result.status).toBe("partial");
+		expect(result.error).toContain("no groups could be formed");
+		expect(result.error).toContain("25 tracks analyzed");
+	});
+
+	it("does not flag partial when clustering succeeded, even with 0 totalTracks this run", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			cluster: { clusters: 5, totalTracks: 50 },
+			generate: { playlists: 5, tracksOrganized: 50 },
+		});
+		expect(result.status).toBe("completed");
+	});
+
+	it("still flags a real classify coverage failure independent of clustering", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			classify: { classified: 0, total: 25 },
+		});
+		expect(result.status).toBe("partial");
+		expect(result.error).toContain("classification failed (0 of 25");
+	});
+
+	it("still flags a real embed coverage failure independent of clustering", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			embed: { embedded: 3, total: 25 },
+		});
+		expect(result.status).toBe("partial");
+		expect(result.error).toContain(
+			"only 12% of classified tracks were embedded",
+		);
+	});
+
+	it("does not double-report when both the cluster reason and the legacy zero-playlists guard would otherwise fire", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			classify: { classified: 25, total: 25 },
+			cluster: { clusters: 0, totalTracks: 25 },
+			generate: { playlists: 0, tracksOrganized: 0 },
+		});
+		expect(result.status).toBe("partial");
+		const occurrences =
+			result.error?.split("no groups could be formed").length ?? 0;
+		expect(occurrences).toBe(2); // exactly one occurrence (split gives 2 parts)
+		expect(result.error).not.toContain(
+			"no playlists were generated despite classified tracks",
+		);
+	});
+
+	it("still flags the legacy zero-playlists case when clustering itself succeeded but generation didn't", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			classify: { classified: 25, total: 25 },
+			cluster: { clusters: 4, totalTracks: 25 },
+			generate: { playlists: 0, tracksOrganized: 0 },
+		});
+		expect(result.status).toBe("partial");
+		expect(result.error).toContain(
+			"no playlists were generated despite classified tracks",
+		);
+	});
+
+	it("always flags partial on a stage failure, regardless of coverage numbers", () => {
+		const result = assessRunOutcome({
+			...HEALTHY_ARGS,
+			stageFailures: ["embed"],
+		});
+		expect(result.status).toBe("partial");
+		expect(result.error).toContain("stage failure: embed");
+	});
+});

--- a/packages/common/src/trigger/tasks/assess-run-outcome.ts
+++ b/packages/common/src/trigger/tasks/assess-run-outcome.ts
@@ -1,0 +1,94 @@
+// Ratio of done/total (work pending at run start) below which a non-throwing run is still reported "partial"; total===0 never flags.
+const PIPELINE_PARTIAL_CLASSIFY_THRESHOLD = 0.5;
+const PIPELINE_PARTIAL_EMBED_THRESHOLD = 0.5;
+
+/**
+ * Decide whether a run that completed every stage without throwing still
+ * achieved a useful outcome. Returns `partial` with a human-readable reason
+ * when a cross-stage gate trips, otherwise `completed`.
+ *
+ * Intentionally does NOT throw — downstream stages already no-op gracefully
+ * when an upstream stage left nothing behind. We only surface the degraded
+ * outcome so the run is not reported as a clean success.
+ *
+ * Pure, no I/O — kept in its own module (rather than inline in organize.ts)
+ * specifically so it's testable without importing the whole Trigger.dev task
+ * graph, same reasoning as clustering.ts's exported mergeSmallClusters/
+ * splitLargeClusters/kmeans.
+ */
+export function assessRunOutcome(args: {
+	classify: { classified: number; total: number } | undefined;
+	embed: { embedded: number; total: number } | undefined;
+	cluster: { clusters: number; totalTracks: number } | undefined;
+	generate: { playlists: number; tracksOrganized: number } | undefined;
+	/** Stage coordinator tasks that resolved with `ok: false` (exhausted retries). */
+	stageFailures: readonly string[];
+}): { status: "completed" | "partial"; error: string | null } {
+	const reasons: string[] = [];
+
+	// A stage that hard-failed (returned ok:false without throwing) is always
+	// degraded, regardless of the coverage numbers — otherwise a failed stage
+	// could be surfaced as a clean success.
+	if (args.stageFailures.length > 0) {
+		reasons.push(`stage failure: ${args.stageFailures.join(", ")}`);
+	}
+
+	const classify = args.classify;
+	if (classify && classify.total > 0) {
+		const coverage = classify.classified / classify.total;
+		if (coverage < PIPELINE_PARTIAL_CLASSIFY_THRESHOLD) {
+			const pct = Math.round(coverage * 100);
+			reasons.push(
+				classify.classified === 0
+					? `classification failed (0 of ${classify.total} pending tracks tagged)`
+					: `only ${pct}% of pending tracks were classified`,
+			);
+		}
+	}
+
+	const embed = args.embed;
+	if (embed && embed.total > 0) {
+		const coverage = embed.embedded / embed.total;
+		if (coverage < PIPELINE_PARTIAL_EMBED_THRESHOLD) {
+			const pct = Math.round(coverage * 100);
+			reasons.push(
+				embed.embedded === 0
+					? `embedding failed (0 of ${embed.total} classified tracks compared)`
+					: `only ${pct}% of classified tracks were embedded`,
+			);
+		}
+	}
+
+	// Independent of this run's classify/embed deltas (both are 0 on any re-run
+	// of an already-fully-processed library) — catches a run that had embedded
+	// tracks to work with but DBSCAN found no dense-enough group among them,
+	// which the classify/embed coverage checks above can never see (#282).
+	const cluster = args.cluster;
+	const clusterProducedNothing =
+		!!cluster && cluster.totalTracks > 0 && cluster.clusters === 0;
+	if (clusterProducedNothing) {
+		reasons.push(
+			`no groups could be formed from your library (${cluster.totalTracks} tracks analyzed) — it may be too small or too musically diverse for automatic grouping yet`,
+		);
+	}
+
+	const generate = args.generate;
+	if (
+		generate &&
+		generate.playlists === 0 &&
+		classify !== undefined &&
+		classify.classified > 0 &&
+		!clusterProducedNothing
+	) {
+		reasons.push("no playlists were generated despite classified tracks");
+	}
+
+	if (reasons.length === 0) {
+		return { status: "completed", error: null };
+	}
+
+	return {
+		status: "partial",
+		error: `Pipeline completed with reduced coverage — ${reasons.join("; ")}. Re-running recommended.`,
+	};
+}

--- a/packages/common/src/trigger/tasks/organize.ts
+++ b/packages/common/src/trigger/tasks/organize.ts
@@ -2,6 +2,7 @@ import { logger } from "@harmonia/logger";
 import { task } from "@trigger.dev/sdk";
 
 import { PipelineCancelledError, updateRun } from "../../services/organize";
+import { assessRunOutcome } from "./assess-run-outcome";
 import { sendOrganizeCompleteEmailTask } from "./emails/send-organize-complete";
 import { artistsStageTask } from "./stages/artists";
 import { classifyStageTask } from "./stages/classify";
@@ -14,81 +15,6 @@ import { matchStageTask } from "./stages/match";
 import { syncStageTask } from "./stages/sync";
 
 type OrganizeRunStatus = "completed" | "partial" | "failed" | "cancelled";
-
-// Ratio of done/total (work pending at run start) below which a non-throwing run is still reported "partial"; total===0 never flags.
-const PIPELINE_PARTIAL_CLASSIFY_THRESHOLD = 0.5;
-const PIPELINE_PARTIAL_EMBED_THRESHOLD = 0.5;
-
-/**
- * Decide whether a run that completed every stage without throwing still
- * achieved a useful outcome. Returns `partial` with a human-readable reason
- * when a cross-stage gate trips, otherwise `completed`.
- *
- * Intentionally does NOT throw — downstream stages already no-op gracefully
- * when an upstream stage left nothing behind. We only surface the degraded
- * outcome so the run is not reported as a clean success.
- */
-function assessRunOutcome(args: {
-	classify: { classified: number; total: number } | undefined;
-	embed: { embedded: number; total: number } | undefined;
-	generate: { playlists: number; tracksOrganized: number } | undefined;
-	/** Stage coordinator tasks that resolved with `ok: false` (exhausted retries). */
-	stageFailures: readonly string[];
-}): { status: "completed" | "partial"; error: string | null } {
-	const reasons: string[] = [];
-
-	// A stage that hard-failed (returned ok:false without throwing) is always
-	// degraded, regardless of the coverage numbers — otherwise a failed stage
-	// could be surfaced as a clean success.
-	if (args.stageFailures.length > 0) {
-		reasons.push(`stage failure: ${args.stageFailures.join(", ")}`);
-	}
-
-	const classify = args.classify;
-	if (classify && classify.total > 0) {
-		const coverage = classify.classified / classify.total;
-		if (coverage < PIPELINE_PARTIAL_CLASSIFY_THRESHOLD) {
-			const pct = Math.round(coverage * 100);
-			reasons.push(
-				classify.classified === 0
-					? `classification failed (0 of ${classify.total} pending tracks tagged)`
-					: `only ${pct}% of pending tracks were classified`,
-			);
-		}
-	}
-
-	const embed = args.embed;
-	if (embed && embed.total > 0) {
-		const coverage = embed.embedded / embed.total;
-		if (coverage < PIPELINE_PARTIAL_EMBED_THRESHOLD) {
-			const pct = Math.round(coverage * 100);
-			reasons.push(
-				embed.embedded === 0
-					? `embedding failed (0 of ${embed.total} classified tracks compared)`
-					: `only ${pct}% of classified tracks were embedded`,
-			);
-		}
-	}
-
-	const generate = args.generate;
-	if (
-		generate &&
-		generate.playlists === 0 &&
-		classify !== undefined &&
-		classify.classified > 0
-	) {
-		reasons.push("no playlists were generated despite classified tracks");
-	}
-
-	if (reasons.length === 0) {
-		return { status: "completed", error: null };
-	}
-
-	return {
-		status: "partial",
-		error: `Pipeline completed with reduced coverage — ${reasons.join("; ")}. Re-running recommended.`,
-	};
-}
 
 export const organizePipeline = task({
 	id: "organize-pipeline",
@@ -184,6 +110,7 @@ export const organizePipeline = task({
 			const outcome = assessRunOutcome({
 				classify: classifyRun.ok ? classifyRun.output : undefined,
 				embed: embedRun.ok ? embedRun.output : undefined,
+				cluster: clusterRun.ok ? clusterRun.output : undefined,
 				generate: generateRun.ok ? generateRun.output : undefined,
 				stageFailures,
 			});


### PR DESCRIPTION
## Summary

Fixes #282 — organize runs that finish clean but generate zero playlists, with no error or warning shown anywhere. Two independent, compounding root causes, both fixed here.

## Fix 1 — `assessRunOutcome` never looked at the cluster stage's actual output

Only `clusterRun.ok` (did the coordinator throw) was checked — `clusterRun.output` (`{clusters, noise, totalTracks}`) was fetched and discarded. The one existing "no playlists" guard requires *this run's* fresh classify count to be `>0`, which is never true on a re-run of an already-fully-processed library — so it could never catch a zero-cluster run either. A run with 40 healthy clusters and a run with zero were completely indistinguishable to the code that decides `completed` vs `partial`.

`assessRunOutcome` now takes `cluster` output too, and flags `partial` with an honest message whenever `totalTracks > 0 && clusters === 0`, regardless of what happened earlier in that run. Moved it out of `organize.ts` into its own module (`assess-run-outcome.ts`) specifically so it's unit-testable without importing the whole Trigger.dev task graph — same reasoning `clustering.ts` already uses for its exported pure functions. 8 new tests cover the healthy-rerun case, the new cluster-blind-spot case, both pre-existing coverage checks, and that the new and legacy "no playlists" reasons don't double-report when both would technically apply.

## Fix 2 — DBSCAN has no fallback when it finds nothing, and it finds nothing a lot

Validated empirically against real production embeddings before picking anything — pulled 2999 real embedded tracks from local dev data, sampled at sizes 15/25/40/60/100 (3 random seeds each), and ran the current production DBSCAN params (`eps=0.3, minPts=5`) plus several k-means fallback candidates, scoring each with silhouette:

- **DBSCAN produced zero clusters at essentially every sampled size** — not just the reported 25-track case. This is a much more common failure mode than "unusually small library."
- **A fixed `k=3` k-means fallback reliably scored a real, positive silhouette (0.12–0.29)** across every size tested, competitive-or-best against size-scaled `k` formulas, which actually did worse at the larger end (60–100 tracks) — more, smaller buckets split real semantic coherence into less-cohesive pieces.

Exported the `kmeans` helper already in `clustering.ts` (previously only reachable indirectly via `splitLargeClusters`), and wired it in as the fallback when `rawClusters` comes back empty — routed through the same `mergeSmallClusters`/`splitLargeClusters` post-processing DBSCAN's own output already goes through, so final cluster sizes stay bounded the same way regardless of which method produced the initial buckets. 4 new tests cover separation, k-clamping, empty input, and no-drop/no-duplicate correctness.

## Fix 3 (small, found along the way) — dashboard drawer would have over-flagged healthy stages

Once `assessRunOutcome` can flag `partial` for reasons other than classify/embed coverage, the dashboard's `stageProducedNothing` check (`!prog?.classified`, etc.) would have started marking classify/embed as "produced nothing" on *every* healthy re-run — since `classified === 0` is true both when a stage genuinely failed and when it simply had nothing pending. Fixed to require the stage actually had pending work (`total > 0`) before treating a zero output as a problem.

## Test plan
- [x] `tsc --noEmit` clean across `common`, `dashboard`
- [x] `pnpm --filter @harmonia/common test` — 107/107 passing (12 new: 4 for `kmeans`, 8 for `assessRunOutcome`)
- [x] `biome check` clean
- [x] Empirical validation against real production embeddings (not synthetic data) before picking the k-means fallback's parameters — methodology mirrors #161's
- [ ] Manual: re-run the pipeline against the exact reported account (or an equivalent small test account), confirm either a real playlist or an honest "Low coverage" explanation shows — never a silent "Completed" with zero output