### PR TITLE
feat(trigger): schedule weekly organize digest via trigger.dev cron

### DIFF
--- a/apps/api/src/trigger/organize.ts
+++ b/apps/api/src/trigger/organize.ts
@@ -10,6 +10,7 @@ export { sendWaitlistApprovedEmailTask } from "@harmonia/common/trigger/tasks/em
 export { sendWaitlistConfirmationEmailTask } from "@harmonia/common/trigger/tasks/emails/send-waitlist-confirmation";
 export { sendWelcomeEmailTask } from "@harmonia/common/trigger/tasks/emails/send-welcome";
 export { organizePipeline } from "@harmonia/common/trigger/tasks/organize";
+export { organizeWeeklyCronTask } from "@harmonia/common/trigger/tasks/organize-weekly-cron";
 export { refreshLibrarySnapshotsTask } from "@harmonia/common/trigger/tasks/spotify/refresh-library-snapshots";
 export { syncUserLibraryTask } from "@harmonia/common/trigger/tasks/spotify/sync-user-library";
 export { artistsStageTask } from "@harmonia/common/trigger/tasks/stages/artists";

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,6 +14,9 @@
 		"./trigger/tasks/organize": {
 			"default": "./src/trigger/tasks/organize.ts"
 		},
+		"./trigger/tasks/organize-weekly-cron": {
+			"default": "./src/trigger/tasks/organize-weekly-cron.ts"
+		},
 		"./trigger/tasks/spotify/refresh-library-snapshots": {
 			"default": "./src/trigger/tasks/spotify/refresh-library-snapshots.ts"
 		},

