### PR TITLE
fix: offload spotify library sync to trigger.dev instead of running inline

### DIFF
--- a/apps/api/src/trigger/organize.ts
+++ b/apps/api/src/trigger/organize.ts
@@ -11,6 +11,7 @@ export { sendWaitlistConfirmationEmailTask } from "@harmonia/common/trigger/task
 export { sendWelcomeEmailTask } from "@harmonia/common/trigger/tasks/emails/send-welcome";
 export { organizePipeline } from "@harmonia/common/trigger/tasks/organize";
 export { refreshLibrarySnapshotsTask } from "@harmonia/common/trigger/tasks/spotify/refresh-library-snapshots";
+export { syncUserLibraryTask } from "@harmonia/common/trigger/tasks/spotify/sync-user-library";
 export { artistsStageTask } from "@harmonia/common/trigger/tasks/stages/artists";
 export {
 	classifyStageTask,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,6 +17,9 @@
 		"./trigger/tasks/spotify/refresh-library-snapshots": {
 			"default": "./src/trigger/tasks/spotify/refresh-library-snapshots.ts"
 		},
+		"./trigger/tasks/spotify/sync-user-library": {
+			"default": "./src/trigger/tasks/spotify/sync-user-library.ts"
+		},
 		"./trigger/tasks/stages/sync": {
 			"default": "./src/trigger/tasks/stages/sync.ts"
 		},

--- a/packages/common/src/trigger/tasks/spotify/sync-user-library.ts
+++ b/packages/common/src/trigger/tasks/spotify/sync-user-library.ts
@@ -1,0 +1,27 @@
+import { logger } from "@harmonia/logger";
+import { metadata, task } from "@trigger.dev/sdk";
+
+import { syncLibraryTracks } from "../../../services/music";
+
+// On-demand, single-user counterpart to refreshLibrarySnapshotsTask (#284),
+// which refreshes stale users on a cron off Vercel. This task lets the
+// dashboard "sync now" / onboarding import flows trigger the same expensive
+// work (paginating Liked Songs + every playlist, normalizing, batched
+// upserts) without holding a Vercel Function CPU-active for the whole sync —
+// the oRPC handlers trigger this task and relay its progress/result instead
+// of calling syncLibraryTracks inline.
+export const syncUserLibraryTask = task({
+	id: "spotify-sync-user-library",
+	run: async ({ userId }: { userId: string }) => {
+		const result = await syncLibraryTracks(userId, async (progress) => {
+			metadata.set("progress", progress);
+		});
+
+		logger.info(
+			{ userId, total: result.total, done: result.done },
+			"Synced user library on demand",
+		);
+
+		return result;
+	},
+});

--- a/packages/orpc/package.json
+++ b/packages/orpc/package.json
@@ -32,6 +32,7 @@
 		"@orpc/client": "catalog:",
 		"@orpc/server": "catalog:",
 		"@orpc/zod": "catalog:",
+		"@trigger.dev/sdk": "catalog:",
 		"better-auth": "catalog:",
 		"drizzle-orm": "catalog:",
 		"next": "catalog:",

--- a/packages/orpc/src/routers/protected/spotify.ts
+++ b/packages/orpc/src/routers/protected/spotify.ts
@@ -1,17 +1,28 @@
-import { getSpotifyLibraryStats, syncLibraryTracks } from "@harmonia/common";
+import { getSpotifyLibraryStats } from "@harmonia/common";
 import {
 	emptyInput,
-	type SyncProgressEvent,
+	type SpotifyLibraryStats,
 	spotifyLibraryStatsSchema,
 	syncProgressEventSchema,
 } from "@harmonia/common/schemas";
-import type { SyncProgress } from "@harmonia/common/types";
+import { syncUserLibraryTask } from "@harmonia/common/trigger/tasks/spotify/sync-user-library";
+import type { SyncPhase, SyncProgress } from "@harmonia/common/types";
 import { db } from "@harmonia/db";
 import { user } from "@harmonia/db/schema/auth";
-import { eventIterator } from "@orpc/server";
+import { eventIterator, ORPCError } from "@orpc/server";
+import { runs } from "@trigger.dev/sdk";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { approvedProcedure } from "../../procedures";
+
+const TERMINAL_FAILURE_STATUSES = new Set([
+	"CANCELED",
+	"FAILED",
+	"CRASHED",
+	"SYSTEM_FAILURE",
+	"EXPIRED",
+	"TIMED_OUT",
+]);
 
 export const spotifyRouter = {
 	libraryStats: approvedProcedure
@@ -28,43 +39,42 @@ export const spotifyRouter = {
 		.handler(async function* ({ context }) {
 			const userId = context.session.user.id;
 
-			const queue: SyncProgressEvent[] = [];
-			let resolveNext: (() => void) | null = null;
-			const waitNext = () =>
-				new Promise<void>((r) => {
-					resolveNext = r;
-				});
-
-			const onProgress = async (p: SyncProgress) => {
-				queue.push({
-					event: "progress",
-					progress: {
-						phase: p.phase ?? "liked",
-						phasesCompleted: p.phasesCompleted ?? 0,
-						percent: p.percent ?? 0,
-						done: p.done ?? false,
-						total: p.total ?? 0,
-					},
-				});
-				resolveNext?.();
-			};
-
-			const syncPromise = syncLibraryTracks(userId, onProgress);
+			// Triggers the sync on Trigger.dev's infra instead of running it
+			// inline here — this handler just relays the run's realtime
+			// metadata/status, so it stays CPU-idle (I/O wait) for the sync's
+			// full duration rather than CPU-active (#295).
+			const handle = await syncUserLibraryTask.trigger({ userId });
 
 			try {
-				while (true) {
-					while (queue.length > 0) {
-						yield queue.shift()!;
+				for await (const run of runs.subscribeToRun(handle)) {
+					const progress = run.metadata?.progress as SyncProgress | undefined;
+
+					if (progress) {
+						yield {
+							event: "progress",
+							progress: {
+								phase: (progress.phase ?? "liked") as SyncPhase,
+								phasesCompleted: progress.phasesCompleted ?? 0,
+								percent: progress.percent ?? 0,
+								done: progress.done ?? false,
+								total: progress.total ?? 0,
+							},
+						};
 					}
 
-					const result = await Promise.race([
-						syncPromise.then((r) => ({ done: true, result: r })),
-						waitNext().then(() => ({ done: false, result: null })),
-					]);
+					if (run.status === "COMPLETED") {
+						const output = run.output as
+							| (SyncProgress & { stats?: SpotifyLibraryStats })
+							| undefined;
+						yield { event: "completed", stats: output?.stats };
+						return;
+					}
 
-					if (result.done && result.result) {
-						const { stats } = result.result;
-						yield { event: "completed", stats };
+					if (TERMINAL_FAILURE_STATUSES.has(run.status)) {
+						yield {
+							event: "failed",
+							error: `Sync ${run.status.toLowerCase()}`,
+						};
 						return;
 					}
 				}
@@ -87,8 +97,16 @@ export const spotifyRouter = {
 		)
 		.handler(async ({ context }) => {
 			const userId = context.session.user.id;
-			const result = await syncLibraryTracks(userId);
-			return result;
+
+			const run = await syncUserLibraryTask.triggerAndWait({ userId });
+			if (!run.ok) {
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message:
+						run.error instanceof Error ? run.error.message : String(run.error),
+				});
+			}
+
+			return run.output;
 		}),
 
 	finalizeOnboarding: approvedProcedure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,6 +841,9 @@ importers:
       '@orpc/zod':
         specifier: 'catalog:'
         version: 1.14.6(@opentelemetry/api@1.9.1)(@orpc/contract@1.14.6(@opentelemetry/api@1.9.1))(@orpc/server@1.14.6(@opentelemetry/api@1.9.1)(ws@8.21.0))(ws@8.21.0)(zod@4.4.3)
+      '@trigger.dev/sdk':
+        specifier: 'catalog:'
+        version: 4.4.6(ai@6.0.205(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
       better-auth:
         specifier: 'catalog:'
         version: 1.6.18(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(next@16.2.9(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@3.2.6(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(supports-color@10.2.2)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
Fixes #302

## Summary

- Both `streamSyncLibrary` and `syncLibrary` in `packages/orpc/src/routers/protected/spotify.ts` called `syncLibraryTracks()` directly from the oRPC handler, holding a Vercel Function CPU-active for the whole sync (tens of seconds: pagination, playlist fetches, normalization, batched upserts).
- Added `packages/common/src/trigger/tasks/spotify/sync-user-library.ts` — a new on-demand Trigger.dev task wrapping `syncLibraryTracks()` for a single user, reporting progress via Trigger.dev run metadata (`metadata.set("progress", ...)`).
- `streamSyncLibrary` now triggers that task and relays its realtime updates (`runs.subscribeToRun`) as the same `SyncProgressEvent` shape the client already consumes — **the streaming contract to the client is unchanged**, so `onboarding.util.ts` / `controller.hook.ts` needed no changes.
- `syncLibrary` now triggers the task and awaits it via `.triggerAndWait()` instead of calling `syncLibraryTracks` inline.
- Registered the new task's export in `apps/api/src/trigger/organize.ts` (Trigger.dev's task discovery entrypoint) and its subpath in `packages/common/package.json`'s `exports` map, following the existing conventions for every other task in this file.
- Added `@trigger.dev/sdk` as an explicit dependency of `@harmonia/orpc` (it now imports `runs` directly).
- Left `refreshLibrarySnapshotsTask` (the cron path) and `stages/sync.ts` (the organize pipeline's sync stage, already a Trigger.dev task) untouched — both were already correct and are the pattern this PR extends to the on-demand paths.

## Test plan

- [x] `tsc --noEmit` passes for `@harmonia/common` and `@harmonia/orpc` (the two packages with logic changes).
- [x] `biome check` passes on all changed files.
- [ ] Not verified end-to-end against a live Trigger.dev/Spotify environment (no credentials in this sandbox) — before merging, please manually verify in a dev/staging environment: onboarding "Import" still shows live progress and reaches the completed state, and a manual "sync now" (if wired to `syncLibrary` anywhere) still returns the expected `{ total, done, stats }` shape.
- [ ] Confirm the new `spotify-sync-user-library` task shows up after the next `trigger.dev deploy` (it's exported the same way as every other task in `apps/api/src/trigger/organize.ts`, so this should be automatic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spotify library synchronization now runs as a background task.
  * Streaming sync updates provide progress information while your library is being processed.
  * Completed synchronizations report summary statistics, such as the number of tracks processed.

* **Bug Fixes**
  * Improved handling and reporting of synchronization failures.
  * Synchronous synchronization now clearly reports unsuccessful runs instead of returning incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->