### PR TITLE
chore(rules): dedupe commit-convention text out of naming-conventions.mdc

### DIFF
--- a/.cursor/rules/01-naming-conventions.mdc
+++ b/.cursor/rules/01-naming-conventions.mdc
@@ -66,8 +66,4 @@ const EMBEDDING_BATCH_SIZE = 64;
 
 Only export a constant into a package's `constants/*.ts` file if it's used from 2+ files. A constant used in exactly one file stays local to that file (unexported, no separate constants-file entry).
 
-## Commits
-
-`feat:` `fix:` `chore:` `perf:` `refactor:` prefixes. No scope required.
-
-No AI/tool branding in commit messages or PR text; no `Co-authored-by:` for assistants (see project overview).
+Commit conventions live in `00-project-overview.mdc`.


### PR DESCRIPTION
Closes #299

## Summary
- `01-naming-conventions.mdc`'s "Commits" section repeated `00-project-overview.mdc`'s "Git commits" section verbatim
- Removed the repeat, left a one-line pointer to where it actually lives

## Test plan
- [x] Diffed both files, confirmed no other content overlaps
- [x] `.cursor/rules/00-project-overview.mdc` unchanged — still the single source of truth for commit conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the naming conventions guidance to reference the project overview documentation for commit conventions.
  * Removed duplicated commit-convention details from the naming conventions guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->