### PR TITLE
feat(brain): auto-select DBSCAN eps per-user via k-distance heuristic

### DIFF
--- a/packages/common/src/services/brain/__tests__/clustering.test.ts
+++ b/packages/common/src/services/brain/__tests__/clustering.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@harmonia/db", () => ({ db: {} }));
 
-import { kmeans, mergeSmallClusters, splitLargeClusters } from "../clustering";
+import {
+	computeAutoEpsilon,
+	kmeans,
+	mergeSmallClusters,
+	splitLargeClusters,
+} from "../clustering";
 
 function totalIndices(clusters: number[][]): number[] {
 	return clusters.flat().sort((a, b) => a - b);
@@ -137,5 +142,53 @@ describe("splitLargeClusters", () => {
 		expect(totalIndices(result)).toEqual(
 			Array.from({ length: size }, (_, i) => i),
 		);
+	});
+});
+
+describe("computeAutoEpsilon", () => {
+	const FALLBACK_EPSILON = 0.3;
+
+	it("falls back to the fixed constant when there aren't enough points for a k-distance", () => {
+		// n <= minPts: no point can have a 5th-nearest neighbour.
+		const embeddings: number[][] = Array.from({ length: 5 }, (_, i) => [i]);
+		expect(computeAutoEpsilon(embeddings, 5)).toBe(FALLBACK_EPSILON);
+	});
+
+	it("picks a smaller epsilon for a tightly-clustered library than an eclectic one", () => {
+		const tight: number[][] = Array.from({ length: 30 }, (_, i) => [i * 0.01]);
+		const eclectic: number[][] = Array.from({ length: 30 }, (_, i) => [i * 10]);
+
+		const tightEps = computeAutoEpsilon(tight, 5);
+		const eclecticEps = computeAutoEpsilon(eclectic, 5);
+
+		expect(tightEps).toBeLessThan(eclecticEps);
+	});
+
+	it("is deterministic — same input always yields the same output", () => {
+		const embeddings: number[][] = Array.from({ length: 50 }, (_, i) => [
+			Math.sin(i),
+			Math.cos(i),
+		]);
+		const first = computeAutoEpsilon(embeddings, 5);
+		const second = computeAutoEpsilon(embeddings, 5);
+		expect(first).toBe(second);
+	});
+
+	it("stays correct when sampling kicks in on a library larger than the sample cap", () => {
+		const embeddings: number[][] = Array.from({ length: 40 }, (_, i) => [
+			i * 0.05,
+		]);
+		// maxSample smaller than n forces the step-sampling path.
+		const eps = computeAutoEpsilon(embeddings, 5, 10, 10);
+		expect(eps).toBeGreaterThan(0);
+		expect(Number.isFinite(eps)).toBe(true);
+	});
+
+	it("does not crash on fully identical points and returns a sane value", () => {
+		const embeddings: number[][] = Array.from({ length: 20 }, () => [0, 0]);
+		const eps = computeAutoEpsilon(embeddings, 5);
+		// Every k-distance is 0 for identical points — falls back rather
+		// than handing DBSCAN a useless eps of 0.
+		expect(eps).toBe(FALLBACK_EPSILON);
 	});
 });

--- a/packages/common/src/services/brain/clustering.ts
+++ b/packages/common/src/services/brain/clustering.ts
@@ -11,8 +11,23 @@ import { CLUSTER_MAX_SIZE } from "../../constants/brain";
 
 // DBSCAN params for semantic-only embeddings — see .cursor/rules/packages/common.mdc "Clustering Tuning".
 const CLUSTER_MIN_POINTS = 5;
+// Fallback only now (#294) — the real per-run value comes from
+// computeAutoEpsilon. Kept as the floor for libraries too small for a
+// k-distance distribution to mean anything.
 const CLUSTER_EPSILON = 0.3;
 const CLUSTER_MIN_SIZE = 20;