--- a/packages/common/src/trigger/tasks/organize-weekly-cron.ts
+++ b/packages/common/src/trigger/tasks/organize-weekly-cron.ts
@@ -1,0 +1,171 @@
+import { db } from "@harmonia/db";
+import { user } from "@harmonia/db/schema/auth";
+import { pipelineRun } from "@harmonia/db/schema/pipeline-run";
+import { logger } from "@harmonia/logger";
+import { schedules } from "@trigger.dev/sdk";
+import { and, eq } from "drizzle-orm";
+
+import { updateRun } from "../../services/organize";
+import { organizePipeline } from "./organize";
+
+const RUNNING_CONSTRAINT_NAME = "pipeline_run_one_running_per_user";
+const MAX_INSERT_ATTEMPTS = 3;
+
+function isAlreadyRunningConflict(err: unknown): boolean {
+	if (typeof err !== "object" || err === null) return false;
+	if (!("code" in err) || !("constraint" in err)) return false;
+	return err.code === "23505" && err.constraint === RUNNING_CONSTRAINT_NAME;
+}
+
+async function findRunningRunId(userId: string): Promise<number | null> {
+	const [existing] = await db
+		.select({ id: pipelineRun.id })
+		.from(pipelineRun)
+		.where(
+			and(eq(pipelineRun.userId, userId), eq(pipelineRun.status, "running")),
+		);
+	return existing?.id ?? null;
+}
+
+export type InsertRunResult =
+	| { kind: "created"; runId: number }
+	| { kind: "skipped"; runId: number };
+
+/**
+ * Inserts a new "running" pipeline_run row for the user, or reports the
+ * existing one if the unique-running-per-user constraint blocks it. If the
+ * conflicting run finishes between our insert attempt and the lookup (a
+ * narrow but real race), the constraint has cleared — retry the insert
+ * instead of dropping a valid request as "skipped".
+ */
+export async function insertRunOrSkip(
+	userId: string,
+	triggeredBy: "user" | "cron",
+): Promise<InsertRunResult> {
+	for (let attempt = 0; attempt < MAX_INSERT_ATTEMPTS; attempt++) {
+		try {
+			const [inserted] = await db
+				.insert(pipelineRun)
+				.values({
+					userId,
+					status: "running",
+					triggeredBy,
+					currentStage: "sync",
+					startedAt: new Date(),
+				})
+				.returning({ id: pipelineRun.id });
+
+			if (!inserted) throw new Error("Failed to create run record");
+			return { kind: "created", runId: inserted.id };
+		} catch (err) {
+			if (!isAlreadyRunningConflict(err)) throw err;
+
+			const existingRunId = await findRunningRunId(userId);
+			if (existingRunId !== null) {
+				return { kind: "skipped", runId: existingRunId };
+			}
+			// Conflicting run finished between our insert and this lookup —
+			// loop around and retry the insert now that it should be clear.
+		}
+	}
+	throw new Error(
+		`Failed to create pipeline run for user ${userId} after ${MAX_INSERT_ATTEMPTS} attempts (repeatedly raced with another run)`,
+	);
+}
+
+export type OrganizeAllUsersResult = {
+	userId: string;
+	runId: number;
+	status: "completed" | "failed" | "skipped";
+	error?: string;
+};
+
+/**
+ * Queues an organize run for every user (skipping anyone with a run already
+ * in progress). Runs created this way are marked `triggeredBy: "cron"`,
+ * which send-organize-complete.ts uses to send the weekly digest email
+ * instead of the regular "organize complete" email.
+ */
+export async function runOrganizeForAllUsers(): Promise<
+	OrganizeAllUsersResult[]
+> {
+	const users = await db.select({ id: user.id }).from(user);
+	const results: OrganizeAllUsersResult[] = [];
+
+	for (const { id } of users) {
+		try {
+			const insertResult = await insertRunOrSkip(id, "cron");
+
+			if (insertResult.kind === "skipped") {
+				logger.info(
+					{ userId: id, existingRunId: insertResult.runId },
+					"organize run skipped for user — a run is already in progress",
+				);
+				results.push({
+					userId: id,
+					runId: insertResult.runId,
+					status: "skipped",
+					error: "A pipeline run is already in progress",
+				});
+				continue;
+			}
+
+			const runId = insertResult.runId;
+
+			try {
+				await organizePipeline.trigger({ userId: id, runId });
+				results.push({ userId: id, runId, status: "completed" });
+			} catch (triggerErr) {
+				const error =
+					triggerErr instanceof Error
+						? triggerErr
+						: new Error(String(triggerErr));
+				await updateRun(runId, {
+					status: "failed",
+					error: error.message,
+					completedAt: new Date(),
+				});
+				logger.error(
+					{ userId: id, runId, error: error.message },
+					"Failed to queue organize for user",
+				);
+				results.push({
+					userId: id,
+					runId,
+					status: "failed",
+					error: error.message,
+				});
+			}
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			logger.error(
+				{ userId: id, error: error.message },
+				"Failed to queue organize for user",
+			);
+			results.push({
+				userId: id,
+				runId: -1,
+				status: "failed",
+				error: error.message,
+			});
+		}
+	}
+
+	return results;
+}
+
+export const organizeWeeklyCronTask = schedules.task({
+	id: "organize-weekly-cron",
+	cron: "0 8 * * 1",
+	run: async () => {
+		const results = await runOrganizeForAllUsers();
+		const summary = {
+			total: results.length,
+			completed: results.filter((r) => r.status === "completed").length,
+			skipped: results.filter((r) => r.status === "skipped").length,
+			failed: results.filter((r) => r.status === "failed").length,
+		};
+		logger.info(summary, "Completed weekly organize cron run");
+		return summary;
+	},
+});

--- a/packages/common/src/trigger/tasks/organize-weekly-cron.ts
+++ b/packages/common/src/trigger/tasks/organize-weekly-cron.ts
@@ -31,13 +31,7 @@ export type InsertRunResult =
 	| { kind: "created"; runId: number }
 	| { kind: "skipped"; runId: number };
 
