### PR TITLE
docs: strengthen the single-line comment rule with a concrete example

### DIFF
--- a/.cursor/rules/02-code-patterns.mdc
+++ b/.cursor/rules/02-code-patterns.mdc
@@ -163,7 +163,21 @@ Hard limits:
 
 - **One line, always.** No multi-line comment blocks, no wrapped paragraphs
   above a function or a field. If it doesn't fit on one line, cut it down
-  until it does — don't wrap it instead.
+  until it does — don't wrap it instead. This has been violated repeatedly;
+  treat it as a hard stop, not a style preference. Before finishing any edit
+  that adds a comment, check it: is it wrapped across 2+ `//` lines? If yes,
+  compress it before moving on, don't leave it for review to catch.
+  Example — wrong:
+  ```ts
+  // Below this track-overlap similarity, a cluster is treated as unrelated
+  // to any existing playlist and gets a brand new one instead of an update.
+  const PLAYLIST_MATCH_THRESHOLD = 0.5;
+  ```
+  right:
+  ```ts
+  // Below this track-overlap similarity, a cluster gets a new playlist instead of matching an existing one.
+  const PLAYLIST_MATCH_THRESHOLD = 0.5;
+  ```
 - If the reasoning genuinely can't compress to one line, it belongs in the
   relevant `.cursor/rules/*.mdc` doc, not the code. Code comments point at a
   local, single-spot reason; anything broader (a convention, a pattern, a


### PR DESCRIPTION
## Summary
- The single-line-comment rule (`.cursor/rules/02-code-patterns.mdc` § No Comments Rule) already existed and was already clearly worded, but kept getting violated in practice anyway
- Added a concrete before/after example and an explicit self-check step ("before finishing any edit that adds a comment, check it") — abstract prose alone wasn't reliably preventing wrapped-paragraph comments

## Context
Found while reviewing #316 — multiple multi-line comment blocks had been written despite this exact rule already being in place and loaded globally via CLAUDE.md. Not a documentation gap, a compliance gap. This change doesn't alter the rule's substance, just makes it harder to miss.