### PR TITLE
feat(dashboard): add a way into the app from the approved-waitlist page

### DIFF
--- a/apps/dashboard/src/app/waiting/page.tsx
+++ b/apps/dashboard/src/app/waiting/page.tsx
@@ -1,6 +1,7 @@
 import { DASHBOARD_ROUTES } from "@harmonia/common/utils/routes";
-import { cn, HarmoniaBrandHeader, Icons } from "@harmonia/ui";
+import { buttonVariants, cn, HarmoniaBrandHeader, Icons } from "@harmonia/ui";
 import { cookies } from "next/headers";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Fragment } from "react";
 import { serverClient } from "@/shared/api/orpc-server";
@@ -117,10 +118,19 @@ export default async function WaitingPage({
 							You're in.
 						</h1>
 						<p className="mt-6 text-base text-muted-foreground leading-relaxed">
-							Check your inbox for the email with your sign-in link.
+							Check your inbox for the email with your sign-in link, or continue
+							below.
 						</p>
 						<div className="mt-10">
 							<Stepper status="approved" />
+						</div>
+						<div className="mt-10">
+							<Link
+								href={`/api/invite/${token}`}
+								className={buttonVariants({ size: "lg" })}
+							>
+								Go to dashboard
+							</Link>
 						</div>
 					</div>
 				</WaitingShell>


### PR DESCRIPTION
## Summary

The "You're in." state on `/waiting?token=...` (shown when someone checks their waitlist status and is approved) only said "check your inbox for the email with your sign-in link" — no way to actually continue from that page if they didn't want to go dig up the email.

Adds a "Go to dashboard" button pointing at `/api/invite/${token}` — reusing the exact same invite token already present in the page's URL. This isn't a generic `/login` link: `/api/invite/[token]` is the same route the approval email itself links to (sets the `harmonia_invite` cookie, then redirects to `/login`, which either redeems immediately if there's a session or shows the Spotify sign-in button). Linking straight to `/login` instead would have left them stuck back on `/waiting` after signing in, since nothing would have set the redemption cookie.

## Test plan
- [x] `pnpm build` (dashboard) — clean
- [x] `biome ci .` — clean (pre-existing baseline only)
- [x] Traced the token through `/api/invite/[token]` → cookie set → `/login` → sign-in → redemption, confirming it's the same path the emailed link uses