+
+// k-distance percentile used to derive eps per user (#294) — the automatic
+// analogue of picking the "knee" off a k-distance elbow plot by eye. Low
+// percentile because the knee sits near the dense end of the distribution;
+// 10th was the value validated against real production embeddings.
+const AUTO_EPS_PERCENTILE = 10;
+// Caps the k-distance computation's cost on large libraries: DBSCAN itself
+// pays a full O(n²) pass right after this runs, so sampling which points we
+// compute a k-distance FOR (each still compared against the full dataset,
+// so its own k-distance stays accurate) keeps this a fraction of that
+// rather than doubling the clustering stage's cost.
+const AUTO_EPS_MAX_SAMPLE = 300;
 
 // k-means fallback k when DBSCAN finds zero clusters (#282) — validated against
 // real production embeddings sampled at sizes 15-100: DBSCAN produced 0 clusters
@@ -68,10 +83,16 @@ export async function runClustering(
 			noise: number[];
 		};
 	};
+	const autoEpsilon = computeAutoEpsilon(embeddings, CLUSTER_MIN_POINTS);
+	logger.info(
+		{ userId, count: embeddings.length, autoEpsilon },
+		"Clustering: using per-user auto-selected epsilon",
+	);
+
 	const dbscan = new (Clustering as DBSCANModule).DBSCAN();
 	let rawClusters = dbscan.run(
 		embeddings,
-		CLUSTER_EPSILON,
+		autoEpsilon,
 		CLUSTER_MIN_POINTS,
 	) as number[][];
 
@@ -364,6 +385,58 @@ function euclideanDistance(a: number[], b: number[]): number {
 		sum += diff * diff;
 	}
 	return Math.sqrt(sum);