-/**
- * Inserts a new "running" pipeline_run row for the user, or reports the
- * existing one if the unique-running-per-user constraint blocks it. If the
- * conflicting run finishes between our insert attempt and the lookup (a
- * narrow but real race), the constraint has cleared — retry the insert
- * instead of dropping a valid request as "skipped".
- */
+// Retries the insert if the running-conflict clears between our attempt and the lookup (narrow race).
 export async function insertRunOrSkip(
 	userId: string,
 	triggeredBy: "user" | "cron",
@@ -64,8 +58,6 @@ export async function insertRunOrSkip(
 			if (existingRunId !== null) {
 				return { kind: "skipped", runId: existingRunId };
 			}
-			// Conflicting run finished between our insert and this lookup —
-			// loop around and retry the insert now that it should be clear.
 		}
 	}
 	throw new Error(
@@ -80,12 +72,7 @@ export type OrganizeAllUsersResult = {
 	error?: string;
 };
 
-/**
- * Queues an organize run for every user (skipping anyone with a run already
- * in progress). Runs created this way are marked `triggeredBy: "cron"`,
- * which send-organize-complete.ts uses to send the weekly digest email
- * instead of the regular "organize complete" email.
- */
+// triggeredBy: "cron" is what makes send-organize-complete.ts send the weekly digest email.
 export async function runOrganizeForAllUsers(): Promise<
 	OrganizeAllUsersResult[]
 > {

--- a/packages/orpc/src/routers/public/organize.ts
+++ b/packages/orpc/src/routers/public/organize.ts
@@ -4,79 +4,14 @@ import {
 } from "@harmonia/common/schemas";
 import { updateRun } from "@harmonia/common/services/organize";
 import { organizePipeline } from "@harmonia/common/trigger/tasks/organize";
-import { db } from "@harmonia/db";
-import { user } from "@harmonia/db/schema/auth";
-import { pipelineRun } from "@harmonia/db/schema/pipeline-run";
+import {
+	insertRunOrSkip,
+	runOrganizeForAllUsers,
+} from "@harmonia/common/trigger/tasks/organize-weekly-cron";
 import { logger } from "@harmonia/logger";
 import { ORPCError } from "@orpc/server";
-import { and, eq } from "drizzle-orm";
 
 import { cronOrAuthProcedure } from "../../procedures";
-
-const RUNNING_CONSTRAINT_NAME = "pipeline_run_one_running_per_user";
-const MAX_INSERT_ATTEMPTS = 3;
-
-function isAlreadyRunningConflict(err: unknown): boolean {
-	if (typeof err !== "object" || err === null) return false;
-	if (!("code" in err) || !("constraint" in err)) return false;
-	return err.code === "23505" && err.constraint === RUNNING_CONSTRAINT_NAME;
-}
-
-async function findRunningRunId(userId: string): Promise<number | null> {
-	const [existing] = await db
-		.select({ id: pipelineRun.id })
-		.from(pipelineRun)
-		.where(
-			and(eq(pipelineRun.userId, userId), eq(pipelineRun.status, "running")),
-		);
-	return existing?.id ?? null;
-}
-
-type InsertRunResult =
-	| { kind: "created"; runId: number }
-	| { kind: "skipped"; runId: number };
-
-/**
- * Inserts a new "running" pipeline_run row for the user, or reports the
- * existing one if the unique-running-per-user constraint blocks it. If the
- * conflicting run finishes between our insert attempt and the lookup (a
- * narrow but real race), the constraint has cleared — retry the insert
- * instead of dropping a valid request as "skipped".
- */
-async function insertRunOrSkip(
-	userId: string,
-	triggeredBy: "user" | "cron",
-): Promise<InsertRunResult> {
-	for (let attempt = 0; attempt < MAX_INSERT_ATTEMPTS; attempt++) {
-		try {
-			const [inserted] = await db
-				.insert(pipelineRun)
-				.values({
-					userId,
-					status: "running",
-					triggeredBy,
-					currentStage: "sync",
-					startedAt: new Date(),
-				})
-				.returning({ id: pipelineRun.id });
-
-			if (!inserted) throw new Error("Failed to create run record");
-			return { kind: "created", runId: inserted.id };
-		} catch (err) {
-			if (!isAlreadyRunningConflict(err)) throw err;
-
-			const existingRunId = await findRunningRunId(userId);
-			if (existingRunId !== null) {
-				return { kind: "skipped", runId: existingRunId };
-			}
-			// Conflicting run finished between our insert and this lookup —
-			// loop around and retry the insert now that it should be clear.
-		}
-	}
-	throw new Error(
-		`Failed to create pipeline run for user ${userId} after ${MAX_INSERT_ATTEMPTS} attempts (repeatedly raced with another run)`,
-	);
-}
 
 /**
  * Organize pipeline: syncs Spotify, fetches lyrics, classifies, embeds, clusters, generates playlists.
@@ -163,73 +98,7 @@ export const organizeRouter = {
 				}
 			}
 
-			const users = await db.select({ id: user.id }).from(user);
-			const results: Array<{
-				userId: string;
-				runId: number;
-				status: "completed" | "failed" | "skipped";
-				error?: string;
-			}> = [];
-
-			for (const { id } of users) {
-				try {
-					const insertResult = await insertRunOrSkip(id, "cron");
-
-					if (insertResult.kind === "skipped") {
-						logger.info(
-							{ userId: id, existingRunId: insertResult.runId },
-							"organize.run skipped for user — a run is already in progress",
-						);
-						results.push({
-							userId: id,
-							runId: insertResult.runId,
-							status: "skipped",
-							error: "A pipeline run is already in progress",
-						});
-						continue;
-					}
-
-					const runId = insertResult.runId;
-
-					try {
-						await organizePipeline.trigger({ userId: id, runId });
-						results.push({ userId: id, runId, status: "completed" });
-					} catch (triggerErr) {
-						const error =
-							triggerErr instanceof Error
-								? triggerErr
-								: new Error(String(triggerErr));
-						await updateRun(runId, {
-							status: "failed",
-							error: error.message,
-							completedAt: new Date(),
-						});
-						logger.error(
-							{ userId: id, runId, error: error.message },
-							"Failed to queue organize for user",
-						);
-						results.push({
-							userId: id,
-							runId,
-							status: "failed",
-							error: error.message,
-						});
-					}
-				} catch (err) {
-					const error = err instanceof Error ? err : new Error(String(err));
-					logger.error(
-						{ userId: id, error: error.message },
-						"Failed to queue organize for user",
-					);
-					results.push({
-						userId: id,
-						runId: -1,
-						status: "failed",
-						error: error.message,
-					});
-				}
-			}
-
+			const results = await runOrganizeForAllUsers();
 			return { success: true, results };
 		}),
 };


### PR DESCRIPTION
## Summary
- Adds `organizeWeeklyCronTask`, a trigger.dev `schedules.task` (Monday 8am UTC) that queues an organize run per user with `triggeredBy: "cron"` — the trigger that makes `send-organize-complete.ts` send the weekly playlist digest email instead of the regular "organize complete" email.
- Extracts the shared "insert run or skip / queue for all users" logic out of the `/organize/run` orpc handler into `packages/common/src/trigger/tasks/organize-weekly-cron.ts` so both the external cron endpoint and the new schedule share one implementation instead of duplicating it.

Closes #304

## Test plan
- [x] `tsc --noEmit` passes for `@harmonia/common`, `@harmonia/orpc`, `api`
- [x] `biome lint` passes on changed files
- [ ] Confirm `organize-weekly-cron` shows up as a scheduled task in the trigger.dev dashboard after deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated weekly organization process that runs every Monday morning.
  * The process queues organization runs for all users while skipping users with an active run.
  * Added aggregate reporting for completed, skipped, and failed runs.

* **Bug Fixes**
  * Improved handling of duplicate scheduling attempts and organization trigger failures.
  * Failed runs are now recorded and included in processing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->