### PR TITLE
chore: lazy-load subdirectory-specific CLAUDE.md rules

### DIFF
--- a/.cursor/rules/00-project-overview.mdc
+++ b/.cursor/rules/00-project-overview.mdc
@@ -32,37 +32,6 @@ Harmonia is an AI-powered music organization app. It syncs a user's Spotify libr
 - `packages/ui`: shadcn/ui component library + shared Tailwind config
 - `packages/email`: React Email templates + Resend send layer (`@harmonia/email`)
 
-## Development Commands
-
-Run all commands from the repository root.
-
-```bash
-pnpm dev:api          # API + Trigger.dev worker
-pnpm dev:ad           # API + dashboard + Trigger.dev
-pnpm dev:admin        # admin app only (port 3004)
-pnpm dev:ada          # API + dashboard + admin + Trigger.dev
-pnpm dev:all          # all apps + Trigger.dev
-pnpm dev:web          # web app only
-
-pnpm db:seed          # seed admin user (requires HARMONIA_ADMIN_PASSWORD)
-
-pnpm db:push          # push Drizzle schema to local Postgres
-pnpm db:studio        # open Drizzle Studio UI
-pnpm db:generate      # generate migration files
-pnpm db:migrate       # run migrations (production)
-pnpm db:setup         # start Docker Postgres + push schema
-pnpm db:reset         # truncate user-data tables (auth + genre_domain preserved)
-pnpm db:nuke          # Docker volume wipe + db:push (local Postgres on 5433)
-
-pnpm trigger:dev      # start Trigger.dev worker alone
-pnpm deps:sync        # update all deps to latest + syncpack fix
-pnpm check-types      # tsc --noEmit across all packages
-pnpm test             # vitest in @harmonia/common and @harmonia/orpc
-pnpm check            # Biome check + fix
-pnpm lint             # Biome lint + fix
-pnpm format           # Biome format + fix
-```
-
 ## Hard Rules
 
 1. **Never `process.env` directly.** Use `import { env } from "@harmonia/env/server"`.
@@ -71,16 +40,6 @@ pnpm format           # Biome format + fix
 4. **All env vars prefixed `HARMONIA_` or `NEXT_PUBLIC_HARMONIA_`.**
 5. **JSONB progress writes: use `updateStageProgress(runId, stage, val)`.** Never overwrite the full column in concurrent code.
 6. **DB driver is conditional.** `.neon.tech` URL → `@neondatabase/serverless`, otherwise → `pg`. Do not change this logic.
-
-## Tooling
-
-- Package manager: `pnpm`
-- Build/task orchestration: `turbo`
-- Linting/formatting: `biome` (tabs, double quotes, auto-organised imports)
-- API layer: `oRPC`
-- ORM: `drizzle-orm`
-- Background jobs: `@trigger.dev/sdk`
-- Auth: `better-auth` — dual instances (dashboard Spotify OAuth + admin email/password)
 
 ## Git commits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,20 +9,8 @@ Rules are maintained in `.cursor/rules/` as the single source of truth — all a
 @.cursor/rules/01-naming-conventions.mdc
 @.cursor/rules/02-code-patterns.mdc
 
-### Apps
-
-@.cursor/rules/apps/api.mdc
-@.cursor/rules/apps/dashboard.mdc
-@.cursor/rules/apps/web.mdc
-@.cursor/rules/apps/admin.mdc
-
 ### Packages
 
-@.cursor/rules/packages/00-package-index.mdc
-@.cursor/rules/packages/common.mdc
-@.cursor/rules/packages/db.mdc
-@.cursor/rules/packages/env.mdc
-@.cursor/rules/packages/orpc.mdc
 @.cursor/rules/packages/trigger.mdc
 @.cursor/rules/packages/ui.mdc
 

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/apps/admin.mdc

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/apps/api.mdc

--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/apps/dashboard.mdc

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/apps/web.mdc

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,0 +1,1 @@
+@../.cursor/rules/packages/00-package-index.mdc

--- a/packages/common/CLAUDE.md
+++ b/packages/common/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/packages/common.mdc

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/packages/db.mdc

--- a/packages/env/CLAUDE.md
+++ b/packages/env/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/packages/env.mdc

--- a/packages/orpc/CLAUDE.md
+++ b/packages/orpc/CLAUDE.md
@@ -1,0 +1,1 @@
+@../../.cursor/rules/packages/orpc.mdc


### PR DESCRIPTION
## Summary
- Root `CLAUDE.md` was unconditionally `@`-importing every `.cursor/rules/*.mdc` file, including 9 that are scoped to a single app/package via their own `alwaysApply: false` + `globs` frontmatter — Cursor honors that scoping, Claude Code's `@import` doesn't, so all ~45.7k chars loaded into every session regardless of relevance.
- Adds a one-line `CLAUDE.md` pointer file in each of `apps/api`, `apps/dashboard`, `apps/web`, `apps/admin`, `packages/common`, `packages/db`, `packages/env`, `packages/orpc`, and `packages/`, each `@`-importing its existing `.cursor/rules/...mdc` file — so `.cursor/rules` stays the single source of truth, content just loads only when Claude works under that directory.
- Removes the corresponding 9 import lines from root `CLAUDE.md`.
- Trims `00-project-overview.mdc`'s `Development Commands` and `Tooling` sections — both fully derivable from `package.json` (scripts and dependencies respectively).

Net effect: always-resident CLAUDE.md content drops from ~45.7k to ~19.1k characters per session, no content lost (still reachable, just conditionally).

## Test plan
- [ ] Confirm Cursor still applies `.cursor/rules/*.mdc` as before (untouched)
- [ ] Confirm Claude Code loads e.g. `apps/dashboard/CLAUDE.md` when editing files under `apps/dashboard/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance to streamline development and tooling references.
  * Added centralized guidance references for application and package areas.
  * Added dedicated guidance for dashboard and API-related development.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->