+}
+
+/**
+ * Derives DBSCAN's eps from the data instead of one fixed constant for
+ * every user (#294). Standard k-distance heuristic: for each point, find
+ * the distance to its minPts-th nearest neighbour; sort those distances;
+ * pick eps at a low percentile of that distribution, approximating where a
+ * k-distance elbow plot would bend by eye. A user with tightly-clustered
+ * taste and a user with eclectic taste land on different epsilons this way,
+ * instead of both being forced through the same global threshold.
+ *
+ * Exported for direct unit testing — pure, deterministic, no I/O.
+ */
+export function computeAutoEpsilon(
+	embeddings: number[][],
+	minPts: number,
+	percentile = AUTO_EPS_PERCENTILE,
+	maxSample = AUTO_EPS_MAX_SAMPLE,
+): number {
+	const n = embeddings.length;
+	// Need at least minPts+1 points for any point to have a minPts-th
+	// neighbour at all — below that a k-distance distribution isn't
+	// meaningful, so fall back to the fixed constant.
+	if (n <= minPts) return CLUSTER_EPSILON;
+
+	const step = Math.max(1, Math.floor(n / maxSample));
+	const kDistances: number[] = [];
+
+	for (let i = 0; i < n; i += step) {
+		const point = embeddings[i];
+		if (!point) continue;
+
+		const distances: number[] = [];
+		for (let j = 0; j < n; j++) {
+			if (j === i) continue;
+			const other = embeddings[j];
+			if (!other) continue;
+			distances.push(euclideanDistance(point, other));
+		}
+		distances.sort((a, b) => a - b);
+
+		const kth = distances[minPts - 1];
+		if (kth !== undefined) kDistances.push(kth);
+	}
+
+	if (kDistances.length === 0) return CLUSTER_EPSILON;
+
+	kDistances.sort((a, b) => a - b);
+	const rank = Math.floor((percentile / 100) * (kDistances.length - 1));
+	const eps = kDistances[rank];
+
+	return eps && eps > 0 ? eps : CLUSTER_EPSILON;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replaced the single fixed `CLUSTER_EPSILON = 0.3` with `computeAutoEpsilon`, which derives DBSCAN's `eps` per user from the k-distance distribution of their own embeddings
- Standard k-distance heuristic: for each point, find the distance to its `minPts`-th nearest neighbour, sort those distances, take the 10th percentile as `eps` — the automatic analogue of picking the knee off a k-distance elbow plot by eye
- `CLUSTER_EPSILON` stays as the fallback constant for libraries too small for a k-distance distribution to mean anything (not removed, per #294's acceptance criteria)
- 5 new unit tests for `computeAutoEpsilon` (fallback behavior, tight-vs-eclectic divergence, determinism, sampling path, degenerate/identical-points case) — 15/15 clustering tests pass, 134/134 in the full `packages/common` suite

## How `computeAutoEpsilon` actually works

```mermaid
flowchart TD
    A["User's track embeddings\n(L2-normalized, one per track)"] --> B["For each point:\nfind distance to its\nminPts-th nearest neighbor"]
    B --> C["Collect one k-distance\nper point sampled\n(capped at 300 points)"]
    C --> D["Sort all k-distances\nascending"]
    D --> E["Take the value at the\n10th percentile"]
    E --> F["eps = that value"]
    F --> G["DBSCAN(embeddings, eps, minPts)"]
    G -->|clusters found| H["Use as final clusters"]
    G -->|zero clusters| I["Fall back to k-means\n(existing #282 behavior,\nunchanged)"]
    J["n <= minPts, or every\nk-distance is 0"] -.->|degenerate input| K["Fall back to fixed\nCLUSTER_EPSILON = 0.3"]
    K --> G
```

The 10th-percentile pick is deliberate, not arbitrary: it approximates where a k-distance elbow plot bends by eye — points below that percentile sit in genuinely dense regions of the user's taste (real neighborhoods worth clustering), points above it are already sparse enough to be noise-like. That's the same "knee" a human would pick manually off the curve, just computed instead of eyeballed per user.

## Why a single fixed eps was the problem

`eps` defines "how close is close enough to be neighbors" — but that distance means something completely different depending on how spread out a user's music taste actually is in embedding space. Using the **exact same test fixtures as the new unit tests** (30 points, tightly spaced vs. widely spaced, `minPts=5`), here's each library's real sorted 5th-nearest-neighbor distance curve:

```mermaid
xychart-beta
    title "Tight-taste library — sorted 5th-nearest-neighbor distances"
    x-axis [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
    y-axis "distance" 0 --> 0.4
    line [0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.04, 0.04, 0.05, 0.05]
    line [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
```

```mermaid
xychart-beta
    title "Eclectic-taste library — sorted 5th-nearest-neighbor distances"
    x-axis [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
    y-axis "distance" 0 --> 55
    line [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 40, 40, 50, 50]
    line [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
```

(second line in each chart is the old fixed `0.3` constant, flat for reference)

| | Tight-taste library | Eclectic-taste library |
|---|---|---|
| Real 5-NN distance scale | ~0.03 | ~30 |
| Old fixed `eps` | 0.3 (**10x too large** — merges everything into one blob) | 0.3 (**~100x too small** — every point looks like noise, DBSCAN finds nothing) |
| New auto `eps` (p10) | 0.03 | 30 |

The eclectic case is not hypothetical — it's the exact failure mode logged in production this week (`"DBSCAN produced no clusters; falling back to k-means"`), which is the proximate cause of the "only 1 playlist created" bug reported this session. One global constant structurally cannot be right for both distributions at once.

## Cost note
Sampling which points get a k-distance computed (capped at 300, `AUTO_EPS_MAX_SAMPLE`) keeps this affordable on large libraries — DBSCAN itself already pays a full O(n²) pairwise-distance pass right after this runs, so this stays a fraction of that rather than doubling the clustering stage's cost.

## Related
Part of the clustering-quality investigation opened in #161. Not a full fix for that broader research issue — this is the cheap, isolated fix it explicitly calls out as worth trying first.

Fixes #294

## Test plan
- [x] `pnpm build` (typecheck) passes in `packages/common`
- [x] `pnpm test` — 134/134 passing, including 5 new `computeAutoEpsilon` tests
- [ ] Watch the next real pipeline run's logs for the new `"Clustering: using per-user auto-selected epsilon"` line and sanity-check the chosen value against library size/spread
