### PR TITLE
fix(email): close race that let the weekly digest send more than once

### DIFF
--- a/packages/common/src/services/email/dedupe.ts
+++ b/packages/common/src/services/email/dedupe.ts
@@ -1,6 +1,6 @@
 import { db } from "@harmonia/db";
 import { emailSendLog } from "@harmonia/db/schema/email-send-log";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { EmailSendStatus, EmailTemplateKey } from "../../schemas";
 
@@ -39,17 +39,33 @@ export async function reserveEmailDelivery({
 		return { created: true, logId: created.id };
 	}
 
+	// Row already exists. The only safe retry is reclaiming a row that
+	// genuinely failed, via an atomic UPDATE...WHERE so a concurrent caller
+	// can't also win the same claim. "queued" (an attempt may be in flight)
+	// or "sent" (already delivered) must never be treated as retryable —
+	// that gap previously let concurrent/duplicate callers each pass a
+	// plain status check and physically send more than once.
+	const [reclaimed] = await db
+		.update(emailSendLog)
+		.set({ status: "queued" })
+		.where(
+			and(
+				eq(emailSendLog.idempotencyKey, idempotencyKey),
+				eq(emailSendLog.status, "failed"),
+			),
+		)
+		.returning({ id: emailSendLog.id });
+
+	if (reclaimed) {
+		return { created: true, logId: reclaimed.id };
+	}
+
 	const [existing] = await db
-		.select({ id: emailSendLog.id, status: emailSendLog.status })
+		.select({ id: emailSendLog.id })
 		.from(emailSendLog)
 		.where(eq(emailSendLog.idempotencyKey, idempotencyKey));
 
-	if (existing?.status === "sent") {
-		return { created: false, logId: existing.id };
-	}
-
-	// Previous attempt didn't make it to "sent" (queued/failed/skipped) - allow retry on the same row.
-	return { created: true, logId: existing?.id ?? null };
+	return { created: false, logId: existing?.id ?? null };
 }
 
 export async function markEmailDelivery({


### PR DESCRIPTION
## Summary
- `reserveEmailDelivery()` only blocked a resend once a row's status was already `sent` — a row still at `queued` was treated as safe to retry, letting concurrent/repeated invocations each pass the check and physically send via Resend
- Retries are now claimed atomically via `UPDATE ... WHERE status = 'failed'`, so only one caller can ever win a retry; `queued` and `sent` both block further sends

## Context
Confirmed against real production data on issue #318 — a single Trigger.dev execution of the weekly organize pipeline (one `pipeline_run` row, "Attempt 1" throughout) resulted in 4 actual weekly-digest emails being delivered, while only one dedup row was ever logged as sent. Full investigation and evidence in the issue thread.

This closes the send-side race regardless of what invoked the send path more than once — that deeper question (likely Trigger.dev-platform-level redelivery) stays open and is tracked separately.

Fixes #318

## Test plan
- [ ] Confirm `reserveEmailDelivery` blocks a second call while a row is `queued`
- [ ] Confirm a `failed` row can still be retried and reclaimed
- [ ] Watch the next weekly cron cycle for a single digest email